### PR TITLE
Add file sync option to zip command

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eject": "react-scripts eject",
     "checksum": "find build -exec shasum -a256 {} ';' > checksums.txt",
     "tar": "tar -czvf bridge-$npm_package_version.tar.gz README.md bridge-https.py checksums.txt build",
-    "zip": "zip -r bridge-$npm_package_version.zip README.md bridge-https.py checksums.txt build",
+    "zip": "zip -FSr bridge-$npm_package_version.zip README.md bridge-https.py checksums.txt build",
     "release": "npm install && npm run build && npm run checksum && npm run zip",
     "pilot:ganache": "ganache-cli -m 'benefit crew supreme gesture quantum web media hazard theory mercy wing kitten' > /dev/null &",
     "pilot:deploy": "cd node_modules/azimuth-solidity && truffle deploy",


### PR DESCRIPTION
Fixes #84 

The problem can be reproduced by running `npm run release`, modifying some code, running `npm run release` again and inspecting the .zip.

You'll get something like 
```console
tree -D build
build
├── [Apr  2 17:09]  asset-manifest.json
├── [Mar 18 22:53]  favicon.ico
├── [Apr  2 17:09]  index.html
├── [Mar 18 22:53]  manifest.json
├── [Apr  2 17:09]  precache-manifest.4eb231253bd00e4e654613b55221e927.js
├── [Apr  2 17:07]  precache-manifest.955df6be55bd39037f7132152208d8ce.js
├── [Apr  2 17:09]  service-worker.js
└── [Apr  2 17:09]  static
    ├── [Apr  2 17:09]  css
    │   ├── [Apr  2 17:09]  main.17bd1ca5.chunk.css
    │   └── [Apr  2 17:09]  main.17bd1ca5.chunk.css.map
    ├── [Apr  2 17:09]  js
    │   ├── [Apr  2 17:09]  1.7700c553.chunk.js
    │   ├── [Apr  2 17:09]  1.7700c553.chunk.js.map
    │   ├── [Apr  2 17:09]  main.32589c19.chunk.js
    │   ├── [Apr  2 17:09]  main.32589c19.chunk.js.map
    │   ├── [Apr  2 17:07]  main.c99d9132.chunk.js
    │   ├── [Apr  2 17:07]  main.c99d9132.chunk.js.map
    │   ├── [Apr  2 17:09]  runtime~main.229c360f.js
    │   └── [Apr  2 17:09]  runtime~main.229c360f.js.map
    └── [Apr  2 17:09]  media
        ├── [Apr  2 17:09]  Inter-UI-Medium.5292a06c.woff
        ├── [Apr  2 17:09]  Inter-UI-Medium.63ba5137.woff2
        ├── [Apr  2 17:09]  Inter-UI-Regular.b36fe2ea.woff
        ├── [Apr  2 17:09]  Inter-UI-Regular.d74d59d2.woff2
        ├── [Apr  2 17:09]  Inter-UI-SemiBold.462a99bc.woff
        └── [Apr  2 17:09]  Inter-UI-SemiBold.a2ae283d.woff2
```

Where the hashes are different and therefore some files get added twice.

Adding the file sync option to the zip command fixes this.