### PR TITLE
Manually follow EIP-155 in certain circumstances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -952,17 +952,28 @@
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
     },
     "@ledgerhq/hw-app-eth": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-4.32.0.tgz",
-      "integrity": "sha512-d22WinjcsqJNoZSI+6UpTWZ7hl+UhL2dFeVeliCwtBWSj40z6F25MpoviGxPsv0WC7IUjayw+a9jIRcOJ5kkIw==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-4.35.0.tgz",
+      "integrity": "sha512-MSDr8+CaoXhtm64ELuI/8wpcfmrMUjzGJgASY6bnjc82vAW+6sHNZlTU0zWRTZxqQUuZ8WpuJP159cf92MWq3g==",
       "requires": {
-        "@ledgerhq/hw-transport": "^4.32.0"
+        "@ledgerhq/hw-transport": "^4.35.0"
+      },
+      "dependencies": {
+        "@ledgerhq/hw-transport": {
+          "version": "4.35.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-4.35.0.tgz",
+          "integrity": "sha512-o8ekdoCkHMvOByIKDmAMNDjm8Q5cu+sbqmebPtGrHAPbgIZBUbNA5UupY/Om+xypdxXYnuBw+MF8FyIVOjnIsg==",
+          "requires": {
+            "events": "^3.0.0"
+          }
+        }
       }
     },
     "@ledgerhq/hw-transport": {
       "version": "4.32.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-4.32.0.tgz",
       "integrity": "sha512-Wgsk9UHC4RShqYoDeIEeKgHZOvNCtB0WWIG0xqlVPzS+IcKDkIxtXQw7hTA7GQSuDuGeauVtlbTQ5yat6+2/BA==",
+      "dev": true,
       "requires": {
         "events": "^3.0.0"
       }
@@ -980,12 +991,22 @@
       }
     },
     "@ledgerhq/hw-transport-u2f": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-4.32.0.tgz",
