### PR TITLE
Generate keyfile in offline mode

### DIFF
--- a/src/bridge/lib/validators.js
+++ b/src/bridge/lib/validators.js
@@ -41,15 +41,12 @@ const validateMnemonic = m => simpleValidatorWrapper({
   errorMessage: 'This is not a valid mnemonic.'
 });
 
-
 // Checks an empty field
 const validateNotEmpty = m => simpleValidatorWrapper({
   prevMessage: m,
-  validator: d => d.length > 1,
+  validator: d => d.length > 0,
   errorMessage: 'This field is required.'
 });
-
-
 
 // Checks if a patp is a valid galaxy
 const validateGalaxy = m => simpleValidatorWrapper({

--- a/src/bridge/views/Point/Actions.js
+++ b/src/bridge/views/Point/Actions.js
@@ -137,7 +137,7 @@ const Actions = (props) => {
           <Button
             prop-size={'sm'}
             prop-type={'link'}
-            disabled={ !canAcceptTransfer }
+            disabled={ online && !canAcceptTransfer }
             onClick={ () => {
               pushRoute(ROUTE_NAMES.ACCEPT_TRANSFER)
             }}
@@ -159,7 +159,7 @@ const Actions = (props) => {
           <Button
             prop-size={'sm'}
             prop-type={'link'}
-            disabled={ !canGenKeyfile }
+            disabled={ online && !canGenKeyfile }
             onClick={ () => {
               pushRoute(ROUTE_NAMES.GEN_KEYFILE)
             }}

--- a/src/bridge/views/SetKeys.js
+++ b/src/bridge/views/SetKeys.js
@@ -34,7 +34,6 @@ class SetKeys extends React.Component {
       point: point,
       cryptoSuiteVersion: 1,
       continuity: false,
-      isManagementSeed: false,
     }
 
     this.handleNetworkSeedInput = this.handleNetworkSeedInput.bind(this)
@@ -52,17 +51,6 @@ class SetKeys extends React.Component {
       Nothing: () => {
         throw BRIDGE_ERROR.MISSING_WALLET
       }
-    })
-
-    this.determineManagementSeed(props.contracts.value, addr)
-  }
-
-  async determineManagementSeed(ctrcs, addr) {
-    const managing =
-      await azimuth.azimuth.getManagerFor(ctrcs, addr)
-
-    this.setState({
-      isManagementSeed: managing.length !== 0
     })
   }
 


### PR DESCRIPTION
This PR allows users to enter their own revision number on the genKeyfile view, allowing them to generate a keyfile that we assume is valid.

This only works if:
  - They log in as a valid management proxy for the point they're generating for 
  - They log in with an Urbit wallet 
  - They enter the correct revision number

Fixes https://github.com/urbit/bridge/issues/102, https://github.com/urbit/bridge/issues/89