### PR TITLE
remove networkSeed input from setKeys / genKeyfile flows

### DIFF
--- a/src/Bridge.js
+++ b/src/Bridge.js
@@ -12,6 +12,11 @@ import { NETWORK_NAMES } from './lib/network'
 import { WALLET_NAMES, DEFAULT_HD_PATH } from './lib/wallet'
 import { BRIDGE_ERROR } from './lib/error'
 
+// import Web3 from 'web3'
+// import * as azimuth from 'azimuth-js'
+// import { CONTRACT_ADDRESSES } from './lib/contracts'
+// import { walletFromMnemonic } from './lib/wallet'
+
 import './style/index.css'
 
 class Bridge extends React.Component {
@@ -51,6 +56,7 @@ class Bridge extends React.Component {
       // urbit wallet-related
       urbitWallet: Maybe.Nothing(),
       authMnemonic: Maybe.Nothing(),
+      networkSeedCache: null,
       // point
       pointCursor: Maybe.Nothing(),
       pointCache: {},
@@ -70,6 +76,7 @@ class Bridge extends React.Component {
     this.setAuthMnemonic = this.setAuthMnemonic.bind(this)
     this.setPointCursor = this.setPointCursor.bind(this)
     this.setTxnHashCursor = this.setTxnHashCursor.bind(this)
+    this.setNetworkSeedCache = this.setNetworkSeedCache.bind(this)
     this.addToPointCache = this.addToPointCache.bind(this)
   }
 
@@ -82,7 +89,7 @@ class Bridge extends React.Component {
 
   // if (process.env.NODE_ENV === 'development') {
   //
-  //   const socket = 'wss://localhost:8545'
+  //   const socket = 'ws://localhost:8545'
   //   const provider = new Web3.providers.WebsocketProvider(socket)
   //   const web3 = new Web3(provider)
   //   const contracts = azimuth.initContracts(web3, CONTRACT_ADDRESSES.DEV)
@@ -92,7 +99,8 @@ class Bridge extends React.Component {
   //
   //   this.setState({
   //     routeCrumbs: Stack([
-  //       ROUTE_NAMES.CREATE_GALAXY,
+  //       // ROUTE_NAMES.CREATE_GALAXY,
+  //       // ROUTE_NAMES.SHIP,
   //       ROUTE_NAMES.SHIPS,
   //       // ROUTE_NAMES.MNEMONIC,
   //       ROUTE_NAMES.WALLET,
@@ -100,12 +108,13 @@ class Bridge extends React.Component {
   //       ROUTE_NAMES.LANDING
   //     ]),
   //     networkType: NETWORK_NAMES.LOCAL,
+  //     pointCursor: Maybe.Just(0),
   //     web3: Maybe.Just(web3),
   //     contracts: Maybe.Just(contracts),
   //     walletType: WALLET_NAMES.MNEMONIC,
   //     wallet: walletFromMnemonic(mnemonic, hdpath),
   //     urbitWallet: Maybe.Nothing(),
-  //     authMnemonic: Maybe.Nothing()
+  //     authMnemonic: Maybe.Just('benefit crew supreme gesture quantum web media hazard theory mercy wing kitten')
   //   })
   // }
 }
@@ -144,6 +153,12 @@ class Bridge extends React.Component {
     } else {
       throw BRIDGE_ERROR.INVALID_NETWORK_TYPE
     }
+  }
+
+  setNetworkSeedCache(networkSeed) {
+    this.setState({
+      networkSeedCache: networkSeed
+    })
   }
 
   setNetwork(web3, contracts) {
@@ -202,6 +217,7 @@ class Bridge extends React.Component {
       wallet,
       urbitWallet,
       authMnemonic,
+      networkSeedCache,
       pointCursor,
       pointCache,
       txnHashCursor,
@@ -252,6 +268,8 @@ class Bridge extends React.Component {
                 addToPointCache={ this.addToPointCache }
                 pointCursor={ pointCursor }
                 pointCache={ pointCache }
+                networkSeedCache= { networkSeedCache }
+                setNetworkSeedCache= { this.setNetworkSeedCache }
                 // txn
                 setTxnHashCursor={ this.setTxnHashCursor }
                 txnHashCursor={ txnHashCursor } />

--- a/src/Bridge.js
+++ b/src/Bridge.js
@@ -12,11 +12,6 @@ import { NETWORK_NAMES } from './lib/network'
 import { WALLET_NAMES, DEFAULT_HD_PATH } from './lib/wallet'
 import { BRIDGE_ERROR } from './lib/error'
 
-// import Web3 from 'web3'
-// import * as azimuth from 'azimuth-js'
-// import { CONTRACT_ADDRESSES } from './lib/contracts'
-// import { walletFromMnemonic } from './lib/wallet'
-
 import './style/index.css'
 
 class Bridge extends React.Component {

--- a/src/Bridge.js
+++ b/src/Bridge.js
@@ -40,6 +40,7 @@ class Bridge extends React.Component {
     this.state = {
       // routes
       routeCrumbs: Stack([ ROUTE_NAMES.LANDING ]),
+      routeData: {},
       // network
       networkType: networkType,
       web3: Maybe.Nothing(),
@@ -120,10 +121,11 @@ class Bridge extends React.Component {
   // }
 }
 
-  pushRoute(symbol) {
+  pushRoute(symbol, routeData) {
     if (lodash.includes(ROUTE_NAMES, symbol)) {
       this.setState((state, _) => ({
         routeCrumbs: state.routeCrumbs.push(symbol),
+        routeData: routeData
       }));
 
       // Scroll to top of page with each route transition.
@@ -212,6 +214,7 @@ class Bridge extends React.Component {
   render() {
     const {
       routeCrumbs,
+      routeData,
       networkType,
       walletType,
       walletHdPath,
@@ -246,6 +249,7 @@ class Bridge extends React.Component {
                 // router
                 pushRoute={ this.pushRoute }
                 popRoute={ this.popRoute }
+                routeData={ routeData }
                 // network
                 setNetworkType={ this.setNetworkType }
                 setNetwork={ this.setNetwork }

--- a/src/style/extend.css
+++ b/src/style/extend.css
@@ -463,3 +463,10 @@ code {
 .clickable {
   cursor: pointer;
 }
+
+.keyfile {
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: 1rem 2rem;
+  margin-bottom: 4rem;
+}

--- a/src/views/GenKeyfile.js
+++ b/src/views/GenKeyfile.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import Maybe from 'folktale/maybe'
 
 import { Button } from '../components/Base'
 import { RequiredInput, InnerLabel } from '../components/Base'
@@ -34,7 +35,12 @@ class GenKeyfile extends React.Component {
 
   async deriveSeed() {
     const next = false
-    const seed = await attemptSeedDerivation(next, this.props)
+    let seed = await attemptSeedDerivation(next, this.props)
+
+    if (seed.getOrElse('') === '' && this.props.networkSeedCache) {
+      seed = Maybe.Just(this.props.networkSeedCache)
+    }
+
     this.setState({
       networkSeed: seed.getOrElse('')
     })

--- a/src/views/GenKeyfile.js
+++ b/src/views/GenKeyfile.js
@@ -107,6 +107,17 @@ class GenKeyfile extends React.Component {
         </Button>
       : ''
 
+    let networkSeedWarning
+
+    if (this.state.networkSeed === '') {
+      networkSeedWarning = (
+        <P>
+          <b>Warning: </b>
+          { "No network seed detected. To generate a keyfile, you must reset your networking keys." }
+        </P>
+      )
+    }
+
     return (
       <Row>
         <Col className={'col-md-8'}>
@@ -116,33 +127,12 @@ class GenKeyfile extends React.Component {
           { "Generate a private key file for booting this point in Arvo." }
           </P>
 
-          <P>
-          {
-            `Enter a network seed below for generating your key file.  Your
-             network seed must be a string of 64 characters (containing 0-9, A-Z, a-z)`
-          }
-          </P>
-          <P>
-          {
-             `If you've authenticated with either a master ticket or a
-             management proxy mnemonic, a seed will be generated for you
-             automatically.`
-          }
-          </P>
-
-          <RequiredInput
-            className='mono'
-            prop-size='lg'
-            prop-format='innerLabel'
-            autoFocus
-            value={ networkSeed }
-            onChange={ this.handleNetworkSeedInput }>
-            <InnerLabel>{ 'Network seed' }</InnerLabel>
-          </RequiredInput>
+          { networkSeedWarning }
 
           <Button
             className={'mt-8'}
             color={'blue'}
+            disabled={this.state.networkSeed === ''}
             onClick={
               () => {
                 if (hexRegExp.test(networkSeed)) {
@@ -155,9 +145,11 @@ class GenKeyfile extends React.Component {
             { 'Generate  →' }
           </Button>
 
-          <Code>
-            { keyfile }
-          </Code>
+          { keyfile !== '' &&
+            <Code className="pb-5">
+              { keyfile }
+            </Code>
+          }
 
           { warning }
 

--- a/src/views/GenKeyfile.js
+++ b/src/views/GenKeyfile.js
@@ -97,7 +97,7 @@ class GenKeyfile extends React.Component {
 
   render() {
     const { point, pointDetails, revision } = this.getPointDetails();
-    const { keyfile, loading } = this.state
+    const { keyfile, loaded } = this.state
 
     return (
       <Row>
@@ -108,17 +108,17 @@ class GenKeyfile extends React.Component {
           { "Download a private key file for booting this point in Arvo." }
           </P>
 
-          { keyfile === '' &&
+          { keyfile === '' && !loaded &&
             <P>
               { "Generating keyfile..." }
             </P>
           }
 
-          { keyfile === '' &&
+          { keyfile === '' && loaded &&
             <P>
               <b>Warning: </b>
               { `No valid network seed detected. To generate a keyfile, you
-                must reset your networking keys, or try logging in with your 
+                must reset your networking keys, or try logging in with your
                 master ticket or management mnemonic` }
             </P>
           }

--- a/src/views/SentTransaction.js
+++ b/src/views/SentTransaction.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Row, Col, H1, H3, P, Warning, Anchor } from '../components/Base'
 import { Button } from '../components/Base'
 
+import { ROUTE_NAMES } from '../lib/router'
 import { BRIDGE_ERROR, renderTxnError } from '../lib/error'
 import { NETWORK_NAMES } from '../lib/network'
 
@@ -75,8 +76,10 @@ const Failure = (props) =>
     </Row>
 
 const SentTransaction = (props) => {
-  const { web3, txnHashCursor, networkType, popRoute } = props
+  const { web3, txnHashCursor, networkType, popRoute, pushRoute } = props
   const { setPointCursor, pointCursor } = props
+
+  const promptKeyfile = props.routeData && props.routeData.promptKeyfile
 
   const w3 = web3.matchWith({
     Nothing: _ => { throw BRIDGE_ERROR.MISSING_WEB3 },
@@ -113,10 +116,32 @@ const SentTransaction = (props) => {
       </Col>
     </Row>
 
+  let keyfile;
+
+  if (promptKeyfile) {
+    keyfile = (
+      <Row>
+        <Col>
+          <Button
+            prop-type={'link'}
+            onClick={
+              () => {
+                popRoute()
+                pushRoute(ROUTE_NAMES.GEN_KEYFILE)
+              }
+            }>
+            { 'Download Keyfile →' }
+          </Button>
+        </Col>
+      </Row>
+    )
+  }
+
   return (
     <div>
       { body }
       { ok }
+      { keyfile }
     </div>
   )
 }

--- a/src/views/SetKeys.js
+++ b/src/views/SetKeys.js
@@ -263,7 +263,7 @@ class SetKeys extends React.Component {
     sendSignedTransaction(props.web3.value, state.stx)
       .then(sent => {
         props.setNetworkSeedCache(this.state.networkSeed)
-        this.downloadKeyfile(this.state.networkSeed)
+        // this.downloadKeyfile(this.state.networkSeed)
         props.setTxnHashCursor(sent)
         props.popRoute()
         props.pushRoute(ROUTE_NAMES.SENT_TRANSACTION)
@@ -350,7 +350,7 @@ class SetKeys extends React.Component {
 
           <P>
           {
-            `Once the transaction is sent, a keyfile will be downloaded, enabling you to instantiate your ship on the network.`
+            `Once the transaction is sent, please generate your Arvo keyfile immediately.`
           }
           </P>
 

--- a/src/views/SetKeys.js
+++ b/src/views/SetKeys.js
@@ -10,6 +10,8 @@ import { BRIDGE_ERROR } from '../lib/error'
 import { ROUTE_NAMES } from '../lib/router'
 import { attemptSeedDerivation } from '../lib/keys'
 
+
+
 import { WALLET_NAMES } from '../lib/wallet'
 
 import * as kg from '../../node_modules/urbit-key-generation/dist/index'
@@ -122,21 +124,33 @@ class SetKeys extends React.Component {
     })
   }
 
+  randomHex(len) {
+    let hex = "";
+
+    for (var i = 0; i < len; i++) {
+      hex = hex + ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b',
+      'c', 'd', 'e', 'f'][Math.floor(Math.random() * 16)]
+    }
+
+    return hex;
+  }
+
   async deriveSeed() {
     const next = true
-    const seed = await attemptSeedDerivation(next, this.props)
+    let seed = await attemptSeedDerivation(next, this.props)
+
+    if (seed.getOrElse('') === '') {
+      seed = Maybe.Just(this.randomHex(64));
+    }
+
     this.setState({
       networkSeed: seed.getOrElse('')
     })
   }
 
-
-
   handleNetworkSeedInput(networkSeed) {
     this.setState({ networkSeed })
   }
-
-
 
   handleCreateUnsignedTxn() {
     const txn = this.createUnsignedTxn()
@@ -229,6 +243,7 @@ class SetKeys extends React.Component {
     sendSignedTransaction(props.web3.value, state.stx)
       .then(sent => {
         props.setTxnHashCursor(sent)
+        props.setNetworkSeedCache(this.state.networkSeed)
         props.popRoute()
         props.pushRoute(ROUTE_NAMES.SENT_TRANSACTION)
       })

--- a/src/views/SetKeys.js
+++ b/src/views/SetKeys.js
@@ -124,6 +124,7 @@ class SetKeys extends React.Component {
     })
   }
 
+  //TODO use web3.utils.randomHex when it gets fixed, see web3.js#1490
   randomHex(len) {
     let hex = "";
 

--- a/src/views/SetKeys.js
+++ b/src/views/SetKeys.js
@@ -335,16 +335,6 @@ class SetKeys extends React.Component {
       ? props.pointCache[state.point]
       : (() => { throw BRIDGE_ERROR.MISSING_POINT })()
 
-    const isManagementMnemonic =
-      this.state.isManagementSeed &&
-      props.walletType === WALLET_NAMES.MNEMONIC
-
-    const isMasterTicket =
-      props.walletType === WALLET_NAMES.TICKET ||
-      props.walletType === WALLET_NAMES.SHARD
-
-    const networkSeedDisabled = isManagementMnemonic || isMasterTicket;
-
     return (
       <Row>
         <Col>
@@ -352,9 +342,15 @@ class SetKeys extends React.Component {
             { 'Set Network Keys For ' } <code>{ `${ob.patp(state.point)}` }</code>
           </H1>
 
+          <P className="mt-10">
+          {
+            `Set new authentication and encryption keys for your Arvo ship.`
+          }
+          </P>
+
           <P>
           {
-            `Set new authentication and encryption keys for your Arvo ship. Once the transaction is sent, a keyfile will be downloaded, enabling you to instantiate your ship on the network.`
+            `Once the transaction is sent, a keyfile will be downloaded, enabling you to instantiate your ship on the network.`
           }
           </P>
 
@@ -367,17 +363,6 @@ class SetKeys extends React.Component {
                 }
               </Warning>
             : <div /> }
-
-          <RequiredInput
-            className='mono'
-            prop-size='lg'
-            prop-format='innerLabel'
-            autoFocus
-            disabled= { networkSeedDisabled }
-            value={ state.networkSeed }
-            onChange={ this.handleNetworkSeedInput }>
-            <InnerLabel>{ 'Network seed' }</InnerLabel>
-          </RequiredInput>
 
           <StatelessTransaction
             // Upper scope

--- a/src/views/SetKeys.js
+++ b/src/views/SetKeys.js
@@ -128,8 +128,8 @@ class SetKeys extends React.Component {
     let hex = "";
 
     for (var i = 0; i < len; i++) {
-      hex = hex + ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b',
-      'c', 'd', 'e', 'f'][Math.floor(Math.random() * 16)]
+      hex = hex + ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B',
+      'C', 'D', 'E', 'F'][Math.floor(Math.random() * 16)]
     }
 
     return hex;

--- a/src/views/SetKeys.js
+++ b/src/views/SetKeys.js
@@ -270,7 +270,7 @@ class SetKeys extends React.Component {
         props.setNetworkSeedCache(this.state.networkSeed)
         props.setTxnHashCursor(sent)
         props.popRoute()
-        props.pushRoute(ROUTE_NAMES.SENT_TRANSACTION)
+        props.pushRoute(ROUTE_NAMES.SENT_TRANSACTION, {promptKeyfile: true})
       })
       .catch(err => {
         this.setState({ txError: err.map(val => val.merge()) })
@@ -355,7 +355,7 @@ class SetKeys extends React.Component {
               <h3 className={'mb-2'}>{'Warning'}</h3>
               {
                 `Your network seed could not be derived automatically. We've
-                generated a random one for you, but you must download your Arvo
+                generated a random one for you, so you must download your Arvo
                 keyfile during this session after setting your keys.`
               }
             </Warning>


### PR DESCRIPTION
This PR makes several changes to the setKeys / generateKeyfile flows: 

1)  Automatically generate a random network seed if user logs in using a non-urbit-generated wallet. Store this value in memory when new keys are set.
2)  Since network seeds are now always generated, hide the 'network seed' input on both setKeys and genKeyfile views. User doesn't need to interact with network seed at all anymore.
3)  Change the copy to reflect the above flow.

There's one sticking point with the above flow; if the non-urbit-wallet user refreshes the page between setting network keys and generating their keyfile, the network seed they use is lost. It's fairly punishing if a user accidentally refreshes between steps. Some options we have include: 

  A) adding the networkSeed to localStorage, 
  B) making the networkSeed generation deterministic (like urbit wallet case)
  C) download the keyfile automatically when new keys are set (combining the two actions into one)

For now Mark and I decided to just inform the user to download their keyfile immediately, but curious if others (@iamwillkim ?) have input here. 