### PR TITLE
fix: clean up the spreading of props to StatelessTransaction

### DIFF
--- a/src/bridge/Bridge.js
+++ b/src/bridge/Bridge.js
@@ -50,11 +50,11 @@ const kInitialPointCursor = kIsStubbed ? Just(0) : Nothing();
 
 // the router itself is just a component that renders a specific view
 // depending on the history
-const Router = function(props) {
+const Router = function() {
   const history = useHistory();
   const Route = router(history.peek());
 
-  return <Route {...props} />;
+  return <Route />;
 };
 
 // NB(shrugs): separate component because it needs useHistory
@@ -90,33 +90,31 @@ const AllProviders = nest([
   TxnCursorProvider,
 ]);
 
-class Bridge extends React.Component {
-  render() {
-    return (
-      <AllProviders
-        initialRoutes={kInitialRoutes}
-        initialNetworkType={kInitialNetworkType}
-        initialWallet={kInitialWallet}
-        initialMnemonic={kInitialMnemonic}
-        initialPointCursor={kInitialPointCursor}>
-        <Container>
-          <Row>
-            <VariableWidthColumn>
-              <Header />
+function Bridge() {
+  return (
+    <AllProviders
+      initialRoutes={kInitialRoutes}
+      initialNetworkType={kInitialNetworkType}
+      initialWallet={kInitialWallet}
+      initialMnemonic={kInitialMnemonic}
+      initialPointCursor={kInitialPointCursor}>
+      <Container>
+        <Row>
+          <VariableWidthColumn>
+            <Header />
 
-              <Row className={'row wrapper'}>
-                <Router />
+            <Row className={'row wrapper'}>
+              <Router />
 
-                <div className={'push'} />
-              </Row>
+              <div className={'push'} />
+            </Row>
 
-              <Footer />
-            </VariableWidthColumn>
-          </Row>
-        </Container>
-      </AllProviders>
-    );
-  }
+            <Footer />
+          </VariableWidthColumn>
+        </Row>
+      </Container>
+    </AllProviders>
+  );
 }
 
 export default Bridge;

--- a/src/bridge/views/AcceptTransfer.js
+++ b/src/bridge/views/AcceptTransfer.js
@@ -108,9 +108,6 @@ class AcceptTransfer extends React.Component {
           </Anchor>
 
           <StatelessTransaction
-            // Upper scope
-            {...props}
-            // Other
             canGenerate={canGenerate}
             createUnsignedTxn={this.createUnsignedTxn}
             ref={this.statelessRef}

--- a/src/bridge/views/CancelTransfer.js
+++ b/src/bridge/views/CancelTransfer.js
@@ -65,9 +65,6 @@ class CancelTransfer extends React.Component {
 
           <P>{`This action will cancel the transfer to ${proxy}.`}</P>
           <StatelessTransaction
-            // Upper scope
-            {...props}
-            // Other
             canGenerate={canGenerate}
             createUnsignedTxn={this.createUnsignedTxn}
           />

--- a/src/bridge/views/CreateGalaxy.js
+++ b/src/bridge/views/CreateGalaxy.js
@@ -183,9 +183,6 @@ class CreateGalaxy extends React.Component {
           </Button>
 
           <StatelessTransaction
-            // Upper scope
-            {...props}
-            // Other
             ref={this.statelessRef}
             canGenerate={canGenerate}
             createUnsignedTxn={this.createUnsignedTxn}

--- a/src/bridge/views/InvitesManage.js
+++ b/src/bridge/views/InvitesManage.js
@@ -172,9 +172,6 @@ class InvitesManage extends React.Component {
           </Input>
 
           <StatelessTransaction
-            // Upper scope
-            {...this.props}
-            // Other
             canGenerate={this.state.canGenerate}
             createUnsignedTxn={this.createUnsignedTxn}
             ref={this.statelessRef}

--- a/src/bridge/views/IssueChild.js
+++ b/src/bridge/views/IssueChild.js
@@ -243,9 +243,6 @@ class IssueChild extends React.Component {
           </Anchor>
 
           <StatelessTransaction
-            // Upper scope
-            {...props}
-            // Other
             canGenerate={canGenerate}
             createUnsignedTxn={this.createUnsignedTxn}
             ref={this.statelessRef}

--- a/src/bridge/views/SetProxy.js
+++ b/src/bridge/views/SetProxy.js
@@ -157,9 +157,6 @@ class _SetProxy extends React.Component {
           {addressInput}
 
           <StatelessTransaction
-            // Upper scope
-            {...props}
-            // Other
             ref={this.statelessRef}
             createUnsignedTxn={this.createUnsignedTxn}
             canGenerate={canGenerate}


### PR DESCRIPTION
A simple PR to remove the prop spreading for StatelessTransaction, since it pulls all of the information it needs from our new state containers