### PR TITLE
Ensure we generate the keyfile for latest-set keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1994,47 +1994,28 @@
       }
     },
     "azimuth-js": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/azimuth-js/-/azimuth-js-0.10.0.tgz",
-      "integrity": "sha512-VDg60BYSpTjsv1K/DX7VY5F0HbxHV0X1cSoG3c1iZYH5Lxy8TErYq4CJ+D6er0xtI7JI3hmKOZS+p+ru42sT3A==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/azimuth-js/-/azimuth-js-0.13.2.tgz",
+      "integrity": "sha512-DiteSHZTqst5Ikf5yoOetnU7MIE/El5JIuO9FjyaQHWPYA8ECB4XUaZJCl4VfScnAzzP1YCnORXz/mtVn2D9ng==",
       "requires": {
-        "azimuth-solidity": "1.0.2",
-        "ethereumjs-util": "^5.2.0",
-        "web3": "1.0.0-beta.33"
+        "azimuth-solidity": "1.1.0",
+        "ethereumjs-util": "^5.2.0"
       },
       "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        },
-        "web3": {
-          "version": "1.0.0-beta.33",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.33.tgz",
-          "integrity": "sha1-xgIbV2mSdyY3HBhLhoRFMRsTkpU=",
+        "azimuth-solidity": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/azimuth-solidity/-/azimuth-solidity-1.1.0.tgz",
+          "integrity": "sha512-YhVWKql1ZZ9Zae96nYA7QLwQlTzGspkNOErq170sl/UJwncQbvAyibSv+heMaS18n4soPDiRSpa1vHFoGoIX1A==",
           "requires": {
-            "web3-bzz": "1.0.0-beta.33",
-            "web3-core": "1.0.0-beta.33",
-            "web3-eth": "1.0.0-beta.33",
-            "web3-eth-personal": "1.0.0-beta.33",
-            "web3-net": "1.0.0-beta.33",
-            "web3-shh": "1.0.0-beta.33",
-            "web3-utils": "1.0.0-beta.33"
+            "babel-polyfill": "^6.26.0",
+            "babel-register": "^6.26.0",
+            "openzeppelin-solidity": "1.12.0",
+            "truffle": "4.1.11"
           },
           "dependencies": {
-            "web3-utils": {
-              "version": "1.0.0-beta.33",
-              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
-              "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
-              "requires": {
-                "bn.js": "4.11.6",
-                "eth-lib": "0.1.27",
-                "ethjs-unit": "0.1.6",
-                "number-to-bn": "1.7.0",
-                "randomhex": "0.1.5",
-                "underscore": "1.8.3",
-                "utf8": "2.1.1"
-              }
+            "openzeppelin-solidity": {
+              "version": "1.12.0",
+              "bundled": true
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@ledgerhq/hw-app-eth": "^4.35.0",
     "@ledgerhq/hw-transport-u2f": "^4.35.0",
     "PaperCollateralRenderer": "github:urbit/PaperCollateralRenderer",
-    "azimuth-js": "^0.10.0",
+    "azimuth-js": "^0.13.2",
     "azimuth-solidity": "1.0.2",
     "babel-polyfill": "^6.26.0",
     "bip32": "^1.0.2",

--- a/src/bridge/Bridge.js
+++ b/src/bridge/Bridge.js
@@ -190,9 +190,10 @@ class Bridge extends React.Component {
     }
   }
 
-  setNetworkSeedCache(networkSeed) {
+  setNetworkSeedCache(networkSeed, revision) {
     this.setState({
-      networkSeedCache: networkSeed
+      networkSeedCache: networkSeed,
+      networkRevisionCache: revision
     })
   }
 
@@ -263,6 +264,7 @@ class Bridge extends React.Component {
       urbitWallet,
       authMnemonic,
       networkSeedCache,
+      networkRevisionCache,
       pointCursor,
       pointCache,
       txnHashCursor,
@@ -316,6 +318,7 @@ class Bridge extends React.Component {
                 pointCursor={ pointCursor }
                 pointCache={ pointCache }
                 networkSeedCache= { networkSeedCache }
+                networkRevisionCache={ networkRevisionCache }
                 setNetworkSeedCache= { this.setNetworkSeedCache }
                 // txn
                 setTxnHashCursor={ this.setTxnHashCursor }

--- a/src/bridge/components/StatelessTransaction.js
+++ b/src/bridge/components/StatelessTransaction.js
@@ -93,8 +93,9 @@ class StatelessTransaction extends React.Component {
         props.setTxnHashCursor(sent)
         props.popRoute()
 
-        if (props.networkSeed) {
-          props.setNetworkSeedCache(props.networkSeed)
+        //TODO this special logic should live in a handler in SetKeys.
+        if (props.networkSeed && props.newRevision) {
+          props.setNetworkSeedCache(props.networkSeed, props.newRevision)
           props.pushRoute(ROUTE_NAMES.SENT_TRANSACTION, {promptKeyfile: true})
         } else {
           props.pushRoute(ROUTE_NAMES.SENT_TRANSACTION)

--- a/src/bridge/views/GenKeyfile.js
+++ b/src/bridge/views/GenKeyfile.js
@@ -40,7 +40,10 @@ class GenKeyfile extends React.Component {
       ? pointCache[point]
       : (() => { throw BRIDGE_ERROR.MISSING_POINT })()
 
-    const revision = parseInt(pointDetails.keyRevisionNumber)
+    // in case we did SetKeys earlier this session, make sure to generate the
+    // newer keyfile, rather than the one that will expire soon
+    const revision = (this.props.networkRevisionCache ||
+                      parseInt(pointDetails.keyRevisionNumber));
 
     return {
       point,

--- a/src/bridge/views/SetKeys.js
+++ b/src/bridge/views/SetKeys.js
@@ -210,6 +210,7 @@ class SetKeys extends React.Component {
             canGenerate={ canGenerate }
             createUnsignedTxn={this.createUnsignedTxn}
             networkSeed={ state.networkSeed }
+            newRevision={ (parseInt(pointDetails.keyRevisionNumber) + 1) }
             setNetworkSeedCache={ props.setNetworkSeedCache } />
 
         </Col>


### PR DESCRIPTION
...rather than latest-seen. Chain might not keep up with user actions, and even if it does, if user navigates to keyfile screen straight away, it won't know about the change yet. Fixes #137.

This was only a problem for UHD-derived networking keys, since the randomly generated ones were pulled out of cache.

This PR also includes an updated azimuth-js, which we actually need for the fancy new auto-complete on the "issue child" page. Currently, it just crashes there. (^:

Will push out a release once this gets approved/merged.