### PR TITLE
Remove reference to build directory.

### DIFF
--- a/bridge-https.py
+++ b/bridge-https.py
@@ -4,5 +4,4 @@ import ssl
 
 httpd = BaseHTTPServer.HTTPServer(('localhost', 4443), SimpleHTTPServer.SimpleHTTPRequestHandler)
 httpd.socket = ssl.wrap_socket (httpd.socket, certfile='localhost.pem', keyfile='localhost-key.pem', server_side=True)
-os.chdir('./build')
 httpd.serve_forever()


### PR DESCRIPTION
(Resolves #122)

The build directory was removed from releases a version or two ago, but it lived on in this script (causing it to break).