### PR TITLE
Fix web3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2008,6 +2008,11 @@
         "web3": "1.0.0-beta.33"
       },
       "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
         "web3": {
           "version": "1.0.0-beta.33",
           "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.33.tgz",
@@ -2020,6 +2025,22 @@
             "web3-net": "1.0.0-beta.33",
             "web3-shh": "1.0.0-beta.33",
             "web3-utils": "1.0.0-beta.33"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.0.0-beta.33",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
+              "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+              "requires": {
+                "bn.js": "4.11.6",
+                "eth-lib": "0.1.27",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.8.3",
+                "utf8": "2.1.1"
+              }
+            }
           }
         }
       }
@@ -2632,7 +2653,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
         "readable-stream": "^2.3.5",
@@ -4333,12 +4354,12 @@
       "dependencies": {
         "file-type": {
           "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
         },
         "get-stream": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "requires": {
             "object-assign": "^4.0.1",
@@ -15750,7 +15771,7 @@
     },
     "query-string": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "requires": {
         "decode-uri-component": "^0.2.0",
@@ -17351,7 +17372,7 @@
     },
     "scrypt.js": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
       "integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
       "requires": {
         "scrypt": "^6.0.2",
@@ -17391,7 +17412,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "requires": {
             "graceful-readlink": ">= 1.0.0"
@@ -17651,7 +17672,7 @@
       "dependencies": {
         "nan": {
           "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
           "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
         }
       }
@@ -18492,7 +18513,7 @@
     },
     "tar": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "requires": {
         "block-stream": "*",
@@ -18528,7 +18549,7 @@
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         }
       }
@@ -19097,7 +19118,7 @@
     },
     "underscore": {
       "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -19362,7 +19383,7 @@
     },
     "utf8": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
       "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
     },
     "util": {
@@ -19797,35 +19818,6 @@
             "web3-utils": "1.0.0-beta.52"
           }
         },
-        "web3-utils": {
-          "version": "1.0.0-beta.52",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.52.tgz",
-          "integrity": "sha512-WdHyzPcZu/sOnNrkcOZT20QEX9FhwD9OJJXENojQNvMK2a1xo3n8JWBcC2gzAGwsa0Aah6z2B3Xwa1P//8FaoA==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "@types/bn.js": "^4.11.4",
-            "@types/node": "^10.12.18",
-            "bn.js": "4.11.8",
-            "eth-lib": "0.2.8",
-            "ethjs-unit": "^0.1.6",
-            "lodash": "^4.17.11",
-            "number-to-bn": "1.7.0",
-            "randomhex": "0.1.5",
-            "utf8": "2.1.1"
-          },
-          "dependencies": {
-            "eth-lib": {
-              "version": "0.2.8",
-              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-              "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-              "requires": {
-                "bn.js": "^4.11.6",
-                "elliptic": "^6.4.0",
-                "xhr-request-promise": "^0.1.2"
-              }
-            }
-          }
-        },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
@@ -19852,6 +19844,27 @@
         "web3-core-method": "1.0.0-beta.33",
         "web3-core-requestmanager": "1.0.0-beta.33",
         "web3-utils": "1.0.0-beta.33"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.33",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
+          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          }
+        }
       }
     },
     "web3-core-helpers": {
@@ -19862,6 +19875,27 @@
         "underscore": "1.8.3",
         "web3-eth-iban": "1.0.0-beta.33",
         "web3-utils": "1.0.0-beta.33"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.33",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
+          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          }
+        }
       }
     },
     "web3-core-method": {
@@ -19874,6 +19908,27 @@
         "web3-core-promievent": "1.0.0-beta.33",
         "web3-core-subscriptions": "1.0.0-beta.33",
         "web3-utils": "1.0.0-beta.33"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.33",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
+          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          }
+        }
       }
     },
     "web3-core-promievent": {
@@ -19924,6 +19979,27 @@
         "web3-eth-personal": "1.0.0-beta.33",
         "web3-net": "1.0.0-beta.33",
         "web3-utils": "1.0.0-beta.33"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.33",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
+          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          }
+        }
       }
     },
     "web3-eth-abi": {
@@ -19941,6 +20017,20 @@
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.33",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
+          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          }
         }
       }
     },
@@ -19975,6 +20065,41 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.33",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
+          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+            },
+            "eth-lib": {
+              "version": "0.1.27",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
+              "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "keccakjs": "^0.2.1",
+                "nano-json-stream-parser": "^0.1.2",
+                "servify": "^0.1.12",
+                "ws": "^3.0.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
+          }
         }
       }
     },
@@ -19991,6 +20116,27 @@
         "web3-core-subscriptions": "1.0.0-beta.33",
         "web3-eth-abi": "1.0.0-beta.33",
         "web3-utils": "1.0.0-beta.33"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.33",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
+          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          }
+        }
       }
     },
     "web3-eth-ens": {
@@ -20152,23 +20298,6 @@
             "web3-providers": "1.0.0-beta.52",
             "web3-utils": "1.0.0-beta.52"
           }
