### PR TITLE
Fix size on rendered points in CreateGalaxy and IssueChild

### DIFF
--- a/src/bridge/views/CreateGalaxy.js
+++ b/src/bridge/views/CreateGalaxy.js
@@ -167,7 +167,7 @@ class CreateGalaxy extends React.Component {
             <ValidatedSigil
               className='tr-0 mt-05 mr-0 abs'
               patp={state.galaxyName}
-              size={76}
+              size={68}
               margin={8} />
           </GalaxyInput>
 

--- a/src/bridge/views/IssueChild.js
+++ b/src/bridge/views/IssueChild.js
@@ -253,7 +253,7 @@ class IssueChild extends React.Component {
             <ValidatedSigil
               className={'tr-0 mt-05 mr-0 abs'}
               patp={state.desiredPoint}
-              size={76}
+              size={68}
               margin={8}
               validator={() => this.validatePoint(state.desiredPoint)} />
           </PointInput>


### PR DESCRIPTION
Before:
<img width="121" alt="image" src="https://user-images.githubusercontent.com/14286382/56246829-c0184180-60ab-11e9-92b5-16d9e39ef770.png">


After:
<img width="126" alt="image" src="https://user-images.githubusercontent.com/14286382/56246556-fe613100-60aa-11e9-80c5-dbfb5f304b73.png">

The size is already correct in ViewPoint, Sigil and Ticket.