### PR TITLE
Incorporate gas tank into StatelessTransaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1346,6 +1346,11 @@
       "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
       "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
     },
+    "aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+    },
     "ajv": {
       "version": "6.6.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
@@ -1438,11 +1443,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-    },
-    "any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "anymatch": {
       "version": "2.0.0",
@@ -2617,14 +2617,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "requires": {
-        "inherits": "~2.0.0"
-      }
-    },
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
@@ -3638,6 +3630,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -5180,6 +5177,22 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "eth-ens-namehash": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
+      "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
+      "requires": {
+        "idna-uts46-hx": "^2.3.1",
+        "js-sha3": "^0.5.7"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        }
+      }
+    },
     "eth-lib": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
@@ -5230,6 +5243,60 @@
         "secp256k1": "^3.0.1"
       }
     },
+    "ethers": {
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.27.tgz",
+      "integrity": "sha512-+DXZLP/tyFnXWxqr2fXLT67KlGUfLuvDkHSOtSC9TUVG9OIj6yrG5JPeXRMYo15xkOYwnjgdMKrXp5V94rtjJA==",
+      "requires": {
+        "@types/node": "^10.3.2",
+        "aes-js": "3.0.0",
+        "bn.js": "^4.4.0",
+        "elliptic": "6.3.3",
+        "hash.js": "1.1.3",
+        "js-sha3": "0.5.7",
+        "scrypt-js": "2.0.4",
+        "setimmediate": "1.0.4",
+        "uuid": "2.0.1",
+        "xmlhttprequest": "1.8.0"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.3.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+          "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        }
+      }
+    },
     "ethjs-unit": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
@@ -5256,9 +5323,9 @@
       }
     },
     "eventemitter3": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
-      "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
     },
     "events": {
       "version": "3.0.0",
@@ -6376,26 +6443,12 @@
         "rimraf": "^2.2.8"
       }
     },
-    "fs-promise": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-2.0.3.tgz",
-      "integrity": "sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=",
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "requires": {
-        "any-promise": "^1.3.0",
-        "fs-extra": "^2.0.0",
-        "mz": "^2.6.0",
-        "thenify-all": "^1.6.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-          "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0"
-          }
-        }
+        "minipass": "^2.2.1"
       }
     },
     "fs-write-stream-atomic": {
@@ -6893,17 +6946,6 @@
           "bundled": true,
           "optional": true
         }
-      }
-    },
-    "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
       }
     },
     "function-bind": {
@@ -7887,11 +7929,6 @@
         "statuses": ">= 1.4.0 < 2"
       }
     },
-    "http-https": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
-      "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs="
-    },
     "http-parser-js": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz",
@@ -8230,6 +8267,21 @@
       "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
       "requires": {
         "harmony-reflect": "^1.4.6"
+      }
+    },
+    "idna-uts46-hx": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
+      "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+        }
       }
     },
     "ieee754": {
@@ -10697,6 +10749,30 @@
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
     "mississippi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
@@ -10817,9 +10893,9 @@
       }
     },
     "mock-fs": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.8.0.tgz",
-      "integrity": "sha512-Gwj4KnJOW15YeTJKO5frFd/WDO5Mc0zxXqL9oHx3+e9rBqW8EVARqQHSaIXznUdljrD6pvbNGW2ZGXKPEfYJfw=="
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.9.0.tgz",
+      "integrity": "sha512-aUj0qIniTNxzGqAC61Bvro7YD37tIBnMw3wpClucUVgNBS7r6YQn/M4wuoH7SGteKz4SvC1OBeDsfpG0MYC+1Q=="
     },
     "more-entropy": {
       "version": "0.0.7",
@@ -10828,11 +10904,6 @@
       "requires": {
         "iced-runtime": ">=0.0.1"
       }
-    },
-    "mout": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
-      "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k="
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -10875,16 +10946,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-    },
-    "mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "requires": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
     },
     "nan": {
       "version": "2.12.1",
@@ -11351,14 +11412,6 @@
         "es-abstract": "^1.6.1",
         "function-bind": "^1.1.0",
         "has": "^1.0.1"
-      }
-    },
-    "oboe": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.3.tgz",
-      "integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=",
-      "requires": {
-        "http-https": "^1.0.0"
       }
     },
     "obuf": {
@@ -17219,6 +17272,11 @@
         "nan": "^2.0.8"
       }
     },
+    "scrypt-js": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+      "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+    },
     "scrypt.js": {
       "version": "0.2.0",
       "resolved": "http://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
@@ -18247,32 +18305,40 @@
       }
     },
     "swarm-js": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.37.tgz",
-      "integrity": "sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==",
+      "version": "0.1.39",
+      "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
+      "integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
       "requires": {
         "bluebird": "^3.5.0",
         "buffer": "^5.0.5",
         "decompress": "^4.0.0",
         "eth-lib": "^0.1.26",
-        "fs-extra": "^2.1.2",
-        "fs-promise": "^2.0.0",
+        "fs-extra": "^4.0.2",
         "got": "^7.1.0",
         "mime-types": "^2.1.16",
         "mkdirp-promise": "^5.0.1",
         "mock-fs": "^4.1.0",
         "setimmediate": "^1.0.5",
-        "tar.gz": "^1.0.5",
+        "tar": "^4.0.2",
         "xhr-request-promise": "^0.1.2"
       },
       "dependencies": {
         "fs-extra": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-          "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
           "requires": {
             "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0"
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
           }
         }
       }
@@ -18361,13 +18427,24 @@
       "integrity": "sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA=="
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.2",
-        "inherits": "2"
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.4",
+        "minizlib": "^1.1.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
       }
     },
     "tar-stream": {
@@ -18382,25 +18459,6 @@
         "readable-stream": "^2.3.0",
         "to-buffer": "^1.1.1",
         "xtend": "^4.0.0"
-      }
-    },
-    "tar.gz": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/tar.gz/-/tar.gz-1.0.7.tgz",
-      "integrity": "sha512-uhGatJvds/3diZrETqMj4RxBR779LKlIE74SsMcn5JProZsfs9j0QBwWO1RW+IWNJxS2x8Zzra1+AW6OQHWphg==",
-      "requires": {
-        "bluebird": "^2.9.34",
-        "commander": "^2.8.1",
-        "fstream": "^1.0.8",
-        "mout": "^0.11.0",
-        "tar": "^2.1.1"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "2.11.0",
-          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
-        }
       }
     },
     "term-size": {
@@ -18547,22 +18605,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
-    },
-    "thenify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
-      "requires": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
-      "requires": {
-        "thenify": ">= 3.1.0 < 4"
-      }
     },
     "throat": {
       "version": "4.1.0",
@@ -18964,11 +19006,6 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
-    },
-    "underscore": {
-      "version": "1.8.3",
-      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -19383,486 +19420,804 @@
       }
     },
     "web3": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.33.tgz",
