### PR TITLE
Extract Wallet Store

### DIFF
--- a/src/bridge/Bridge.js
+++ b/src/bridge/Bridge.js
@@ -1,44 +1,47 @@
 import React from 'react';
 import { Just, Nothing } from 'folktale/maybe';
-import { includes } from 'lodash';
 
 import Footer from './components/Footer';
 import Header from './components/Header';
 import { Container, Row, Col } from './components/Base';
 
+import nest from './lib/nest';
 import { router } from './lib/router';
 import { ROUTE_NAMES } from './lib/routeNames';
+import { NETWORK_TYPES } from './lib/network';
+import { DEFAULT_HD_PATH, walletFromMnemonic } from './lib/wallet';
+import { isDevelopment } from './lib/flags';
+
 import { HistoryProvider, withHistory, useHistory } from './store/history';
 import { TxnConfirmationsProvider } from './store/txnConfirmations';
-import { NETWORK_TYPES } from './lib/network';
-import {
-  WALLET_NAMES,
-  DEFAULT_HD_PATH,
-  walletFromMnemonic,
-  addressFromSecp256k1Public,
-} from './lib/wallet';
-import { BRIDGE_ERROR } from './lib/error';
-import { isDevelopment } from './lib/flags';
-import nest from './lib/nest';
 import { OnlineProvider } from './store/online';
 import { NetworkProvider } from './store/network';
+import { WalletProvider } from './store/wallet';
 
-// NB(shrugs): toggle this variable to use the default local state.
-// don't commit changes to this line, but there shouldn't be a problem
-// if you do because we'll never stub on a production build.
-const shouldStubLocal = false;
-const isStubbed = isDevelopment && shouldStubLocal;
-const kInitialRoutes = isStubbed
-  ? [
-      { name: ROUTE_NAMES.SHIPS },
-      { name: ROUTE_NAMES.WALLET },
-      { name: ROUTE_NAMES.NETWORK },
-      { name: ROUTE_NAMES.LANDING },
-    ]
-  : [{ name: ROUTE_NAMES.LANDING }];
 const kInitialNetworkType = isDevelopment
   ? NETWORK_TYPES.LOCAL
   : NETWORK_TYPES.MAINNET;
+
+// NB(shrugs): toggle these variables to change the default local state.
+// try not to commit changes to this line, but there shouldn't be a problem
+// if you do because we'll never stub on a production build.
+const shouldStubLocal = false;
+const kIsStubbed = isDevelopment && shouldStubLocal;
+const kInitialRoutes = kIsStubbed
+  ? [
+      { name: ROUTE_NAMES.LANDING },
+      { name: ROUTE_NAMES.NETWORK },
+      { name: ROUTE_NAMES.WALLET },
+      { name: ROUTE_NAMES.SHIPS },
+    ]
+  : [{ name: ROUTE_NAMES.LANDING }];
+
+const kInitialWallet = kIsStubbed
+  ? walletFromMnemonic(
+      process.env.REACT_APP_DEV_MNEMONIC,
+      process.env.REACT_APP_HD_PATH
+    )
+  : undefined;
 
 // the router itself is just a component that renders a specific view
 // depending on the history
