### PR TITLE
genKeyfile warning addition

### DIFF
--- a/src/bridge/views/GenKeyfile.js
+++ b/src/bridge/views/GenKeyfile.js
@@ -115,12 +115,18 @@ class GenKeyfile extends React.Component {
           }
 
           { keyfile === '' && loaded &&
-            <P>
-              <b>Warning: </b>
-              { `No valid network seed detected. To generate a keyfile, you
-                must reset your networking keys, or try logging in with your
-                master ticket or management mnemonic` }
-            </P>
+            <React.Fragment>
+              <P>
+                <b>Warning: </b>
+                { `No valid network seed detected. To generate a keyfile, you
+                  must reset your networking keys, or try logging in with your
+                  master ticket or management mnemonic.` }
+              </P>
+
+              <P>
+                { `If you've just reset your networking keys, you may need to wait for the transaction to go through. Check back shortly.` }
+              </P>
+            </React.Fragment>
           }
 
           { keyfile !== '' &&


### PR DESCRIPTION
During Ropstein testing, I noticed there are some edge cases where the user hits the genKeyfile page before the setKeys transaction hits the network. This warns the user to wait a little bit if they just set their keys and their keyfile isn't showing up yet.

@Fang- 