-      "integrity": "sha1-xgIbV2mSdyY3HBhLhoRFMRsTkpU=",
+      "version": "1.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.54.tgz",
+      "integrity": "sha512-rMQaLFwBNR3Lc8Npa9uasdkJKhsnp2FrDA0r8J814mU1VITkAG7l8NPICrlUaDLNiQn0bf6QnONTNujuds+yNg==",
       "requires": {
-        "web3-bzz": "1.0.0-beta.33",
-        "web3-core": "1.0.0-beta.33",
-        "web3-eth": "1.0.0-beta.33",
-        "web3-eth-personal": "1.0.0-beta.33",
-        "web3-net": "1.0.0-beta.33",
-        "web3-shh": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
+        "@babel/runtime": "^7.3.1",
+        "@types/node": "^10.12.18",
+        "web3-bzz": "1.0.0-beta.54",
+        "web3-core": "1.0.0-beta.54",
+        "web3-core-helpers": "1.0.0-beta.54",
+        "web3-core-method": "1.0.0-beta.54",
+        "web3-eth": "1.0.0-beta.54",
+        "web3-eth-personal": "1.0.0-beta.54",
+        "web3-net": "1.0.0-beta.54",
+        "web3-providers": "1.0.0-beta.54",
+        "web3-shh": "1.0.0-beta.54",
+        "web3-utils": "1.0.0-beta.54"
       },
       "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        },
-        "web3-utils": {
-          "version": "1.0.0-beta.33",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
-          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+        "@babel/runtime": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+          "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
           "requires": {
-            "bn.js": "4.11.6",
-            "eth-lib": "0.1.27",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randomhex": "0.1.5",
-            "underscore": "1.8.3",
-            "utf8": "2.1.1"
+            "regenerator-runtime": "^0.13.2"
           }
-        }
-      }
-    },
-    "web3-bzz": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.33.tgz",
-      "integrity": "sha1-MVAPaZt+cO31FJDFXv+0J7+7OwE=",
-      "requires": {
-        "got": "7.1.0",
-        "swarm-js": "0.1.37",
-        "underscore": "1.8.3"
-      }
-    },
-    "web3-core": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.33.tgz",
-      "integrity": "sha1-+C7VJfW2auzale7O08rSvWlfeDk=",
-      "requires": {
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-core-requestmanager": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         },
-        "web3-utils": {
-          "version": "1.0.0-beta.33",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
-          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
-          "requires": {
-            "bn.js": "4.11.6",
-            "eth-lib": "0.1.27",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randomhex": "0.1.5",
-            "underscore": "1.8.3",
-            "utf8": "2.1.1"
-          }
-        }
-      }
-    },
-    "web3-core-helpers": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.33.tgz",
-      "integrity": "sha1-Kvcz5QTbBefDZIwdrPV3sOwV3EM=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-eth-iban": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        },
-        "web3-utils": {
-          "version": "1.0.0-beta.33",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
-          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
-          "requires": {
-            "bn.js": "4.11.6",
-            "eth-lib": "0.1.27",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randomhex": "0.1.5",
-            "underscore": "1.8.3",
-            "utf8": "2.1.1"
-          }
-        }
-      }
-    },
-    "web3-core-method": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.33.tgz",
-      "integrity": "sha1-7Y7ExK+rIdwJid41g2hEZlIrboY=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-core-promievent": "1.0.0-beta.33",
-        "web3-core-subscriptions": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        },
-        "web3-utils": {
-          "version": "1.0.0-beta.33",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
-          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
-          "requires": {
-            "bn.js": "4.11.6",
-            "eth-lib": "0.1.27",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randomhex": "0.1.5",
-            "underscore": "1.8.3",
-            "utf8": "2.1.1"
-          }
-        }
-      }
-    },
-    "web3-core-promievent": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.33.tgz",
-      "integrity": "sha1-0fXrtgFSfdSWViw2IXblWNly01g=",
-      "requires": {
-        "any-promise": "1.3.0",
-        "eventemitter3": "1.1.1"
-      }
-    },
-    "web3-core-requestmanager": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.33.tgz",
-      "integrity": "sha1-ejbEA1QALfsXnKLb22pgEsn3Ges=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-providers-http": "1.0.0-beta.33",
-        "web3-providers-ipc": "1.0.0-beta.33",
-        "web3-providers-ws": "1.0.0-beta.33"
-      }
-    },
-    "web3-core-subscriptions": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.33.tgz",
-      "integrity": "sha1-YCh1yfTV9NDhYhRitfwewZs1veM=",
-      "requires": {
-        "eventemitter3": "1.1.1",
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33"
-      }
-    },
-    "web3-eth": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.33.tgz",
-      "integrity": "sha1-hKn5TallUnyS2DitTlcN8CWJhJ8=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.33",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-core-subscriptions": "1.0.0-beta.33",
-        "web3-eth-abi": "1.0.0-beta.33",
-        "web3-eth-accounts": "1.0.0-beta.33",
-        "web3-eth-contract": "1.0.0-beta.33",
-        "web3-eth-iban": "1.0.0-beta.33",
-        "web3-eth-personal": "1.0.0-beta.33",
-        "web3-net": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        },
-        "web3-utils": {
-          "version": "1.0.0-beta.33",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
-          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
-          "requires": {
-            "bn.js": "4.11.6",
-            "eth-lib": "0.1.27",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randomhex": "0.1.5",
-            "underscore": "1.8.3",
-            "utf8": "2.1.1"
-          }
-        }
-      }
-    },
-    "web3-eth-abi": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.33.tgz",
-      "integrity": "sha1-IiH3FRZDZgAypN80D2EjSRaMgko=",
-      "requires": {
-        "bn.js": "4.11.6",
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        },
-        "web3-utils": {
-          "version": "1.0.0-beta.33",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
-          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
-          "requires": {
-            "bn.js": "4.11.6",
-            "eth-lib": "0.1.27",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randomhex": "0.1.5",
-            "underscore": "1.8.3",
-            "utf8": "2.1.1"
-          }
-        }
-      }
-    },
-    "web3-eth-accounts": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.33.tgz",
-      "integrity": "sha1-JajX9OWOHpk7kvBpVILMzckhL5E=",
-      "requires": {
-        "any-promise": "1.3.0",
-        "crypto-browserify": "3.12.0",
-        "eth-lib": "0.2.7",
-        "scrypt.js": "0.2.0",
-        "underscore": "1.8.3",
-        "uuid": "2.0.1",
-        "web3-core": "1.0.0-beta.33",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
-      },
-      "dependencies": {
         "eth-lib": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
           "requires": {
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
             "xhr-request-promise": "^0.1.2"
           }
         },