@@ -73,30 +76,14 @@ const AllProviders = nest([
   TxnConfirmationsProvider,
   OnlineProvider,
   NetworkProvider,
+  WalletProvider,
 ]);
 
 class Bridge extends React.Component {
   constructor(props) {
     super(props);
 
-    // NB (jtobin):
-    //
-    // Note that the 'wallet' prop has type depending on the 'walletType' prop.
-    // These could be bound together in a single structure (so that
-    // 'walletType' acted more explicitly as a data constructor of sorts) but
-    // it doesn't necessarily help us much, since we branch on 'walletType'
-    // before setting 'wallet'.
-    //
-    // Wallets are always wrapped in Maybe.  For most authentication
-    // mechanisms, Maybe wraps a BIP32 HD wallet; for Ethereum private keys,
-    // JSON keystore files, and Metamask authentication, it wraps an
-    // 'EthereumWallet'.
-
     this.state = {
-      // wallet
-      walletType: WALLET_NAMES.MNEMONIC,
-      wallet: Nothing(),
-      walletHdPath: DEFAULT_HD_PATH,
       // urbit wallet-related
       urbitWallet: Nothing(),
       authMnemonic: Nothing(),
@@ -109,9 +96,6 @@ class Bridge extends React.Component {
       txnConfirmations: {},
     };
 
-    this.setWalletType = this.setWalletType.bind(this);
-    this.setWallet = this.setWallet.bind(this);
-    this.setWalletHdPath = this.setWalletHdPath.bind(this);
     this.setUrbitWallet = this.setUrbitWallet.bind(this);
     this.setAuthMnemonic = this.setAuthMnemonic.bind(this);
     this.setPointCursor = this.setPointCursor.bind(this);
@@ -125,14 +109,11 @@ class Bridge extends React.Component {
     //
     // If running in development, the following can be tweaked to get you set
     // up with a desirable initial state.
-    if (isStubbed) {
+    if (kIsStubbed) {
       const mnemonic = process.env.REACT_APP_DEV_MNEMONIC;
-      const hdpath = process.env.REACT_APP_HD_PATH;
 
       this.setState({
         pointCursor: Just(0),
-        walletType: WALLET_NAMES.MNEMONIC,
-        wallet: walletFromMnemonic(mnemonic, hdpath),
         urbitWallet: Nothing(),
         authMnemonic: Just(mnemonic),
       });
@@ -144,28 +125,6 @@ class Bridge extends React.Component {
       networkSeedCache: networkSeed,
       networkRevisionCache: revision,
     });
-  }
-
-  setWalletType(symbol) {
-    if (includes(WALLET_NAMES, symbol)) {
-      this.setState({
-        walletType: symbol,
-      });
-    } else {
-      throw BRIDGE_ERROR.INVALID_WALLET_TYPE;
-    }
-  }
-
-  setWallet(wallet) {
-    wallet.map(wal => {
-      wal.address = wal.address || addressFromSecp256k1Public(wal.publicKey);
-      return wal;
-    });
-    this.setState({ wallet });
-  }
-
-  setWalletHdPath(walletHdPath) {
-    this.setState({ walletHdPath });
   }
 
   // also sets wallet to ownership address
@@ -206,9 +165,6 @@ class Bridge extends React.Component {
 
   render() {
     const {
-      walletType,
-      walletHdPath,
-      wallet,
       urbitWallet,
       authMnemonic,
       networkSeedCache,
@@ -221,20 +177,15 @@ class Bridge extends React.Component {
     return (
       <AllProviders
         initialRoutes={kInitialRoutes}
-        initialNetworkType={kInitialNetworkType}>
+        initialNetworkType={kInitialNetworkType}
+        initialWallet={kInitialWallet}>
         <Container>
           <Row>
             <VariableWidthColumn>
-              <Header wallet={wallet} pointCursor={pointCursor} />
+              <Header pointCursor={pointCursor} />
 
               <Row className={'row wrapper'}>
                 <Router
-                  setWalletType={this.setWalletType}
-                  setWalletHdPath={this.setWalletHdPath}
-                  setWallet={this.setWallet}
-                  walletType={walletType}
-                  walletHdPath={walletHdPath}
-                  wallet={wallet}
                   urbitWallet={urbitWallet}
                   setUrbitWallet={this.setUrbitWallet}
                   authMnemonic={authMnemonic}

--- a/src/bridge/components/Header.js
+++ b/src/bridge/components/Header.js
@@ -6,10 +6,15 @@ import { ROUTE_NAMES } from '../lib/routeNames';
 import { useHistory } from '../store/history';
 import { isLast } from '../lib/lib';
 import { useNetwork } from '../store/network';
+import { useWallet } from '../store/wallet';
 
+// hook to create a breadcrumb builder function based on the current
+// global states
 function useRouteBreadcrumbBuilder(props) {
   const { networkType } = useNetwork();
-  return getRouteBreadcrumb({ ...props, networkType });
+  const { wallet } = useWallet();
+
+  return getRouteBreadcrumb({ ...props, networkType, wallet });
 }
 
 function Crumbs(props) {
@@ -48,7 +53,7 @@ function Header(props) {
   if (showCrumbs) {
     return (
       <div className={'flex items-center h-10'}>
-        <Crumbs wallet={props.wallet} pointCursor={props.pointCursor} />
+        <Crumbs pointCursor={props.pointCursor} />
       </div>
     );
   }

--- a/src/bridge/components/Passport.js
+++ b/src/bridge/components/Passport.js
@@ -8,6 +8,8 @@ import { Button } from './Base';
 
 import { WALLET_STATES } from '../lib/invite';
 import { downloadWallet } from '../lib/invite';
+import { compose } from '../lib/lib';
+import { withWallet } from '../store/wallet';
 
 class Passport extends React.Component {
   constructor(props) {
@@ -231,4 +233,4 @@ Passport.defaultProps = {
   wallet: null,
 };
 
-export default Passport;
+export default compose(withWallet)(Passport);

--- a/src/bridge/components/StatelessTransaction.js
+++ b/src/bridge/components/StatelessTransaction.js
@@ -24,6 +24,7 @@ import {
 import { withTxnConfirmations } from '../store/txnConfirmations';
 import { withNetwork } from '../store/network';
 import { withHistory } from '../store/history';
+import { withWallet } from '../store/wallet';
 
 const SUBMISSION_STATES = {
   PROMPT: 'Send transaction',
@@ -584,5 +585,6 @@ class StatelessTransaction extends React.Component {
 export default compose(
   withNetwork,
   withTxnConfirmations,
-  withHistory
+  withHistory,
+  withWallet
 )(StatelessTransaction);

--- a/src/bridge/lib/invite.js
+++ b/src/bridge/lib/invite.js
@@ -12,7 +12,7 @@ import saveAs from 'file-saver';
 import { sendSignedTransaction } from './txn';
 import { BRIDGE_ERROR } from '../lib/error';
 import { attemptSeedDerivation } from './keys';
-import { addHexPrefix, WALLET_NAMES } from './wallet';
+import { addHexPrefix, WALLET_TYPES } from './wallet';
 
 const INVITE_STAGES = {
   INVITE_LOGIN: 'invite login',
@@ -213,7 +213,7 @@ async function startTransactions(args) {
   // configure networking public keys
   //TODO feels like more of this logic should live in a lib?
   let networkSeed = await attemptSeedDerivation(true, {
-    walletType: WALLET_NAMES.TICKET,
+    walletType: WALLET_TYPES.TICKET,
     urbitWallet: Just(realWallet),
     pointCursor: Just(point),
     pointCache: { [point]: { keyRevisionNumber: 0 } },

--- a/src/bridge/lib/keys.js
+++ b/src/bridge/lib/keys.js
@@ -7,7 +7,7 @@ import * as serial from '../nockjs/serial';
 import * as kg from 'urbit-key-generation/dist/index';
 
 import { BRIDGE_ERROR } from './error';
-import { WALLET_NAMES, eqAddr } from './wallet';
+import { WALLET_TYPES, eqAddr } from './wallet';
 
 // ctsy joemfb
 const b64 = buf => {
@@ -67,8 +67,7 @@ const genKey = (networkSeed, point, revision) => {
 // 'next' refers to setting the next set of keys
 // if false, we use revision - 1
 const attemptSeedDerivation = async (next, args) => {
-  const { walletType } = args;
-  const { urbitWallet, authMnemonic } = args;
+  const { walletType, urbitWallet, authMnemonic } = args;
 
   // NB (jtobin):
   //
@@ -84,7 +83,7 @@ const attemptSeedDerivation = async (next, args) => {
 
   let managementSeed = '';
 
-  const ticketLike = [WALLET_NAMES.TICKET, WALLET_NAMES.SHARDS];
+  const ticketLike = [WALLET_TYPES.TICKET, WALLET_TYPES.SHARDS];
 
   if (ticketLike.includes(walletType)) {
     const uwal = urbitWallet.matchWith({
@@ -95,7 +94,7 @@ const attemptSeedDerivation = async (next, args) => {
     });
 
     managementSeed = uwal.management.seed;
-  } else if (walletType === WALLET_NAMES.MNEMONIC) {
+  } else if (walletType === WALLET_TYPES.MNEMONIC) {
     const walProxy = need.address(args);
 
     const mnemonic = authMnemonic.matchWith({

--- a/src/bridge/lib/txn.js
+++ b/src/bridge/lib/txn.js
@@ -7,7 +7,7 @@ import { BRIDGE_ERROR } from '../lib/error';
 import { NETWORK_TYPES } from '../lib/network';
 import { ledgerSignTransaction } from '../lib/ledger';
 import { trezorSignTransaction } from '../lib/trezor';
-import { WALLET_NAMES, addHexPrefix } from '../lib/wallet';
+import { WALLET_TYPES, addHexPrefix } from '../lib/wallet';
 
 const TXN_PURPOSE = {
   SET_MANAGEMENT_PROXY: Symbol('SET_MANAGEMENT_PROXY'),
@@ -96,7 +96,7 @@ const signTransaction = async config => {
   ];
 
   const needEip155Params =
-    walletType === WALLET_NAMES.LEDGER &&
+    walletType === WALLET_TYPES.LEDGER &&
     defaultEip155Networks.includes(networkType);
 
   const signingParams = needEip155Params
@@ -121,9 +121,9 @@ const signTransaction = async config => {
 
   const stx = new Tx(utx);
 
-  if (walletType === WALLET_NAMES.LEDGER) {
+  if (walletType === WALLET_TYPES.LEDGER) {
     await ledgerSignTransaction(stx, walletHdPath);
-  } else if (walletType === WALLET_NAMES.TREZOR) {
+  } else if (walletType === WALLET_TYPES.TREZOR) {
     await trezorSignTransaction(stx, walletHdPath);
   } else {
     stx.sign(sec);

--- a/src/bridge/lib/wallet.js
+++ b/src/bridge/lib/wallet.js
@@ -14,7 +14,7 @@ const ETH_ZERO_ADDR = '0x0000000000000000000000000000000000000000';
 const CURVE_ZERO_ADDR =
   '0x0000000000000000000000000000000000000000000000000000000000000000';
 
-const WALLET_NAMES = {
+const WALLET_TYPES = {
   MNEMONIC: Symbol('MNEMONIC'),
   TICKET: Symbol('TICKET'),
   SHARDS: Symbol('SHARDS'),
@@ -32,19 +32,19 @@ function EthereumWallet(privateKey) {
 }
 
 const renderWalletType = wallet =>
-  wallet === WALLET_NAMES.MNEMONIC
+  wallet === WALLET_TYPES.MNEMONIC
     ? 'Mnemonic'
-    : wallet === WALLET_NAMES.TICKET
+    : wallet === WALLET_TYPES.TICKET
     ? 'Ticket'
-    : wallet === WALLET_NAMES.SHARDS
+    : wallet === WALLET_TYPES.SHARDS
     ? 'Ticket Shards'
-    : wallet === WALLET_NAMES.LEDGER
+    : wallet === WALLET_TYPES.LEDGER
     ? 'Ledger'
-    : wallet === WALLET_NAMES.TREZOR
+    : wallet === WALLET_TYPES.TREZOR
     ? 'Trezor'
-    : wallet === WALLET_NAMES.PRIVATE_KEY
+    : wallet === WALLET_TYPES.PRIVATE_KEY
     ? 'Private Key'
-    : wallet === WALLET_NAMES.KEYSTORE
+    : wallet === WALLET_TYPES.KEYSTORE
     ? 'Keystore File'
     : 'Wallet';
 
@@ -135,7 +135,7 @@ const walletFromMnemonic = (mnemonic, hdpath, passphrase) => {
 
 export {
   DEFAULT_HD_PATH,
-  WALLET_NAMES,
+  WALLET_TYPES,
   ETH_ZERO_ADDR,
   CURVE_ZERO_ADDR,
   renderWalletType,

--- a/src/bridge/store/wallet.js
+++ b/src/bridge/store/wallet.js
@@ -1,0 +1,86 @@
+import React, { createContext, forwardRef, useContext, useState } from 'react';
+import Maybe from 'folktale/maybe';
+import { includes } from 'lodash';
+
+import {
+  WALLET_TYPES,
+  DEFAULT_HD_PATH,
+  addressFromSecp256k1Public,
+} from '../lib/wallet';
+import { BRIDGE_ERROR } from '../lib/error';
+
+export const WalletContext = createContext(null);
+
+// NB (jtobin):
+//
+// Note that the 'wallet' prop has type depending on the 'walletType' prop.
+// These could be bound together in a single structure (so that
+// 'walletType' acted more explicitly as a data constructor of sorts) but
+// it doesn't necessarily help us much, since we branch on 'walletType'
+// before setting 'wallet'.
+//
+// Wallets are always wrapped in Maybe.  For most authentication
+// mechanisms, Maybe wraps a BIP32 HD wallet; for Ethereum private keys,
+// JSON keystore files, and Metamask authentication, it wraps an
+// 'EthereumWallet'.
+function _useWallet(initialWallet = Maybe.Nothing()) {
+  const [walletType, _setWalletType] = useState(WALLET_TYPES.MNEMONIC);
+  const [walletHdPath, setWalletHdPath] = useState(DEFAULT_HD_PATH);
+  const [wallet, _setWallet] = useState(initialWallet);
+
+  const setWalletType = walletType => {
+    if (!includes(WALLET_TYPES, walletType)) {
+      throw BRIDGE_ERROR.INVALID_WALLET_TYPE;
+    }
+
+    _setWalletType(walletType);
+  };
+
+  const setWallet = wallet => {
+    // force that public addresses are derived for each wallet
+    wallet.map(wal => {
+      wal.address = wal.address || addressFromSecp256k1Public(wal.publicKey);
+      return wal;
+    });
+
+    _setWallet(wallet);
+  };
+
+  return {
+    //
+    walletType,
+    setWalletType,
+    //
+    walletHdPath,
+    setWalletHdPath,
+    //
+    wallet,
+    setWallet,
+    //
+    // urbitWallet
+    // setUrbitWallet
+    // authMnemonic
+    // setAuthMnemonic
+  };
+}
+
+export function WalletProvider({ initialWallet, children }) {
+  const wallet = _useWallet(initialWallet);
+
+  return (
+    <WalletContext.Provider value={wallet}>{children}</WalletContext.Provider>
+  );
+}
+
+// Hook version
+export function useWallet() {
+  return useContext(WalletContext);
+}
+
+// HOC version
+export const withWallet = Component =>
+  forwardRef((props, ref) => (
+    <WalletContext.Consumer>
+      {wallet => <Component ref={ref} {...wallet} {...props} />}
+    </WalletContext.Consumer>
+  ));

--- a/src/bridge/views/AcceptTransfer.js
+++ b/src/bridge/views/AcceptTransfer.js
@@ -16,6 +16,7 @@ import { NETWORK_TYPES } from '../lib/network';
 import { isValidAddress } from '../lib/wallet';
 import { withNetwork } from '../store/network';
 import { compose } from '../lib/lib';
+import { withWallet } from '../store/wallet';
 
 class AcceptTransfer extends React.Component {
   constructor(props) {
@@ -119,4 +120,7 @@ class AcceptTransfer extends React.Component {
   }
 }
 
-export default compose(withNetwork)(AcceptTransfer);
+export default compose(
+  withNetwork,
+  withWallet
+)(AcceptTransfer);

--- a/src/bridge/views/CreateGalaxy.js
+++ b/src/bridge/views/CreateGalaxy.js
@@ -22,6 +22,7 @@ import { ETH_ZERO_ADDR, isValidAddress, eqAddr } from '../lib/wallet';
 
 import { isValidGalaxy, compose } from '../lib/lib';
 import { withNetwork } from '../store/network';
+import { withWallet } from '../store/wallet';
 
 const buttonTriState = status => {
   if (status === null) return 'blue';
@@ -195,4 +196,7 @@ class CreateGalaxy extends React.Component {
   }
 }
 
-export default compose(withNetwork)(CreateGalaxy);
+export default compose(
+  withNetwork,
+  withWallet
+)(CreateGalaxy);

--- a/src/bridge/views/GenKeyfile.js
+++ b/src/bridge/views/GenKeyfile.js
@@ -11,6 +11,8 @@ import saveAs from 'file-saver';
 
 import { attemptSeedDerivation, genKey } from '../lib/keys';
 import { addHexPrefix } from '../lib/wallet';
+import { compose } from '../lib/lib';
+import { withWallet } from '../store/wallet';
 
 class GenKeyfile extends React.Component {
   constructor(props) {
@@ -132,4 +134,4 @@ class GenKeyfile extends React.Component {
   }
 }
 
-export default GenKeyfile;
+export default compose(withWallet)(GenKeyfile);

--- a/src/bridge/views/InviteTicket.js
+++ b/src/bridge/views/InviteTicket.js
@@ -29,6 +29,7 @@ import {
 } from '../lib/invite';
 import { generateWallet, startTransactions } from '../lib/invite';
 import { withNetwork } from '../store/network';
+import { withWallet } from '../store/wallet';
 
 class InviteTicket extends React.Component {
   constructor(props) {
@@ -425,5 +426,6 @@ class InviteTicket extends React.Component {
 
 export default compose(
   withNetwork,
-  withHistory
+  withHistory,
+  withWallet
 )(InviteTicket);

--- a/src/bridge/views/InvitesSend.js
+++ b/src/bridge/views/InvitesSend.js
@@ -21,6 +21,7 @@ import {
 import * as tank from '../lib/tank';
 import { withNetwork } from '../store/network';
 import { compose } from '../lib/lib';
+import { withWallet } from '../store/wallet';
 
 const GAS_PRICE_GWEI = 20; // we pay the premium for faster ux
 const GAS_LIMIT = 350000;
@@ -493,4 +494,7 @@ class InvitesSend extends React.Component {
   }
 }
 
-export default compose(withNetwork)(InvitesSend);
+export default compose(
+  withNetwork,
+  withWallet
+)(InvitesSend);

--- a/src/bridge/views/Keystore.js
+++ b/src/bridge/views/Keystore.js
@@ -11,6 +11,7 @@ import { ROUTE_NAMES } from '../lib/routeNames';
 import { withHistory } from '../store/history';
 import { EthereumWallet } from '../lib/wallet';
 import { compose } from '../lib/lib';
+import { withWallet } from '../store/wallet';
 
 class Keystore extends React.Component {
   constructor(props) {
@@ -160,4 +161,7 @@ class Keystore extends React.Component {
   }
 }
 
-export default compose(withHistory)(Keystore);
+export default compose(
+  withHistory,
+  withWallet
+)(Keystore);

--- a/src/bridge/views/Ledger.js
+++ b/src/bridge/views/Ledger.js
@@ -12,6 +12,7 @@ import { LEDGER_LIVE_PATH, LEDGER_LEGACY_PATH } from '../lib/ledger';
 import { ROUTE_NAMES } from '../lib/routeNames';
 import { withHistory } from '../store/history';
 import { compose } from '../lib/lib';
+import { withWallet } from '../store/wallet';
 
 const chopHdPrefix = str => (str.slice(0, 2) === 'm/' ? str.slice(2) : str);
 
@@ -218,4 +219,7 @@ class Ledger extends React.Component {
   }
 }
 
-export default compose(withHistory)(Ledger);
+export default compose(
+  withHistory,
+  withWallet
+)(Ledger);

--- a/src/bridge/views/Mnemonic.js
+++ b/src/bridge/views/Mnemonic.js
@@ -14,6 +14,7 @@ import { ROUTE_NAMES } from '../lib/routeNames';
 import { withHistory } from '../store/history';
 import { DEFAULT_HD_PATH, walletFromMnemonic } from '../lib/wallet';
 import { compose } from '../lib/lib';
+import { withWallet } from '../store/wallet';
 
 class Mnemonic extends React.Component {
   constructor(props) {
@@ -161,4 +162,7 @@ class Mnemonic extends React.Component {
   }
 }
 
-export default compose(withHistory)(Mnemonic);
+export default compose(
+  withHistory,
+  withWallet
+)(Mnemonic);

--- a/src/bridge/views/Point.js
+++ b/src/bridge/views/Point.js
@@ -13,6 +13,7 @@ import { Row, Col, H1, H3 } from '../components/Base';
 import { withHistory } from '../store/history';
 import { withNetwork } from '../store/network';
 import { compose } from '../lib/lib';
+import { withWallet } from '../store/wallet';
 
 class Point extends React.Component {
   constructor(props) {
@@ -139,5 +140,6 @@ class Point extends React.Component {
 
 export default compose(
   withNetwork,
-  withHistory
+  withHistory,
+  withWallet
 )(Point);

--- a/src/bridge/views/Point.js
+++ b/src/bridge/views/Point.js
@@ -123,7 +123,6 @@ class Point extends React.Component {
           {authenticated ? (
             <Actions
               online={online}
-              wallet={wallet}
               point={point}
               pointDetails={pointDetails}
               invites={this.state.invites}

--- a/src/bridge/views/Point/Actions.js
+++ b/src/bridge/views/Point/Actions.js
@@ -7,6 +7,7 @@ import { Row, Col, H2, P } from '../../components/Base';
 import { Button } from '../../components/Base';
 import { ROUTE_NAMES } from '../../lib/routeNames';
 import { useHistory } from '../../store/history';
+import { useWallet } from '../../store/wallet';
 
 const isPlanet = point =>
   azimuth.getPointSize(point) === azimuth.PointSize.Planet;
@@ -14,9 +15,10 @@ const isStar = point => azimuth.getPointSize(point) === azimuth.PointSize.Star;
 
 function Actions(props) {
   const history = useHistory();
+  const { wallet } = useWallet();
   const { online, point, pointDetails, invites } = props;
 
-  const addr = need.address(props);
+  const addr = need.address({ wallet });
 
   const isOwner = pointDetails.matchWith({
     Nothing: _ => false,

--- a/src/bridge/views/Points.js
+++ b/src/bridge/views/Points.js
@@ -10,6 +10,7 @@ import { withHistory } from '../store/history';
 import { ETH_ZERO_ADDR, eqAddr } from '../lib/wallet';
 import { withNetwork } from '../store/network';
 import { compose } from '../lib/lib';
+import { withWallet } from '../store/wallet';
 
 const hasTransferProxy = (cache, point) =>
   point in cache ? !eqAddr(cache[point].transferProxy, ETH_ZERO_ADDR) : false;
@@ -82,8 +83,7 @@ class Points extends React.Component {
   }
 
   render() {
-    const { setPointCursor, history } = this.props;
-    const { pointCache } = this.props;
+    const { setPointCursor, history, pointCache } = this.props;
 
     const {
       points,
@@ -259,5 +259,6 @@ class Points extends React.Component {
 
 export default compose(
   withNetwork,
-  withHistory
+  withHistory,
+  withWallet
 )(Points);

--- a/src/bridge/views/PrivateKey.js
+++ b/src/bridge/views/PrivateKey.js
@@ -8,6 +8,7 @@ import { ROUTE_NAMES } from '../lib/routeNames';
 import { withHistory } from '../store/history';
 import { EthereumWallet } from '../lib/wallet';
 import { compose } from '../lib/lib';
+import { withWallet } from '../store/wallet';
 
 class PrivateKey extends React.Component {
   constructor(props) {
@@ -74,4 +75,7 @@ class PrivateKey extends React.Component {
   }
 }
 
-export default compose(withHistory)(PrivateKey);
+export default compose(
+  withHistory,
+  withWallet
+)(PrivateKey);

--- a/src/bridge/views/SetKeys.js
+++ b/src/bridge/views/SetKeys.js
@@ -3,16 +3,17 @@ import Maybe from 'folktale/maybe';
 import * as azimuth from 'azimuth-js';
 import * as ob from 'urbit-ob';
 import * as need from '../lib/need';
+import * as kg from 'urbit-key-generation/dist/index';
 import { Row, Col, H1, P, Warning, CheckboxButton } from '../components/Base';
 
 import StatelessTransaction from '../components/StatelessTransaction';
 import { attemptSeedDerivation } from '../lib/keys';
 
-import * as kg from 'urbit-key-generation/dist/index';
-
 import { addHexPrefix } from '../lib/wallet';
-import { withNetwork } from '../store/network';
 import { compose } from '../lib/lib';
+
+import { withNetwork } from '../store/network';
+import { withWallet } from '../store/wallet';
 
 class SetKeys extends React.Component {
   constructor(props) {
@@ -198,4 +199,7 @@ class SetKeys extends React.Component {
   }
 }
 
-export default compose(withNetwork)(SetKeys);
+export default compose(
+  withNetwork,
+  withWallet
+)(SetKeys);

--- a/src/bridge/views/Shards.js
+++ b/src/bridge/views/Shards.js
@@ -17,6 +17,7 @@ import { ROUTE_NAMES } from '../lib/routeNames';
 import { withHistory } from '../store/history';
 import { urbitWalletFromTicket } from '../lib/wallet';
 import { compose } from '../lib/lib';
+import { withWallet } from '../store/wallet';
 
 const placeholder = len => {
   let bytes = window.crypto.getRandomValues(new Uint8Array(len));
@@ -212,4 +213,7 @@ class Shards extends React.Component {
   }
 }
 
-export default compose(withHistory)(Shards);
+export default compose(
+  withHistory,
+  withWallet
+)(Shards);

--- a/src/bridge/views/Ticket.js
+++ b/src/bridge/views/Ticket.js
@@ -15,6 +15,7 @@ import { randomPatq, compose } from '../lib/lib';
 import { ROUTE_NAMES } from '../lib/routeNames';
 import { withHistory } from '../store/history';
 import { urbitWalletFromTicket } from '../lib/wallet';
+import { withWallet } from '../store/wallet';
 
 class Ticket extends React.Component {
   constructor(props) {
@@ -150,4 +151,7 @@ class Ticket extends React.Component {
   }
 }
 
-export default compose(withHistory)(Ticket);
+export default compose(
+  withHistory,
+  withWallet
+)(Ticket);

--- a/src/bridge/views/Trezor.js
+++ b/src/bridge/views/Trezor.js
@@ -11,6 +11,7 @@ import { TREZOR_PATH } from '../lib/trezor';
 import { ROUTE_NAMES } from '../lib/routeNames';
 import { withHistory } from '../store/history';
 import { compose } from '../lib/lib';
+import { withWallet } from '../store/wallet';
 
 class Trezor extends React.Component {
   constructor(props) {
@@ -140,4 +141,7 @@ class Trezor extends React.Component {
   }
 }
 
-export default compose(withHistory)(Trezor);
+export default compose(
+  withHistory,
+  withWallet
+)(Trezor);

--- a/src/bridge/views/Wallet.js
+++ b/src/bridge/views/Wallet.js
@@ -6,8 +6,9 @@ import { Row, Col } from '../components/Base';
 
 import { ROUTE_NAMES } from '../lib/routeNames';
 import { withHistory } from '../store/history';
-import { WALLET_NAMES, renderWalletType } from '../lib/wallet';
+import { WALLET_TYPES, renderWalletType } from '../lib/wallet';
 import { compose } from '../lib/lib';
+import { withWallet } from '../store/wallet';
 
 class Wallet extends React.Component {
   componentDidMount() {
@@ -19,37 +20,37 @@ class Wallet extends React.Component {
     return [
       {
         title: 'Urbit Master Ticket',
-        value: WALLET_NAMES.TICKET,
+        value: WALLET_TYPES.TICKET,
       },
       {
         title: 'Urbit Master Ticket (Shards)',
-        value: WALLET_NAMES.SHARDS,
+        value: WALLET_TYPES.SHARDS,
       },
       {
         type: 'divider',
       },
       {
         title: 'Ledger',
-        value: WALLET_NAMES.LEDGER,
+        value: WALLET_TYPES.LEDGER,
       },
       {
         title: 'Trezor',
-        value: WALLET_NAMES.TREZOR,
+        value: WALLET_TYPES.TREZOR,
       },
       {
         type: 'divider',
       },
       {
         title: 'BIP39 Mnemonic',
-        value: WALLET_NAMES.MNEMONIC,
+        value: WALLET_TYPES.MNEMONIC,
       },
       {
         title: 'Ethereum Private Key',
-        value: WALLET_NAMES.PRIVATE_KEY,
+        value: WALLET_TYPES.PRIVATE_KEY,
       },
       {
         title: 'Ethereum Keystore File',
-        value: WALLET_NAMES.KEYSTORE,
+        value: WALLET_TYPES.KEYSTORE,
       },
     ];
   }
@@ -80,19 +81,19 @@ class Wallet extends React.Component {
             className={'mt-10'}
             onClick={() =>
               props.history.push(
-                props.walletType === WALLET_NAMES.MNEMONIC
+                props.walletType === WALLET_TYPES.MNEMONIC
                   ? ROUTE_NAMES.MNEMONIC
-                  : props.walletType === WALLET_NAMES.TICKET
+                  : props.walletType === WALLET_TYPES.TICKET
                   ? ROUTE_NAMES.TICKET
-                  : props.walletType === WALLET_NAMES.SHARDS
+                  : props.walletType === WALLET_TYPES.SHARDS
                   ? ROUTE_NAMES.SHARDS
-                  : props.walletType === WALLET_NAMES.LEDGER
+                  : props.walletType === WALLET_TYPES.LEDGER
                   ? ROUTE_NAMES.LEDGER
-                  : props.walletType === WALLET_NAMES.TREZOR
+                  : props.walletType === WALLET_TYPES.TREZOR
                   ? ROUTE_NAMES.TREZOR
-                  : props.walletType === WALLET_NAMES.PRIVATE_KEY
+                  : props.walletType === WALLET_TYPES.PRIVATE_KEY
                   ? ROUTE_NAMES.PRIVATE_KEY
-                  : props.walletType === WALLET_NAMES.KEYSTORE
+                  : props.walletType === WALLET_TYPES.KEYSTORE
                   ? ROUTE_NAMES.KEYSTORE
                   : ROUTE_NAMES.DEFAULT
               )
@@ -105,4 +106,7 @@ class Wallet extends React.Component {
   }
 }
 
-export default compose(withHistory)(Wallet);
+export default compose(
+  withHistory,
+  withWallet
+)(Wallet);


### PR DESCRIPTION
This PR moves wallet, walletHdPath, and walletType to a container store like we've done to network, history, etc.

It's hard to tell if I've caught all of the usages of wallet because of the implicit dependencies involved in just passing all of the props from a parent, but this _should_ be everything. Definitely worth going through some of the core flows independently to make sure we've got them all. These sorts of implicit dependencies will go away during any transition to hooks and towards the end of this "extract everything" journey, so our refactoring experience should be much more confident in time.

~TODO: move urbit wallet information into this same container~