### PR TITLE
Add WalletHdPath to Set Network Keys transaction scope

### DIFF
--- a/src/views/SetKeys.js
+++ b/src/views/SetKeys.js
@@ -330,6 +330,7 @@ class SetKeys extends React.Component {
               contracts={props.contracts}
               wallet={props.wallet}
               walletType={props.walletType}
+              walletHdPath={props.walletHdPath}
               // Tx
               txn={state.txn}
               stx={state.stx}


### PR DESCRIPTION
This fixes a bug preventing Trezor users from being able to sign the Set Network Keys transaction.