### PR TITLE
Include label in CheckboxButton component

### DIFF
--- a/src/bridge/components/CheckboxButton.js
+++ b/src/bridge/components/CheckboxButton.js
@@ -16,7 +16,8 @@ const CheckboxButton = props => {
   return (
     <div
       className={`flex items-center ${props.className}`}
-      style={props.style}>
+      style={{cursor: 'pointer', ...props.style}}
+      onClick={props.onToggle}>
 
       <ProtoButton
         // {...getDomProps(props)}
@@ -38,6 +39,7 @@ const CheckboxButton = props => {
 
       </ProtoButton>
 
+      <div>{ props.label }</div>
       { props.children }
 
     </div>

--- a/src/bridge/components/StatelessTransaction.js
+++ b/src/bridge/components/StatelessTransaction.js
@@ -428,13 +428,10 @@ class StatelessTransaction extends React.Component {
       <CheckboxButton
         className={ 'mt-8' }
         disabled={ !canApprove }
-        onClick={ setUserApproval }
+        onToggle={ setUserApproval }
         state={ userApproval }
-      >
-        <div onClick={ setUserApproval }>
-          { `I approve this transaction and wish to send.` }
-        </div>
-      </CheckboxButton>
+        label='I approve this transaction and wish to send.'
+      ></CheckboxButton>
 
     const sendTxnButton =
       <Button

--- a/src/bridge/views/SetKeys.js
+++ b/src/bridge/views/SetKeys.js
@@ -187,13 +187,12 @@ class SetKeys extends React.Component {
 
           <CheckboxButton
             className='mt-8'
-            onClick={ this.toggleDiscontinuity }
+            onToggle={ this.toggleDiscontinuity }
             state={ state.discontinuity }
-          >
-            <div style={{cursor: 'pointer'}} onClick={ this.toggleDiscontinuity }>
-              { 'I have lost important off-chain data relating to this point and need to do a hard-reset. (For example, rebooting an Arvo ship.)' }
-            </div>
-          </CheckboxButton>
+            label={`I have lost important off-chain data relating to this point
+                    and need to do a hard-reset.
+                    (For example, rebooting an Arvo ship.)`}
+          ></CheckboxButton>
 
           <StatelessTransaction
             // Upper scope


### PR DESCRIPTION
For more consistent experience, styling, etc.

This PR targets #130 because that creates a `CheckboxButton` that we want updated to fit this. If that gets merged before this, we can just target master instead.