### PR TITLE
Fix bug where entire application re-renders on setTxnConfirmations

### DIFF
--- a/src/bridge/Bridge.js
+++ b/src/bridge/Bridge.js
@@ -244,9 +244,12 @@ class Bridge extends React.Component {
   }
 
   setTxnConfirmations(txnHash, txnConfirmations) {
-    this.setState((prevState, _) =>
-                  ({txnConfirmations: { ...prevState.txnConfirmations,
-                                        [txnHash]: txnConfirmations}}))
+    this.setState((prevState, _) => {
+      return prevState.routeCrumbs.peek() === ROUTE_NAMES.SENT_TRANSACTION
+      ? {txnConfirmations: { ...prevState.txnConfirmations,
+                               [txnHash]: txnConfirmations}}
+      : null
+    })
   }
 
   render() {


### PR DESCRIPTION
Sorry for introducing this bug my dudes!

This PR is a quick fix for #125, but is obviously not very nice. The state flow for the transaction confirmations is very convoluted at the moment so a real fix will need some refactoring. I'll do it straight away when I have time, probably using some polling logic like @Fang- suggested in the issue comments.

I still think it's worth having a PR like this fixing the bug until then. 