-        "uuid": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
         },
         "web3-utils": {
-          "version": "1.0.0-beta.33",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
-          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+          "version": "1.0.0-beta.54",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.54.tgz",
+          "integrity": "sha512-yb/cjzjTU99P/9bEaAnb6cjqGjyMUF0OmjD7/ix89IfcDhBJ3jExSuClTAKU8Hz9Rf7IXLiXqBny9W8PdogwmQ==",
           "requires": {
-            "bn.js": "4.11.6",
-            "eth-lib": "0.1.27",
-            "ethjs-unit": "0.1.6",
+            "@babel/runtime": "^7.3.1",
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^10.12.18",
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.8",
+            "ethjs-unit": "^0.1.6",
+            "lodash": "^4.17.11",
             "number-to-bn": "1.7.0",
             "randomhex": "0.1.5",
-            "underscore": "1.8.3",
             "utf8": "2.1.1"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.6",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-            },
-            "eth-lib": {
-              "version": "0.1.27",
-              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
-              "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
-              "requires": {
-                "bn.js": "^4.11.6",
-                "elliptic": "^6.4.0",
-                "keccakjs": "^0.2.1",
-                "nano-json-stream-parser": "^0.1.2",
-                "servify": "^0.1.12",
-                "ws": "^3.0.0",
-                "xhr-request-promise": "^0.1.2"
-              }
-            }
+          }
+        }
+      }
+    },
+    "web3-bzz": {
+      "version": "1.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.54.tgz",
+      "integrity": "sha512-YKoYJWSAxyekk52V0v/rx/gtklqFbMpT8S2Wevox+9MjWchizt34MovJOIbAQzUEUpDhMffdoycVoebmJBcVfA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "@types/node": "^10.12.18",
+        "lodash": "^4.17.11",
+        "swarm-js": "^0.1.39"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+          "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
+      }
+    },
+    "web3-core": {
+      "version": "1.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.54.tgz",
+      "integrity": "sha512-phgFlv0LotX1ym1H+5mchhjJY3MVFov3DdUnFg1eZQlgHxsRKNfRI/nf3+ICVkDqOJP6mdX+oSPFizIXZJqLGQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "@types/bn.js": "^4.11.4",
+        "@types/node": "^10.12.18",
+        "lodash": "^4.17.11",
+        "web3-utils": "1.0.0-beta.54"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+          "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.54",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.54.tgz",
+          "integrity": "sha512-yb/cjzjTU99P/9bEaAnb6cjqGjyMUF0OmjD7/ix89IfcDhBJ3jExSuClTAKU8Hz9Rf7IXLiXqBny9W8PdogwmQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^10.12.18",
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.8",
+            "ethjs-unit": "^0.1.6",
+            "lodash": "^4.17.11",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "utf8": "2.1.1"
+          }
+        }
+      }
+    },
+    "web3-core-helpers": {
+      "version": "1.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.54.tgz",
+      "integrity": "sha512-tASbzdfWyUd6ICbrhDAkWP8NxzSk8+t8IGrpaTBen00gR4gudz3KLPZKTJXrE7y3FB6YONRFPlpYqbim/TS6XQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "lodash": "^4.17.11",
+        "web3-eth-iban": "1.0.0-beta.54",
+        "web3-utils": "1.0.0-beta.54"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+          "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.54",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.54.tgz",
+          "integrity": "sha512-yb/cjzjTU99P/9bEaAnb6cjqGjyMUF0OmjD7/ix89IfcDhBJ3jExSuClTAKU8Hz9Rf7IXLiXqBny9W8PdogwmQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^10.12.18",
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.8",
+            "ethjs-unit": "^0.1.6",
+            "lodash": "^4.17.11",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "utf8": "2.1.1"
+          }
+        }
+      }
+    },
+    "web3-core-method": {
+      "version": "1.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.54.tgz",
+      "integrity": "sha512-5Ar3+jj1tOdNA8+ra105QD+cYef5w9wmgmaaIyGmjsgPZGMDeCIIPLgdSdFuyOdgPhy0zKhhwJsIzr3fJXtMxw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "eventemitter3": "3.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+          "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
+      }
+    },
+    "web3-core-subscriptions": {
+      "version": "1.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.54.tgz",
+      "integrity": "sha512-JQK0pgdIPQU0Ff0Muv8eVNeeABRzvEa4rDkqKyEkZtHKd+JcxBFWp7Y9nlDLViAq20ahH5yh4AB/pCGh7mxIiw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "eventemitter3": "^3.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+          "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
+      }
+    },
+    "web3-eth": {
+      "version": "1.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.54.tgz",
+      "integrity": "sha512-rXjx2I24xY2id43mz66RAH/ZyFpjporKIrIJTGRgyPO6jN+DdGjJbDcFpw7G/H6a+bRdOfVyo5tdl3eW1j6xdg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "ethereumjs-tx": "^1.3.7",
+        "rxjs": "^6.4.0",
+        "web3-core": "1.0.0-beta.54",
+        "web3-core-helpers": "1.0.0-beta.54",
+        "web3-core-method": "1.0.0-beta.54",
+        "web3-core-subscriptions": "1.0.0-beta.54",
+        "web3-eth-abi": "1.0.0-beta.54",
+        "web3-eth-accounts": "1.0.0-beta.54",
+        "web3-eth-contract": "1.0.0-beta.54",
+        "web3-eth-ens": "1.0.0-beta.54",
+        "web3-eth-iban": "1.0.0-beta.54",
+        "web3-eth-personal": "1.0.0-beta.54",
+        "web3-net": "1.0.0-beta.54",
+        "web3-providers": "1.0.0-beta.54",
+        "web3-utils": "1.0.0-beta.54"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+          "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        },
+        "rxjs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.1.tgz",
+          "integrity": "sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==",
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.54",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.54.tgz",
+          "integrity": "sha512-yb/cjzjTU99P/9bEaAnb6cjqGjyMUF0OmjD7/ix89IfcDhBJ3jExSuClTAKU8Hz9Rf7IXLiXqBny9W8PdogwmQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^10.12.18",
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.8",
+            "ethjs-unit": "^0.1.6",
+            "lodash": "^4.17.11",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "utf8": "2.1.1"
+          }
+        }
+      }
+    },
+    "web3-eth-abi": {
+      "version": "1.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.54.tgz",
+      "integrity": "sha512-2hePxe8VHtNvGX6i14rntPCjAuwO8Iktn95HcR/VgXW2SoqeKkqmKow+lR6ePjl/D/BQyEa/bWCaLrSpArfK9g==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "ethers": "^4.0.27",
+        "lodash": "^4.17.11",
+        "web3-utils": "1.0.0-beta.54"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+          "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.54",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.54.tgz",
+          "integrity": "sha512-yb/cjzjTU99P/9bEaAnb6cjqGjyMUF0OmjD7/ix89IfcDhBJ3jExSuClTAKU8Hz9Rf7IXLiXqBny9W8PdogwmQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^10.12.18",
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.8",
+            "ethjs-unit": "^0.1.6",
+            "lodash": "^4.17.11",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "utf8": "2.1.1"
+          }
+        }
+      }
+    },
+    "web3-eth-accounts": {
+      "version": "1.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.54.tgz",
+      "integrity": "sha512-/cIwYx4vod+W05tyQoLBcmBs2wGcnvuyvptoRk2y+krwsVNY+8OvUCu8hU4pIqhH8lt6Q++D1dshttsZsue5hw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "crypto-browserify": "3.12.0",
+        "eth-lib": "0.2.8",
+        "lodash": "^4.17.11",
+        "scrypt.js": "0.2.0",
+        "uuid": "3.3.2",
+        "web3-core": "1.0.0-beta.54",
+        "web3-core-helpers": "1.0.0-beta.54",
+        "web3-core-method": "1.0.0-beta.54",
+        "web3-providers": "1.0.0-beta.54",
+        "web3-utils": "1.0.0-beta.54"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+          "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.54",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.54.tgz",
+          "integrity": "sha512-yb/cjzjTU99P/9bEaAnb6cjqGjyMUF0OmjD7/ix89IfcDhBJ3jExSuClTAKU8Hz9Rf7IXLiXqBny9W8PdogwmQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^10.12.18",
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.8",
+            "ethjs-unit": "^0.1.6",
+            "lodash": "^4.17.11",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "utf8": "2.1.1"
           }
         }
       }
     },
     "web3-eth-contract": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.33.tgz",
