### PR TITLE
Use Azimuth-native function for accepting transfer

### DIFF
--- a/src/bridge/views/AcceptTransfer.js
+++ b/src/bridge/views/AcceptTransfer.js
@@ -60,13 +60,11 @@ class AcceptTransfer extends React.Component {
       }
     })
 
-    const owner = props.pointCache[validPoint].owner
-
-    return Just(azimuth.ecliptic.transferFrom(
+    return Just(azimuth.ecliptic.transferPoint(
       validContracts,
-      owner,
+      validPoint,
       state.receivingAddress,
-      validPoint
+      true
     ))
   }
 


### PR DESCRIPTION
Use `transferPoint` over `transferFrom`, because the latter is a generic part of the ERC721 standard, while the former is part of Azimuth and allows more fine-grained control over what happens during the transaction while presenting a simpler interface.

We do a `reset` here, just like the `transferFrom` does implicitly.