### PR TITLE
Implement back navigation

### DIFF
--- a/src/Bridge.js
+++ b/src/Bridge.js
@@ -74,6 +74,12 @@ class Bridge extends React.Component {
   }
 
   componentDidMount() {
+    window.history.pushState(null, null, null);
+
+    window.onpopstate = (e) => {
+      window.history.pushState(null, null, null);
+      this.popRoute();
+    }
 
   // NB (jtobin):
   //

--- a/src/views/Network.js
+++ b/src/views/Network.js
@@ -45,7 +45,7 @@ class Network extends React.Component {
     if (network === NETWORK_NAMES.LOCAL) {
       setNetworkType(network)
 
-      const endpoint = 'wss://localhost:8545'
+      const endpoint = 'ws://localhost:8545'
       const provider = new Web3.providers.WebsocketProvider(endpoint)
       const web3 = new Web3(provider)
       const contracts = azimuth.initContracts(web3, CONTRACT_ADDRESSES.DEV)


### PR DESCRIPTION
Okay, I feel really stupid about this.

It turns out the history API works pretty well if you just add a new history entry every time the back button is pressed. This "clears" the forward history, so the user isn't prompted to navigate forward (which is where the problems happen).

So there's no forward navigation, but this seems to work comfortably without any major router overhauls.