### PR TITLE
Make suggestions better in IssueChild.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react": "^16.6.0",
     "react-dom": "^16.6.0",
     "react-router-dom": "^4.3.1",
+    "react-scramble": "^0.4.2",
     "react-scripts": "^2.1.1",
     "secp256k1": "^3.5.2",
     "sigil-js": "github:urbit/sigil-js#f7f29c5",

--- a/src/bridge/lib/child.js
+++ b/src/bridge/lib/child.js
@@ -4,17 +4,11 @@ const MIN_PLANET = Math.pow(2, 16)
 const MAX_GALAXY = MIN_STAR - 1
 const MAX_STAR = MIN_PLANET - 1
 
-const randomStarName = galaxy =>
-  (Math.floor(Math.random() * MAX_GALAXY) + 1) * MIN_STAR + galaxy
-
-const randomPlanetName = star =>
-  (Math.floor(Math.random() * MAX_STAR) + 1) * (MAX_STAR + 1) + star
-
-const getSpawnCandidate = point =>
-    point >= MIN_GALAXY && point < MIN_STAR
-  ? randomStarName(point)
-  : randomPlanetName(point)
+const getNthSpawnCandidate = (point, n) => {
+  let childSpace = point >= MIN_GALAXY && point < MIN_STAR ? 0x100 : 0x10000
+  return point + ((n + 1) * childSpace)
+}
 
 export {
-  getSpawnCandidate
+  getNthSpawnCandidate
 }


### PR DESCRIPTION
![Suggestion gif](https://media.giphy.com/media/ZFVxOm3RsNJJg2s3kq/giphy.gif)

The problem this PR is trying to solve is that the three random point suggestions in IssueChild.js (see gif) do not come from azimuth and may therefore be already spawned. That's annoying, but getting stuff from azimuth can be slow so we don't want any shitty waiting either.

This PR changes the suggestion logic in the following way: instead of generating random children it generates the n first children. When we get a response back from azimuth regarding the actual unspawned children we fix the suggestions with the sick effect pictured above.

Now all this might be too fancy, especially since it introduces a new npm dependency, but I think this looks pretty cool!