-      "integrity": "sha1-nlkZ8pF6PGe0+2Vp1JxeMDiSW84=",
+      "version": "1.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.54.tgz",
+      "integrity": "sha512-on5LfhA3041VKo1wIlA16HeNIyy+JkyoM/lTLOPHMueD2b+4+USFh+x8rKE4LNrtvjq4wE8+emxLmHrRez459Q==",
       "requires": {
-        "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.33",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-core-promievent": "1.0.0-beta.33",
-        "web3-core-subscriptions": "1.0.0-beta.33",
-        "web3-eth-abi": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
+        "@babel/runtime": "^7.3.1",
+        "@types/bn.js": "^4.11.4",
+        "lodash": "^4.17.11",
+        "web3-core": "1.0.0-beta.54",
+        "web3-core-helpers": "1.0.0-beta.54",
+        "web3-core-method": "1.0.0-beta.54",
+        "web3-core-subscriptions": "1.0.0-beta.54",
+        "web3-eth-abi": "1.0.0-beta.54",
+        "web3-eth-accounts": "1.0.0-beta.54",
+        "web3-providers": "1.0.0-beta.54",
+        "web3-utils": "1.0.0-beta.54"
       },
       "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        "@babel/runtime": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+          "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
         },
         "web3-utils": {
-          "version": "1.0.0-beta.33",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
-          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+          "version": "1.0.0-beta.54",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.54.tgz",
+          "integrity": "sha512-yb/cjzjTU99P/9bEaAnb6cjqGjyMUF0OmjD7/ix89IfcDhBJ3jExSuClTAKU8Hz9Rf7IXLiXqBny9W8PdogwmQ==",
           "requires": {
-            "bn.js": "4.11.6",
-            "eth-lib": "0.1.27",
-            "ethjs-unit": "0.1.6",
+            "@babel/runtime": "^7.3.1",
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^10.12.18",
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.8",
+            "ethjs-unit": "^0.1.6",
+            "lodash": "^4.17.11",
             "number-to-bn": "1.7.0",
             "randomhex": "0.1.5",
-            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          }
+        }
+      }
+    },
+    "web3-eth-ens": {
+      "version": "1.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.0.0-beta.54.tgz",
+      "integrity": "sha512-YXdBq7qB0Hfp3+FZKwsUOkHxcM0F0mGDNSEhjVrfuJy7+S+qKA4/gXVMoUA3z+M0TbygtHr7cgY0ayz/n8s3BQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "eth-ens-namehash": "2.0.8",
+        "lodash": "^4.17.11",
+        "web3-core": "1.0.0-beta.54",
+        "web3-core-helpers": "1.0.0-beta.54",
+        "web3-core-method": "1.0.0-beta.54",
+        "web3-eth-abi": "1.0.0-beta.54",
+        "web3-eth-contract": "1.0.0-beta.54",
+        "web3-net": "1.0.0-beta.54",
+        "web3-providers": "1.0.0-beta.54",
+        "web3-utils": "1.0.0-beta.54"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+          "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.54",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.54.tgz",
+          "integrity": "sha512-yb/cjzjTU99P/9bEaAnb6cjqGjyMUF0OmjD7/ix89IfcDhBJ3jExSuClTAKU8Hz9Rf7IXLiXqBny9W8PdogwmQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^10.12.18",
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.8",
+            "ethjs-unit": "^0.1.6",
+            "lodash": "^4.17.11",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
             "utf8": "2.1.1"
           }
         }
       }
     },
     "web3-eth-iban": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.33.tgz",
-      "integrity": "sha1-HXPQxSiKRWWxdUp1tfs+oLd6Uy8=",
+      "version": "1.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.54.tgz",
+      "integrity": "sha512-wgPP7KFb3zKOk7FAeRCcUkGryqRPvPL38eMWNlsqcwcrq3Hmj/wdVSnARYed7Xg0pcagabSyaPtEGuHnxCmtRg==",
       "requires": {
-        "bn.js": "4.11.6",
-        "web3-utils": "1.0.0-beta.33"
+        "@babel/runtime": "^7.3.1",
+        "bn.js": "4.11.8",
+        "web3-utils": "1.0.0-beta.54"
       },
       "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        "@babel/runtime": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+          "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
         },
         "web3-utils": {
-          "version": "1.0.0-beta.33",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
-          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+          "version": "1.0.0-beta.54",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.54.tgz",
+          "integrity": "sha512-yb/cjzjTU99P/9bEaAnb6cjqGjyMUF0OmjD7/ix89IfcDhBJ3jExSuClTAKU8Hz9Rf7IXLiXqBny9W8PdogwmQ==",
           "requires": {
-            "bn.js": "4.11.6",
-            "eth-lib": "0.1.27",
-            "ethjs-unit": "0.1.6",
+            "@babel/runtime": "^7.3.1",
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^10.12.18",
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.8",
+            "ethjs-unit": "^0.1.6",
+            "lodash": "^4.17.11",
             "number-to-bn": "1.7.0",
             "randomhex": "0.1.5",
-            "underscore": "1.8.3",
             "utf8": "2.1.1"
           }
         }
       }
     },
     "web3-eth-personal": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.33.tgz",
