### PR TITLE
fix: check if stub exactly equals 'true' instead of presence

### DIFF
--- a/src/bridge/Bridge.js
+++ b/src/bridge/Bridge.js
@@ -26,7 +26,7 @@ const kInitialNetworkType = isDevelopment
   : NETWORK_TYPES.MAINNET;
 
 // NB(shrugs): modify these variables to change the default local state.
-const shouldStubLocal = process.env.REACT_APP_STUB_LOCAL;
+const shouldStubLocal = process.env.REACT_APP_STUB_LOCAL === 'true';
 const kIsStubbed = isDevelopment && shouldStubLocal;
 const kInitialRoutes = kIsStubbed
   ? [


### PR DESCRIPTION
self explanatory - i goofed on that initial PR when I reimplemented  #169 and didn't test well enough