### PR TITLE
Replace 'Urbit' with 'Arvo' where appropriate.

### DIFF
--- a/src/views/Point.js
+++ b/src/views/Point.js
@@ -242,7 +242,7 @@ class Point extends React.Component {
             {
               displayReminder
                 ? <P>{`Before you can issue child points or generate your Arvo
-                  keyfile, you need to set your Urbit networking keys.`}</P>
+                  keyfile, you need to set your public keys.`}</P>
                 : ''
             }
 
@@ -336,7 +336,7 @@ class Point extends React.Component {
                   pushRoute(ROUTE_NAMES.SET_KEYS)
                 }}
               >
-                { 'Set Urbit networking keys' }
+                { 'Set public keys' }
               </Button>
 
               </Col>

--- a/src/views/Point/KeysAndMetadata.js
+++ b/src/views/Point/KeysAndMetadata.js
@@ -171,7 +171,7 @@ const UrbitNetworking = props => {
 
   return (
     <div>
-      <H2>{ 'Urbit Networking' }</H2>
+      <H2>{ 'Public Keys' }</H2>
 
       { body }
     </div>

--- a/src/views/Points.js
+++ b/src/views/Points.js
@@ -162,8 +162,8 @@ class Points extends React.Component {
       ? <React.Fragment>
           <H2>{ 'You Are a Management Proxy For' }</H2>
           <P>
-          { `You can configure or set Urbit networking keys and conduct
-            sponsorship related operations for these points.` }
+          { `You can configure or set public keys and conduct sponsorship
+             related operations for these points.` }
           </P>
           <PointList
             setPointCursor={ setPointCursor }

--- a/src/views/SetKeys.js
+++ b/src/views/SetKeys.js
@@ -306,8 +306,8 @@ class SetKeys extends React.Component {
             ? <Warning>
                 <h3 className={'mb-2'}>{'Warning'}</h3>
                 {
-                  'Once these keys have been set, your Urbit is considered ' +
-                  "'Linked'.  This operation cannot be undone."
+                  'Once these keys have been set, your point is considered ' +
+                  "'linked'.  This operation cannot be undone."
                 }
               </Warning>
             : <div /> }


### PR DESCRIPTION
Resolves #39.

This preserves the word 'Urbit' when referencing the Urbit HD wallet, but other instances of the word are axed.