-      "integrity": "sha1-tOSFh8xOfrAY2ib947Tzul+bmO8=",
+      "version": "1.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.54.tgz",
+      "integrity": "sha512-bnKbNXgo5lInir8FQ0cyL/55e/vq3xWBNw//fAvUCPKLgL+PQ9eGhr6ftApJTpxapAgMIEHzpP3rjtfLC5djWQ==",
       "requires": {
-        "web3-core": "1.0.0-beta.33",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-net": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
+        "@babel/runtime": "^7.3.1",
+        "web3-core": "1.0.0-beta.54",
+        "web3-core-helpers": "1.0.0-beta.54",
+        "web3-core-method": "1.0.0-beta.54",
+        "web3-eth-accounts": "1.0.0-beta.54",
+        "web3-net": "1.0.0-beta.54",
+        "web3-providers": "1.0.0-beta.54",
+        "web3-utils": "1.0.0-beta.54"
       },
       "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        "@babel/runtime": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+          "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
         },
         "web3-utils": {
-          "version": "1.0.0-beta.33",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
-          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+          "version": "1.0.0-beta.54",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.54.tgz",
+          "integrity": "sha512-yb/cjzjTU99P/9bEaAnb6cjqGjyMUF0OmjD7/ix89IfcDhBJ3jExSuClTAKU8Hz9Rf7IXLiXqBny9W8PdogwmQ==",
           "requires": {
-            "bn.js": "4.11.6",
-            "eth-lib": "0.1.27",
-            "ethjs-unit": "0.1.6",
+            "@babel/runtime": "^7.3.1",
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^10.12.18",
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.8",
+            "ethjs-unit": "^0.1.6",
+            "lodash": "^4.17.11",
             "number-to-bn": "1.7.0",
             "randomhex": "0.1.5",
-            "underscore": "1.8.3",
             "utf8": "2.1.1"
           }
         }
       }
     },
     "web3-net": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.33.tgz",
-      "integrity": "sha1-tskNGg4WJuquiz2SKsFTZy/VZEU=",
+      "version": "1.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.54.tgz",
+      "integrity": "sha512-3YjdjHvUpitGDs3b+g9HfzWQdd6fd1mpHDCLgBJQUykKgjwxgkEbb0Dm7vqQMSggLm6W37LV2xBQjIOMmYsA/Q==",
       "requires": {
-        "web3-core": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
+        "@babel/runtime": "^7.3.1",
+        "lodash": "^4.17.11",
+        "web3-core": "1.0.0-beta.54",
+        "web3-core-helpers": "1.0.0-beta.54",
+        "web3-core-method": "1.0.0-beta.54",
+        "web3-providers": "1.0.0-beta.54",
+        "web3-utils": "1.0.0-beta.54"
       },
       "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        "@babel/runtime": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+          "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
         },
         "web3-utils": {
-          "version": "1.0.0-beta.33",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
-          "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+          "version": "1.0.0-beta.54",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.54.tgz",
+          "integrity": "sha512-yb/cjzjTU99P/9bEaAnb6cjqGjyMUF0OmjD7/ix89IfcDhBJ3jExSuClTAKU8Hz9Rf7IXLiXqBny9W8PdogwmQ==",
           "requires": {
-            "bn.js": "4.11.6",
-            "eth-lib": "0.1.27",
-            "ethjs-unit": "0.1.6",
+            "@babel/runtime": "^7.3.1",
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^10.12.18",
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.8",
+            "ethjs-unit": "^0.1.6",
+            "lodash": "^4.17.11",
             "number-to-bn": "1.7.0",
             "randomhex": "0.1.5",
-            "underscore": "1.8.3",
             "utf8": "2.1.1"
           }
         }
       }
     },
-    "web3-providers-http": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.33.tgz",
-      "integrity": "sha1-OzWuAO599blrSTSWKtSobypVmcE=",
+    "web3-providers": {
+      "version": "1.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/web3-providers/-/web3-providers-1.0.0-beta.54.tgz",
+      "integrity": "sha512-P55MQHkfU2VLt3t+3IbqRUVwOziLOMiXxKulVYXzTu9M8p9aogl1tvPjKXpRUGygCY3LsWTpt/UlJR8Aaia+CQ==",
       "requires": {
-        "web3-core-helpers": "1.0.0-beta.33",
-        "xhr2": "0.1.4"
-      }
-    },
-    "web3-providers-ipc": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.33.tgz",
-      "integrity": "sha1-Twrcmv6dEsBm5L5cPFNvUHPLB8Y=",
-      "requires": {
-        "oboe": "2.1.3",
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33"
-      }
-    },
-    "web3-providers-ws": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.33.tgz",
-      "integrity": "sha1-j93qQuGbvyUh7IeVRkV6Yjqdye8=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
+        "@babel/runtime": "^7.3.1",
+        "@types/node": "^10.12.18",
+        "eventemitter3": "3.1.0",
+        "lodash": "^4.17.11",
+        "url-parse": "1.4.4",
+        "websocket": "^1.0.28",
+        "xhr2-cookies": "1.1.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+          "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
       }
     },
     "web3-shh": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.33.tgz",
-      "integrity": "sha1-+Z4mVz9uCZMhrw2fK/z+Pe01UKE=",
+      "version": "1.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.54.tgz",
+      "integrity": "sha512-YO+sMZ3szof0wTZ+Lh43mkioVGSLhDH2paGzcBB7JM8PoZ9QbuLquNypiM3XWfehNusCQmEGvq0R0nVZe/Juaw==",
       "requires": {
-        "web3-core": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-core-subscriptions": "1.0.0-beta.33",
-        "web3-net": "1.0.0-beta.33"
+        "@babel/runtime": "^7.3.1",
+        "web3-core": "1.0.0-beta.54",
+        "web3-core-helpers": "1.0.0-beta.54",
+        "web3-core-method": "1.0.0-beta.54",
+        "web3-core-subscriptions": "1.0.0-beta.54",
+        "web3-net": "1.0.0-beta.54",
+        "web3-providers": "1.0.0-beta.54",
+        "web3-utils": "1.0.0-beta.54"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+          "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.54",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.54.tgz",
+          "integrity": "sha512-yb/cjzjTU99P/9bEaAnb6cjqGjyMUF0OmjD7/ix89IfcDhBJ3jExSuClTAKU8Hz9Rf7IXLiXqBny9W8PdogwmQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^10.12.18",
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.8",
+            "ethjs-unit": "^0.1.6",
+            "lodash": "^4.17.11",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "utf8": "2.1.1"
+          }
+        }
       }
     },
     "web3-utils": {
@@ -20571,12 +20926,13 @@
       }
     },
     "websocket": {
-      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.28.tgz",
+      "integrity": "sha512-00y/20/80P7H4bCYkzuuvvfDvh+dgtXi5kzDf3UcZwN6boTYaKvsrtZ5lIYm1Gsg48siMErd9M4zjSYfYFHTrA==",
       "requires": {
         "debug": "^2.2.0",
-        "nan": "^2.3.3",
-        "typedarray-to-buffer": "^3.1.2",
+        "nan": "^2.11.0",
+        "typedarray-to-buffer": "^3.1.5",
         "yaeti": "^0.0.6"
       }
     },