-      "integrity": "sha512-xzY+Q7ObVVv/V/wxvp1eEbDhFf+LFnavQGvqw8EZkCEmkX4iKh2w7AH+B8k1XWS+Mpa3CiG3TVQQE85mf+6jQg==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-4.35.0.tgz",
+      "integrity": "sha512-cVPH0SNRrIKVZz9zHvulHGPSdDQiV1hCK634KZa2M2+fMVhQxUi4YRBQz7QpI88CwRyEy+sBfTfSahPWjQUN2Q==",
       "requires": {
-        "@ledgerhq/hw-transport": "^4.32.0",
+        "@ledgerhq/hw-transport": "^4.35.0",
         "u2f-api": "0.2.7"
+      },
+      "dependencies": {
+        "@ledgerhq/hw-transport": {
+          "version": "4.35.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-4.35.0.tgz",
+          "integrity": "sha512-o8ekdoCkHMvOByIKDmAMNDjm8Q5cu+sbqmebPtGrHAPbgIZBUbNA5UupY/Om+xypdxXYnuBw+MF8FyIVOjnIsg==",
+          "requires": {
+            "events": "^3.0.0"
+          }
+        }
       }
     },
     "@mrmlnc/readdir-enhanced": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "node": "11.0.0"
   },
   "dependencies": {
-    "@ledgerhq/hw-app-eth": "^4.24.0",
-    "@ledgerhq/hw-transport-u2f": "^4.28.0",
     "azimuth-js": "^0.10.0",
+    "@ledgerhq/hw-app-eth": "^4.35.0",
+    "@ledgerhq/hw-transport-u2f": "^4.35.0",
     "azimuth-solidity": "1.0.2",
     "babel-polyfill": "^6.26.0",
     "bip32": "^1.0.2",

--- a/src/components/StatelessTransaction.js
+++ b/src/components/StatelessTransaction.js
@@ -114,6 +114,7 @@ const StatelessTransaction = props => {
             wallet: props.wallet,
             walletType: props.walletType,
             walletHdPath: props.walletHdPath,
+            networkType: props.networkType,
             txn: props.txn,
             setStx: props.setStx,
             nonce: props.nonce,

--- a/src/lib/txn.js
+++ b/src/lib/txn.js
@@ -12,7 +12,6 @@ import {
   addHexPrefix
   } from '../lib/wallet'
 
-
 const TXN_PURPOSE = {
   SET_MANAGEMENT_PROXY: Symbol('SET_MANAGEMENT_PROXY'),
   SET_TRANSFER_PROXY: Symbol('SET_TRANSFER_PROXY'),
@@ -43,35 +42,6 @@ const renderTxnPurpose = (purpose) =>
   ? 'cancel this transfer'
   : 'perform this transaction'
 
-
-
-
-
-// const createUnsignedTxn = config => {
-//   const {
-//     contracts,
-//     galaxyName,
-//     add,
-//     setTxn
-//   } = config
-//
-//   const ctrcs = contracts.matchWith({
-//     Just: (cs) => cs.value,
-//     Nothing: () => {
-//       throw BRIDGE_ERROR.MISSING_CONTRACTS
-//     }
-//   })
-//
-//   const galaxy = parseInt(ob.patp2dec(galaxyName), 10)
-//
-//   const txn = isValidGalaxy(galaxyName) && isValidAddress(galaxyOwner)
-//     ? Maybe.Just(azimuth.ecliptic.createGalaxy(ctrcs, galaxy, galaxyOwner))
-//     : Maybe.Nothing()
-//
-//   setTxn(txn)
-// }
-
-
 const signTransaction = async config => {
 
   let {
@@ -93,9 +63,7 @@ const signTransaction = async config => {
 
   const wal = wallet.matchWith({
     Just: (w) => w.value,
-    Nothing: () => {
-      throw BRIDGE_ERROR.MISSING_WALLET
-    }
+    Nothing: () => { throw BRIDGE_ERROR.MISSING_WALLET }
   })
 
   const sec = wal.privateKey
@@ -120,8 +88,6 @@ const signTransaction = async config => {
 
   setStx(Maybe.Just(stx))
 }
-
-
 
 const sendSignedTransaction = (web3, stx) => {
   const txn = stx.matchWith({
@@ -170,28 +136,6 @@ const toHex = dummy.utils.toHex
 const toWei = dummy.utils.toWei
 const fromWei = dummy.utils.fromWei
 
-
-// const confirmShipAvailability = (point, contracts) => {
-//
-//   if (canDecodePatp(point) === true) {
-//
-//     const pointDec = ob.patp2dec(point)
-//
-//     contracts.matchWith({
-//       Nothing: () => {
-//         throw BRIDGE_ERROR.MISSING_CONTRACTS
-//       },
-//       Just: async (contracts) => {
-//         const owner = await azimuth.azimuth.getOwner(contracts.value, point)
-//         if (eqAddr(owner, ETH_ZERO_ADDR)) return true
-//         return false
-//       }
-//     })
-//   }
-//   return false
-// }
-
-
 const canDecodePatp = p => {
   try {
     ob.patp2dec(p)
@@ -200,21 +144,6 @@ const canDecodePatp = p => {
     return false
   }
 }
-
-
-
-
-
-// const bridgeAPI = {
-//   shipAvailability: {
-//     planet: planet => {},
-//     star: star => {},
-//     galaxy: galaxy => {},
-//   },
-//   // dummyWeb3: {
-//   //
-//   // }
-// }
 
 export {
   signTransaction,
@@ -228,5 +157,4 @@ export {
   toWei,
   fromWei,
   canDecodePatp,
-  // confirmShipAvailability,
 }

--- a/src/views/AcceptTransfer.js
+++ b/src/views/AcceptTransfer.js
@@ -303,6 +303,7 @@ class AcceptTransfer extends React.Component {
             wallet={props.wallet}
             walletType={props.walletType}
             walletHdPath={props.walletHdPath}
+            networkType={props.networkType}
             // Tx
             txn={state.txn}
             stx={state.stx}

--- a/src/views/AcceptTransfer.js
+++ b/src/views/AcceptTransfer.js
@@ -7,6 +7,7 @@ import * as ob from 'urbit-ob'
 
 import StatelessTransaction from '../components/StatelessTransaction'
 import { BRIDGE_ERROR } from '../lib/error'
+import { NETWORK_NAMES } from '../lib/network'
 import { ROUTE_NAMES } from '../lib/router'
 
 import {
@@ -263,6 +264,14 @@ class AcceptTransfer extends React.Component {
     const canApprove = !Maybe.Nothing.hasInstance(state.stx)
     const canSend = !Maybe.Nothing.hasInstance(state.stx) && state.userApproval === true
 
+    const esvisible =
+        props.networkType === NETWORK_NAMES.ROPSTEN ||
+        props.networkType === NETWORK_NAMES.MAINNET
+
+    const esdomain =
+        props.networkType === NETWORK_NAMES.ROPSTEN
+      ? "ropsten.etherscan.io"
+      : "etherscan.io"
 
     return (
       <Row>
@@ -290,9 +299,9 @@ class AcceptTransfer extends React.Component {
           <Anchor
             className={'mt-1 sm'}
             prop-size='sm'
-            prop-disabled={!isValidAddress(state.receivingAddress)}
+            prop-disabled={!isValidAddress(state.receivingAddress) || !esvisible}
             target={'_blank'}
-            href={`https://etherscan.io/address/${state.receivingAddress}`}>
+            href={`https://${esdomain}/address/${state.receivingAddress}`}>
               {'View on Etherscan ↗'}
           </Anchor>
 

--- a/src/views/CancelTransfer.js
+++ b/src/views/CancelTransfer.js
@@ -234,6 +234,7 @@ class CancelTransfer extends React.Component {
               wallet={props.wallet}
               walletType={props.walletType}
               walletHdPath={props.walletHdPath}
+              networkType={props.networkType}
               // Tx
               txn={state.txn}
               stx={state.stx}

--- a/src/views/CreateGalaxy.js
+++ b/src/views/CreateGalaxy.js
@@ -10,6 +10,8 @@ import StatelessTransaction from '../components/StatelessTransaction'
 
 import { BRIDGE_ERROR } from '../lib/error'
 
+import { NETWORK_NAMES } from '../lib/network'
+
 import {
   sendSignedTransaction,
   getTxnInfo,
@@ -179,6 +181,14 @@ class CreateGalaxy extends React.Component {
     const validAddress = isValidAddress(state.galaxyOwner)
     const validGalaxy = isValidGalaxy(state.galaxyName)
 
+    const esvisible =
+        props.networkType === NETWORK_NAMES.ROPSTEN ||
+        props.networkType === NETWORK_NAMES.MAINNET
+
+    const esdomain =
+        props.networkType === NETWORK_NAMES.ROPSTEN
+      ? "ropsten.etherscan.io"
+      : "etherscan.io"
 
     return (
       <Row>
@@ -225,9 +235,9 @@ class CreateGalaxy extends React.Component {
           <Anchor
             className={'mt-1'}
             prop-size={'sm'}
-            prop-disabled={!validAddress}
+            prop-disabled={!validAddress || !esvisible}
             target={'_blank'}
-            href={`https://etherscan.io/address/${state.galaxyOwner}`}>
+            href={`https://${esdomain}/address/${state.galaxyOwner}`}>
               {'View on Etherscan ↗'}
           </Anchor>
 

--- a/src/views/CreateGalaxy.js
+++ b/src/views/CreateGalaxy.js
@@ -249,6 +249,7 @@ class CreateGalaxy extends React.Component {
             wallet={props.wallet}
             walletType={props.walletType}
             walletHdPath={props.walletHdPath}
+            networkType={props.networkType}
             // Tx
             txApproval={state.txApproval}
             txn={state.txn}

--- a/src/views/IssueChild.js
+++ b/src/views/IssueChild.js
@@ -461,6 +461,7 @@ class IssueChild extends React.Component {
             wallet={props.wallet}
             walletType={props.walletType}
             walletHdPath={props.walletHdPath}
+            networkType={props.networkType}
             // Tx
             txn={state.txn}
             stx={state.stx}
@@ -498,6 +499,7 @@ class IssueChild extends React.Component {
                   { state.txError.value }
               </Warning>
           }
+
         </Col>
       </Row>
     )

--- a/src/views/IssueChild.js
+++ b/src/views/IssueChild.js
@@ -10,6 +10,7 @@ import { PointInput, AddressInput, InnerLabel } from '../components/Base'
 import StatelessTransaction from '../components/StatelessTransaction'
 
 import { ROUTE_NAMES } from '../lib/router'
+import { NETWORK_NAMES } from '../lib/network'
 import { BRIDGE_ERROR } from '../lib/error'
 import { getSpawnCandidate } from '../lib/child'
 import {
@@ -337,8 +338,6 @@ class IssueChild extends React.Component {
   render() {
     const { props, state } = this
 
-
-
     const validAddress = isValidAddress(state.receivingAddress)
     const validPoint = canDecodePatp(state.desiredPoint)
 
@@ -354,10 +353,18 @@ class IssueChild extends React.Component {
       }
     })
 
-
     const canSign = !Maybe.Nothing.hasInstance(state.txn)
     const canApprove = !Maybe.Nothing.hasInstance(state.stx)
     const canSend = !Maybe.Nothing.hasInstance(state.stx) && state.userApproval === true
+
+    const esvisible =
+        props.networkType === NETWORK_NAMES.ROPSTEN ||
+        props.networkType === NETWORK_NAMES.MAINNET
+
+    const esdomain =
+        props.networkType === NETWORK_NAMES.ROPSTEN
+      ? "ropsten.etherscan.io"
+      : "etherscan.io"
 
     return (
       <Row>
@@ -433,9 +440,9 @@ class IssueChild extends React.Component {
           <Anchor
             className={'mt-1'}
             prop-size={'sm'}
-            prop-disabled={!isValidAddress(state.receivingAddress)}
+            prop-disabled={!isValidAddress(state.receivingAddress) || !esvisible}
             target={'_blank'}
-            href={`https://etherscan.io/address/${state.receivingAddress}`}>
+            href={`https://${esdomain}/address/${state.receivingAddress}`}>
               {'View on Etherscan ↗'}
           </Anchor>
 

--- a/src/views/SentTransaction.js
+++ b/src/views/SentTransaction.js
@@ -4,7 +4,36 @@ import { Button } from '../components/Base'
 
 import { BRIDGE_ERROR, renderTxnError } from '../lib/error'
 
-const Success = (props) =>
+import { NETWORK_NAMES } from '../lib/network'
+
+const Success = (props) => {
+
+  const esvisible =
+      props.networkType === NETWORK_NAMES.ROPSTEN ||
+      props.networkType === NETWORK_NAMES.MAINNET
+
+  const esdomain =
+      props.networkType === NETWORK_NAMES.ROPSTEN
+    ? "ropsten.etherscan.io"
+    : "etherscan.io"
+
+  const esmessage =
+      esvisible === true
+    ? "If you’d like to keep track of it, click the Etherscan link below."
+    : ''
+
+  const esanchor =
+      esvisible === false
+    ? <div />
+    : <Anchor
+        className={'mb-4 mt-1'}
+        prop-size={'sm'}
+        target={'_blank'}
+        href={`https://${esdomain}/tx/${props.hash}`}>
+          {'View on Etherscan ↗'}
+      </Anchor>
+
+  return (
     <Row>
       <Col>
         <H1>{ 'Your Transaction was Sent' }</H1>
@@ -12,8 +41,7 @@ const Success = (props) =>
         <P>
           {
             `We sent your transaction to the chain. It can take some time to
-            execute, especially if the network is busy. If you’d like to keep
-            track of it, click the Etherscan link below.`
+            execute, especially if the network is busy. ${esmessage}`
           }
         </P>
 
@@ -21,15 +49,13 @@ const Success = (props) =>
         <P>
           { props.hash }
         </P>
-        <Anchor
-          className={'mb-4 mt-1'}
-          prop-size={'sm'}
-          target={'_blank'}
-          href={`https://etherscan.io/tx/${props.hash}`}>
-            {'View on Etherscan ↗'}
-        </Anchor>
+
+        { esanchor }
+
       </Col>
     </Row>
+  )
+}
 
 const Failure = (props) =>
 
@@ -50,7 +76,7 @@ const Failure = (props) =>
     </Row>
 
 const SentTransaction = (props) => {
-  const { web3, txnCursor, popRoute } = props
+  const { web3, txnCursor, networkType, popRoute } = props
   const { setPointCursor, pointCursor } = props
 
   const w3 = web3.matchWith({
@@ -65,7 +91,11 @@ const SentTransaction = (props) => {
 
   const body = result.matchWith({
     Error: message => <Failure web3={ w3 } message={ message.value } />,
-    Ok: txn => <Success hash={ txn.value.transactionHash } />
+    Ok: txn =>
+      <Success
+        hash={ txn.value.transactionHash }
+        networkType={ networkType }
+      />
   })
 
   const ok =

--- a/src/views/SetKeys.js
+++ b/src/views/SetKeys.js
@@ -329,6 +329,7 @@ class SetKeys extends React.Component {
             contracts={props.contracts}
             wallet={props.wallet}
             walletType={props.walletType}
+            networkType={props.networkType}
             // Tx
             txn={state.txn}
             stx={state.stx}

--- a/src/views/SetKeys.js
+++ b/src/views/SetKeys.js
@@ -329,6 +329,7 @@ class SetKeys extends React.Component {
             contracts={props.contracts}
             wallet={props.wallet}
             walletType={props.walletType}
+            walletHdPath={props.walletHdPath}
             networkType={props.networkType}
             // Tx
             txn={state.txn}

--- a/src/views/SetProxy.js
+++ b/src/views/SetProxy.js
@@ -8,6 +8,8 @@ import * as ob from 'urbit-ob'
 import { PROXY_TYPE, renderProxyType } from '../lib/proxy'
 import { BRIDGE_ERROR } from '../lib/error'
 
+import { NETWORK_NAMES } from '../lib/network'
+
 import StatelessTransaction from '../components/StatelessTransaction'
 
 import { ROUTE_NAMES } from '../lib/router'
@@ -274,6 +276,14 @@ class SetProxy extends React.Component {
     const canApprove = !Maybe.Nothing.hasInstance(state.stx)
     const canSend = !Maybe.Nothing.hasInstance(state.stx) && state.userApproval === true
 
+    const esvisible =
+        props.networkType === NETWORK_NAMES.ROPSTEN ||
+        props.networkType === NETWORK_NAMES.MAINNET
+
+    const esdomain =
+        props.networkType === NETWORK_NAMES.ROPSTEN
+      ? "ropsten.etherscan.io"
+      : "etherscan.io"
 
     const ucFirst = w => w.charAt(0).toUpperCase() + w.slice(1);
 
@@ -308,9 +318,9 @@ class SetProxy extends React.Component {
           <Anchor
             className={'mt-1'}
             prop-size={'sm'}
-            disabled={!isValidAddress(state.proxyAddress)}
+            prop-disabled={!isValidAddress(state.proxyAddress) || !esvisible}
             target={'_blank'}
-            href={`https://etherscan.io/address/${state.proxyAddress}`}>
+            href={`https://${esdomain}/address/${state.proxyAddress}`}>
               {'View on Etherscan ↗'}
           </Anchor>
 

--- a/src/views/SetProxy.js
+++ b/src/views/SetProxy.js
@@ -293,6 +293,7 @@ class SetProxy extends React.Component {
             'Generator to generate a keypair.'
           }
           </P>
+
           <AddressInput
             className='mono mt-8'
             prop-size='lg'
@@ -320,6 +321,7 @@ class SetProxy extends React.Component {
             wallet={props.wallet}
             walletType={props.walletType}
             walletHdPath={props.walletHdPath}
+            networkType={props.networkType}
             // Tx
             txn={state.txn}
             stx={state.stx}

--- a/src/views/Transfer.js
+++ b/src/views/Transfer.js
@@ -265,6 +265,7 @@ class Transfer extends React.Component {
             You may cancel the transfer until the transfer is accepted.`
           }
           </P>
+
           <AddressInput
             className={'mono mt-8'}
             prop-size='lg'
@@ -292,6 +293,7 @@ class Transfer extends React.Component {
             wallet={props.wallet}
             walletType={props.walletType}
             walletHdPath={props.walletHdPath}
+            networkType={props.networkType}
             // Tx
             txn={state.txn}
             stx={state.stx}

--- a/src/views/Transfer.js
+++ b/src/views/Transfer.js
@@ -8,6 +8,7 @@ import { AddressInput, Warning, H3 } from '../components/Base'
 import StatelessTransaction from '../components/StatelessTransaction'
 
 import { BRIDGE_ERROR } from '../lib/error'
+import { NETWORK_NAMES } from '../lib/network'
 import { ROUTE_NAMES } from '../lib/router'
 
 import {
@@ -250,6 +251,15 @@ class Transfer extends React.Component {
     const canApprove = !Maybe.Nothing.hasInstance(state.stx)
     const canSend = !Maybe.Nothing.hasInstance(state.stx) && state.userApproval === true
 
+    const esvisible =
+        props.networkType === NETWORK_NAMES.ROPSTEN ||
+        props.networkType === NETWORK_NAMES.MAINNET
+
+    const esdomain =
+        props.networkType === NETWORK_NAMES.ROPSTEN
+      ? "ropsten.etherscan.io"
+      : "etherscan.io"
+
     return (
       <Row>
         <Col>
@@ -280,9 +290,9 @@ class Transfer extends React.Component {
           <Anchor
             className={'mt-1'}
             prop-size={'s'}
-            disabled={!isValidAddress(state.receivingAddress)}
+            prop-disabled={!isValidAddress(state.receivingAddress) || !esvisible}
             target={'_blank'}
-            href={`https://etherscan.io/address/${state.receivingAddress}`}>
+            href={`https://${esdomain}/address/${state.receivingAddress}`}>
               {'View on Etherscan ↗'}
           </Anchor>
 


### PR DESCRIPTION
Resolves #12.

Ledger does not seem to handle EIP-155 automatically.  When using a Ledger, if the block number is at least FORK_BLKNUM = 2675000, one needs to pre-set the ECDSA signature parameters with r = 0, s = 0, and v = chainId prior to signing.

The easiest way to handle this on our end is to just branch on the network type, since mainnet and Ropsten have obviously passed FORK_BLKNUM.

This is somewhat awkward when dealing with offline transactions, since we might want to test them on a local network as well.  For now we can assume that users generating offline transactions wish to later submit them to mainnet, but the best thing to do is probably to add an 'advanced' tab to offline transaction generation where one can disable the defaulted-on EIP-155 settings in that case.

See:

https://github.com/LedgerHQ/ledgerjs/issues/43#issuecomment-366984725

https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md
