### PR TITLE
Put build dir contents into root of release zip

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "checksum": "find build -exec shasum -a256 {} ';' > checksums.txt",
-    "tar": "tar -czvf bridge-$npm_package_version.tar.gz README.md bridge-https.py checksums.txt build",
     "zip": "zip -FSr bridge-$npm_package_version.zip README.md bridge-https.py checksums.txt && cd build && zip -FSr ../bridge-$npm_package_version.zip ./* && cd ..",
     "release": "npm install && npm run build && npm run checksum && npm run zip",
     "pilot:ganache": "ganache-cli -m 'benefit crew supreme gesture quantum web media hazard theory mercy wing kitten' > /dev/null &",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eject": "react-scripts eject",
     "checksum": "find build -exec shasum -a256 {} ';' > checksums.txt",
     "tar": "tar -czvf bridge-$npm_package_version.tar.gz README.md bridge-https.py checksums.txt build",
-    "zip": "zip -FSr bridge-$npm_package_version.zip README.md bridge-https.py checksums.txt build",
+    "zip": "zip -FSr bridge-$npm_package_version.zip README.md bridge-https.py checksums.txt && cd build && zip -FSr ../bridge-$npm_package_version.zip ./* && cd ..",
     "release": "npm install && npm run build && npm run checksum && npm run zip",
     "pilot:ganache": "ganache-cli -m 'benefit crew supreme gesture quantum web media hazard theory mercy wing kitten' > /dev/null &",
     "pilot:deploy": "cd node_modules/azimuth-solidity && truffle deploy",


### PR DESCRIPTION
By `cd`ing into the `build` directory, and *then* adding the files in it to the zip, we can add it to the release root so that people won't have to use `--directory build` or equivalent when using the python script to host Bridge.

Sort of fixes #88.