@@ -20948,10 +21304,13 @@
         "xhr-request": "^1.0.1"
       }
     },
-    "xhr2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
-      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8="
+    "xhr2-cookies": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
+      "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
+      "requires": {
+        "cookiejar": "^2.1.1"
+      }
     },
     "xml-name-validator": {
       "version": "3.0.0",
@@ -20962,6 +21321,11 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-1.3.1.tgz",
       "integrity": "sha512-tGkGJkN8XqCod7OT+EvGYK5Z4SfDQGD30zAa58OcnAa0RRWgzUEK72tkXhsX1FZd+rgnhRxFtmO+ihkp8LHSkw=="
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
     },
     "xregexp": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "checksum": "cd build && find . -exec shasum -a256 {} ';' > ../checksums.txt && cd ..",
     "zip": "zip -ur bridge-$npm_package_version.zip README.md bridge-https.py checksums.txt && cd build && zip -ur ../bridge-$npm_package_version.zip ./* && cd ..",
     "release": "npm install && npm run build && npm run checksum && npm run zip",
-    "pilot:ganache": "ganache-cli --blockTime 1 -m 'benefit crew supreme gesture quantum web media hazard theory mercy wing kitten' > /dev/null &",
+    "pilot:ganache": "ganache-cli --blockTime 1 --networkId 1 -m 'benefit crew supreme gesture quantum web media hazard theory mercy wing kitten' > /dev/null &",
     "pilot:deploy": "cd node_modules/azimuth-solidity && truffle deploy",
     "pilot:setup": "npm run pilot:ganache && npm run pilot:deploy",
     "pilot": "HTTPS=true npm-run-all pilot:setup start pilot:cleanup --continue-on-error",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "trezor-connect": "^7.0.1",
     "urbit-key-generation": "0.12.1",
     "urbit-ob": "^3.1.0",
-    "web3": "1.0.0-beta.33",
+    "web3": "1.0.0-beta.54",
     "web3-utils": "^1.0.0-beta.52"
   },
   "scripts": {

--- a/src/bridge/components/StatelessTransaction.js
+++ b/src/bridge/components/StatelessTransaction.js
@@ -232,7 +232,7 @@ class StatelessTransaction extends React.Component {
         props.setTxnConfirmations
       )
       .then(txHash => {
-        props.setTxnHashCursor(Just(Ok(txHash)));
+        props.onSent(Just(Ok(txHash)), state.stx.value);
         props.popRoute();
 
         let routeData = {};

--- a/src/bridge/components/StatelessTransaction.js
+++ b/src/bridge/components/StatelessTransaction.js
@@ -185,7 +185,13 @@ class StatelessTransaction extends React.Component {
 
     this.setState({ txStatus: SUBMISSION_STATES.FUNDING });
 
-    const rawTx = hexify(state.stx.value.serialize());
+    const stx = state.stx.matchWith({
+      Just: tx => tx.value,
+      Nothing: () => {
+        throw BRIDGE_ERROR.MISSING_TXN;
+      }
+    });
+    const rawTx = hexify(stx.serialize());
     const cost = (state.gasLimit * toWei(state.gasPrice, 'gwei'));
 
     //TODO need a lib function or something for address=, it's everywhere

--- a/src/bridge/components/StatelessTransaction.js
+++ b/src/bridge/components/StatelessTransaction.js
@@ -1,4 +1,5 @@
 import { Nothing, Just } from 'folktale/maybe'
+import { Ok } from 'folktale/result'
 import React from 'react'
 
 import { Code, H3 } from './Base'
@@ -10,13 +11,23 @@ import {  Warning } from '../components/Base'
 import { addressFromSecp256k1Public } from '../lib/wallet'
 import { BRIDGE_ERROR } from '../lib/error'
 import { ROUTE_NAMES } from '../lib/router'
+import * as tank from '../lib/tank'
 
 import {
   sendSignedTransaction,
+  waitForTransactionConfirm,
   fromWei,
+  toWei,
+  hexify,
   renderSignedTx,
   signTransaction
  } from '../lib/txn'
+
+const SUBMISSION_STATES = {
+  PROMPT: 'Send transaction',
+  FUNDING: 'Finding transaction funding...',
+  SENDING: 'Sending transaction...'
+};
 
 class StatelessTransaction extends React.Component {
 
@@ -33,11 +44,11 @@ class StatelessTransaction extends React.Component {
       nonce: '0',
       stx: Nothing(),
       txn: Nothing(),
+      txStatus: SUBMISSION_STATES.PROMPT,
       txError: Nothing()
     }
 
     this.createUnsignedTxn = this.createUnsignedTxn.bind(this)
-    this.submit = this.submit.bind(this)
     this.setUserApproval = this.setUserApproval.bind(this)
     this.setTxn = this.setTxn.bind(this)
     this.setStx = this.setStx.bind(this)
@@ -84,32 +95,6 @@ class StatelessTransaction extends React.Component {
         })
       }
     });
-  }
-
-  submit(){
-    const { props, state } = this
-    sendSignedTransaction(props.web3.value, state.stx, props.setTxnConfirmations)
-      .then(sent => {
-        props.setTxnHashCursor(sent)
-        props.popRoute()
-
-        let routeData = {};
-        if (props.networkSeed) {
-          props.setNetworkSeedCache(props.networkSeed);
-          routeData.promptKeyfile = true;
-        }
-        if (props.promptText) {
-          routeData.promptText = props.promptText;
-        }
-        props.pushRoute(ROUTE_NAMES.SENT_TRANSACTION, routeData);
-      })
-      .catch(err => {
-        if (err.map) {
-          this.setState({ txError: err.map(val => val.merge()) })
-        } else {
-          this.setState({ txError: err })
-        }
-      })
   }
 
   handleChainUpdate(chainId) {
@@ -194,16 +179,95 @@ class StatelessTransaction extends React.Component {
     })
   }
 