-        },
-        "web3-utils": {
-          "version": "1.0.0-beta.52",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.52.tgz",
-          "integrity": "sha512-WdHyzPcZu/sOnNrkcOZT20QEX9FhwD9OJJXENojQNvMK2a1xo3n8JWBcC2gzAGwsa0Aah6z2B3Xwa1P//8FaoA==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "@types/bn.js": "^4.11.4",
-            "@types/node": "^10.12.18",
-            "bn.js": "4.11.8",
-            "eth-lib": "0.2.8",
-            "ethjs-unit": "^0.1.6",
-            "lodash": "^4.17.11",
-            "number-to-bn": "1.7.0",
-            "randomhex": "0.1.5",
-            "utf8": "2.1.1"
-          }
         }
       }
     },
@@ -20185,6 +20314,20 @@
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.33",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
+          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          }
         }
       }
     },
@@ -20198,6 +20341,27 @@
         "web3-core-method": "1.0.0-beta.33",
         "web3-net": "1.0.0-beta.33",
         "web3-utils": "1.0.0-beta.33"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.33",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
+          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          }
+        }
       }
     },
     "web3-net": {
@@ -20208,6 +20372,27 @@
         "web3-core": "1.0.0-beta.33",
         "web3-core-method": "1.0.0-beta.33",
         "web3-utils": "1.0.0-beta.33"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.33",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
+          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          }
+        }
       }
     },
     "web3-providers": {
@@ -20296,23 +20481,44 @@
       }
     },
     "web3-utils": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
-      "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+      "version": "1.0.0-beta.52",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.52.tgz",
+      "integrity": "sha512-WdHyzPcZu/sOnNrkcOZT20QEX9FhwD9OJJXENojQNvMK2a1xo3n8JWBcC2gzAGwsa0Aah6z2B3Xwa1P//8FaoA==",
       "requires": {
-        "bn.js": "4.11.6",
-        "eth-lib": "0.1.27",
-        "ethjs-unit": "0.1.6",
+        "@babel/runtime": "^7.3.1",
+        "@types/bn.js": "^4.11.4",
+        "@types/node": "^10.12.18",
+        "bn.js": "4.11.8",
+        "eth-lib": "0.2.8",
+        "ethjs-unit": "^0.1.6",
+        "lodash": "^4.17.11",
         "number-to-bn": "1.7.0",
         "randomhex": "0.1.5",
-        "underscore": "1.8.3",
         "utf8": "2.1.1"
       },
       "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        "@babel/runtime": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
+          "integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
     "node": "11.0.0"
   },
   "dependencies": {
-    "azimuth-js": "^0.10.0",
     "@ledgerhq/hw-app-eth": "^4.35.0",
     "@ledgerhq/hw-transport-u2f": "^4.35.0",
+    "PaperCollateralRenderer": "github:urbit/PaperCollateralRenderer",
+    "azimuth-js": "^0.10.0",
     "azimuth-solidity": "1.0.2",
     "babel-polyfill": "^6.26.0",
     "bip32": "^1.0.2",
@@ -34,7 +35,6 @@
     "keythereum": "^1.0.4",
     "lodash": "^4.17.11",
     "more-entropy": "^0.0.7",
-    "PaperCollateralRenderer": "github:urbit/PaperCollateralRenderer",
     "prop-types": "^15.6.2",
     "react": "^16.6.0",
     "react-dom": "^16.6.0",
@@ -45,7 +45,8 @@
     "trezor-connect": "^7.0.1",
     "urbit-key-generation": "0.12.1",
     "urbit-ob": "^3.1.0",
-    "web3": "1.0.0-beta.52"
+    "web3": "1.0.0-beta.52",
+    "web3-utils": "^1.0.0-beta.52"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/bridge/lib/txn.js
+++ b/src/bridge/lib/txn.js
@@ -3,6 +3,7 @@ import { Just } from 'folktale/maybe'
 import { Ok, Error } from 'folktale/result'
 import Tx from 'ethereumjs-tx'
 import Web3 from 'web3'
+import { toWei, fromWei, toHex } from 'web3-utils'
 
 import { BRIDGE_ERROR } from '../lib/error'
 import { NETWORK_NAMES } from '../lib/network'
@@ -181,11 +182,6 @@ const getTxnInfo = async (web3, addr) => {
     gasPrice: fromWei(gasPrice, 'gwei')
   }
 }
-
-const dummy = new Web3()
-const toHex = dummy.utils.toHex
-const toWei = dummy.utils.toWei
-const fromWei = dummy.utils.fromWei
 
 const canDecodePatp = p => {
   try {

--- a/src/bridge/views/Network.js
+++ b/src/bridge/views/Network.js
@@ -70,7 +70,10 @@ class Network extends React.Component {
       // We may want to offer the ability to select a target network for
       // transactions when offline.
 
-      const web3 = new Web3()
+      // Note: localhost:3456 doesn't actually point to anything, we just need
+      // a provider to initialize the Web3 object
+      const provider = new Web3.providers.HttpProvider("http://localhost:3456")
+      const web3 = new Web3(provider)
 
       const target =
           process.env.NODE_ENV === 'development'


### PR DESCRIPTION
Turns out, web3@beta.52 does break some things; it requires the Web3 object to pass in a provider, whereas before `new Web3()` worked without one. 

This PR includes web3-utils directly in cases where we don't want a web3 object. In offline mode, we do need a web3 object to build the contracts, so we pass in a dummy localhost address during initialization.