-  // TODO: Investigate
-  // setState doesn't seem to work in SetProxy/submit;
-  //   - TypeError: Cannot read property 'updater' of undefined
-  // so just modifying the DOM manually here. (https://imgur.com/a/i0Qsyq1)
+  async sendTxn() {
+    const { props, state } = this;
+    const web3 = props.web3.value;
 
-  sendTxn(e) {
-    e.target.setAttribute("disabled", true);
-    let spinner = e.target.querySelectorAll('.btn-spinner')[0];
-    spinner.classList.remove('hide');
-    this.submit()
+    this.setState({ txStatus: SUBMISSION_STATES.FUNDING });
+
+    const rawTx = hexify(state.stx.value.serialize());
+    const cost = (state.gasLimit * toWei(state.gasPrice, 'gwei'));
+
+    //TODO need a lib function or something for address=, it's everywhere
+    const address = props.wallet.matchWith({
+      Just: wal => addressFromSecp256k1Public(wal.value.publicKey),
+      Nothing: () => {
+        throw BRIDGE_ERROR.MISSING_WALLET
+      }
+    });
+    let balance = await web3.eth.getBalance(address);
+    let hasBalance = (balance >= cost);
+
+    let usedTank = false;
+    // if we need to, try and fund the transaction
+    if (!hasBalance) {
+      hasBalance = await this.ensureFundsFor(web3, address, cost, [rawTx]);
+      usedTank = hasBalance;
+    }
+
+    // if we still don't have sufficient balance, fail and tell the user
+    if (!hasBalance) {
+      this.setState({
+        txStatus: SUBMISSION_STATES.PROMPT,
+        txError: Just(`Insufficient funds.
+          Address ${address} needs at least ${fromWei(cost.toString())} ETH,
+          currently has ${fromWei(balance.toString())} ETH.`
+        )
+      });
+
+    // if we have the balance, proceed with submission
+    } else {
+      this.setState({ txStatus: SUBMISSION_STATES.SENDING });
+
+      sendSignedTransaction(
+        web3,
+        state.stx,
+        usedTank,
+        props.setTxnConfirmations
+      )
+      .then(txHash => {
+        props.setTxnHashCursor(Just(Ok(txHash)));
+        props.popRoute();
+
+        let routeData = {};
+        if (props.networkSeed) {
+          props.setNetworkSeedCache(props.networkSeed);
+          routeData.promptKeyfile = true;
+        }
+        if (props.promptText) {
+          routeData.promptText = props.promptText;
+        }
+        props.pushRoute(ROUTE_NAMES.SENT_TRANSACTION, routeData);
+      })
+      .catch(err => {
+        this.setState({
+          txStatus: SUBMISSION_STATES.PROMPT,
+          txError: err
+        });
+      });
+    }
+  }
+
+  //TODO partially copied from InviteTransactions, try to move into tank lib
+  async ensureFundsFor(web3, address, cost, signedTxs) {
+    let balance = await web3.eth.getBalance(address);
+    if (cost > balance) {
+      try {
+
+        const res = await tank.fundTransactions(signedTxs);
+        if (!res.success) {
+          return false;
+        } else {
+          await waitForTransactionConfirm(web3, res.txHash);
+          return true;
+        }
+
+      } catch (e) {
+        return false;
+      }
+    } else {
+      return true;
+    }
   }
 
   getChainTitle(chainId) {
@@ -249,7 +313,7 @@ class StatelessTransaction extends React.Component {
     const { web3, canGenerate } = this.props
     const { gasPrice, gasLimit, nonce, chainId,
       txn, stx, userApproval, showGasDetails,
-      customChain } = this.state
+      customChain, txStatus } = this.state
 
     const { setNonce, setChainId, setGasLimit, setGasPrice, toggleGasDetails,
       setUserApproval, sendTxn, createUnsignedTxn, handleChainUpdate } = this
@@ -439,16 +503,18 @@ class StatelessTransaction extends React.Component {
         </div>
       </CheckboxButton>
 
+    const sending = (txStatus !== SUBMISSION_STATES.PROMPT);
+    const sendTxnSpinner = sending ? '' : 'hide';
     const sendTxnButton =
       <Button
         prop-size={ 'xl wide' }
         className={ 'mt-8' }
-        disabled={ !canSend }
+        disabled={ !canSend || sending }
         onClick={ sendTxn }
       >
         <span className="relative">
-          <span className="btn-spinner hide"></span>
-          { 'Send Transaction' }
+          <span className={`btn-spinner ${sendTxnSpinner}`}></span>
+          { txStatus }
         </span>
       </Button>
 

--- a/src/bridge/components/StatelessTransaction.js
+++ b/src/bridge/components/StatelessTransaction.js
@@ -245,7 +245,7 @@ class StatelessTransaction extends React.Component {
       .catch(err => {
         this.setState({
           txStatus: SUBMISSION_STATES.PROMPT,
-          txError: err
+          txError: Just(err)
         });
       });
     }

--- a/src/bridge/components/StatelessTransaction.js
+++ b/src/bridge/components/StatelessTransaction.js
@@ -240,9 +240,6 @@ class StatelessTransaction extends React.Component {
           props.setNetworkSeedCache(props.networkSeed);
           routeData.promptKeyfile = true;
         }
-        if (props.promptText) {
-          routeData.promptText = props.promptText;
-        }
         props.pushRoute(ROUTE_NAMES.SENT_TRANSACTION, routeData);
       })
       .catch(err => {

--- a/src/bridge/lib/tank.js
+++ b/src/bridge/lib/tank.js
@@ -26,6 +26,7 @@ function sendRequest(where, what) {
 }
 
 const remainingTransactions = point => {
+  if (typeof point === 'string') point = Number(point);
   return sendRequest('/point', {point:point});
 };
 

--- a/src/bridge/views/AcceptTransfer.js
+++ b/src/bridge/views/AcceptTransfer.js
@@ -125,7 +125,7 @@ class AcceptTransfer extends React.Component {
             walletType={props.walletType}
             walletHdPath={props.walletHdPath}
             networkType={props.networkType}
-            setTxnHashCursor={props.setTxnHashCursor}
+            onSent={props.setTxnHashCursor}
             setTxnConfirmations={props.setTxnConfirmations}
             popRoute={props.popRoute}
             pushRoute={props.pushRoute}

--- a/src/bridge/views/CancelTransfer.js
+++ b/src/bridge/views/CancelTransfer.js
@@ -86,7 +86,7 @@ class CancelTransfer extends React.Component {
               walletType={props.walletType}
               walletHdPath={props.walletHdPath}
               networkType={props.networkType}
-              setTxnHashCursor={props.setTxnHashCursor}
+              onSent={props.setTxnHashCursor}
               setTxnConfirmations={props.setTxnConfirmations}
               popRoute={props.popRoute}
               pushRoute={props.pushRoute}

--- a/src/bridge/views/CreateGalaxy.js
+++ b/src/bridge/views/CreateGalaxy.js
@@ -211,7 +211,7 @@ class CreateGalaxy extends React.Component {
             walletType={props.walletType}
             walletHdPath={props.walletHdPath}
             networkType={props.networkType}
-            setTxnHashCursor={props.setTxnHashCursor}
+            onSent={props.setTxnHashCursor}
             setTxnConfirmations={props.setTxnConfirmations}
             popRoute={props.popRoute}
             pushRoute={props.pushRoute}

--- a/src/bridge/views/InvitesManage.js
+++ b/src/bridge/views/InvitesManage.js
@@ -189,7 +189,7 @@ class InvitesManage extends React.Component {
             walletType={this.props.walletType}
             walletHdPath={this.props.walletHdPath}
             networkType={this.props.networkType}
-            setTxnHashCursor={this.props.setTxnHashCursor}
+            onSent={this.props.setTxnHashCursor}
             setTxnConfirmations={this.props.setTxnConfirmations}
             popRoute={this.props.popRoute}
             pushRoute={this.props.pushRoute}

--- a/src/bridge/views/InvitesSend.js
+++ b/src/bridge/views/InvitesSend.js
@@ -56,8 +56,6 @@ class InvitesSend extends React.Component {
     this.handleEmailInput = this.handleEmailInput.bind(this);
     this.txnConfirmation = this.txnConfirmation.bind(this);
     this.createUnsignedTxn = this.createUnsignedTxn.bind(this);
-
-    this.promptText = 'The email will be sent on first confirmation. Please wait.';
   }
 
   componentDidMount() {
@@ -221,7 +219,6 @@ class InvitesSend extends React.Component {
             popRoute={this.props.popRoute}
             pushRoute={this.props.pushRoute}
             // Other
-            promptText={this.promptText}
             canGenerate={this.canGenerate()}
             createUnsignedTxn={this.createUnsignedTxn}
             ref={this.statelessRef} />

--- a/src/bridge/views/InvitesSend.js
+++ b/src/bridge/views/InvitesSend.js
@@ -214,8 +214,8 @@ class InvitesSend extends React.Component {
             walletType={this.props.walletType}
             walletHdPath={this.props.walletHdPath}
             networkType={this.props.networkType}
-            setTxnHashCursor={this.props.setTxnHashCursor}
             setTxnConfirmations={this.txnConfirmation}
+            onSent={this.props.setTxnHashCursor}
             popRoute={this.props.popRoute}
             pushRoute={this.props.pushRoute}
             // Other

--- a/src/bridge/views/IssueChild.js
+++ b/src/bridge/views/IssueChild.js
@@ -302,7 +302,7 @@ class IssueChild extends React.Component {
             walletType={props.walletType}
             walletHdPath={props.walletHdPath}
             networkType={props.networkType}
-            setTxnHashCursor={props.setTxnHashCursor}
+            onSent={props.setTxnHashCursor}
             setTxnConfirmations={props.setTxnConfirmations}
             popRoute={props.popRoute}
             pushRoute={props.pushRoute}

--- a/src/bridge/views/SentTransaction.js
+++ b/src/bridge/views/SentTransaction.js
@@ -126,7 +126,6 @@ const SentTransaction = (props) => {
   const { setPointCursor, pointCursor } = props
 
   const promptKeyfile = props.routeData && props.routeData.promptKeyfile
-  const promptText = props.routeData && props.routeData.promptText
 
   const w3 = web3.matchWith({
     Nothing: _ => { throw BRIDGE_ERROR.MISSING_WEB3 },
@@ -147,17 +146,6 @@ const SentTransaction = (props) => {
         txnConfirmations={ txnConfirmations }
       />
   })
-
-  let text;
-  if (promptText) {
-    text = (
-      <Row>
-        <Col>
-          <p>{promptText}</p>
-        </Col>
-      </Row>
-    )
-  }
 
   const ok =
     <Row>
@@ -199,7 +187,6 @@ const SentTransaction = (props) => {
   return (
     <div>
       { body }
-      { text }
       { ok }
       { keyfile }
     </div>

--- a/src/bridge/views/SetKeys.js
+++ b/src/bridge/views/SetKeys.js
@@ -193,7 +193,7 @@ class SetKeys extends React.Component {
             walletType={props.walletType}
             walletHdPath={props.walletHdPath}
             networkType={props.networkType}
-            setTxnHashCursor={props.setTxnHashCursor}
+            onSent={props.setTxnHashCursor}
             setTxnConfirmations={props.setTxnConfirmations}
             popRoute={props.popRoute}
             pushRoute={props.pushRoute}

--- a/src/bridge/views/SetProxy.js
+++ b/src/bridge/views/SetProxy.js
@@ -161,7 +161,7 @@ class SetProxy extends React.Component {
             walletType={props.walletType}
             walletHdPath={props.walletHdPath}
             networkType={props.networkType}
-            setTxnHashCursor={props.setTxnHashCursor}
+            onSent={props.setTxnHashCursor}
             setTxnConfirmations={props.setTxnConfirmations}
             popRoute={props.popRoute}
             pushRoute={props.pushRoute}

--- a/src/bridge/views/Transfer.js
+++ b/src/bridge/views/Transfer.js
@@ -131,7 +131,7 @@ class Transfer extends React.Component {
             walletType={props.walletType}
             walletHdPath={props.walletHdPath}
             networkType={props.networkType}
-            setTxnHashCursor={props.setTxnHashCursor}
+            onSent={props.setTxnHashCursor}
             setTxnConfirmations={props.setTxnConfirmations}
             popRoute={props.popRoute}
             pushRoute={props.pushRoute}


### PR DESCRIPTION
Oof, this was a struggle alright.

This PR makes StatelessTransaction do more or less what the "claim invite" flow does for transactions. If the account can't fund the transaction itself, reach out to the gas tank for help.

Most of the weirdness here deals with the situation where the gas tank submits the transaction for us, causing our submission to fail with "nonce too low". For some reason web3 isn't capable of detecting we're submitting the exact same transaction...

To work around that, we mimic invite flow logic and, observing a nonce error, realize what's going on. We wait for the first confirmation to finalize the flow.

This replaces the existing `sendSignedTransaction` logic, which felt about as jank as this does, for seemingly less necessary reasons.