### PR TITLE
Add tool for finding real-world gas usage

### DIFF
--- a/find-gas-usage.js
+++ b/find-gas-usage.js
@@ -1,0 +1,121 @@
+// usage: tweak constants at head of file, then run "node find-gas-usage.js"
+//        for very common events/calls, you may need to use a smaller TO-FROM
+//        range to keep web3 from yelling at you
+
+const ORIGIN = 6784800; // launch ceremony begins
+const PUBLIC = 7033765; // azimuth becomes public
+const LATEST = 'latest';
+
+const FROM = ORIGIN;
+const TO = LATEST;
+
+const VENT = 'ChangedKeys';
+const FUNC = '0x4447e48c'; // configureKeys
+const ARGS = 5;
+
+// const VENT = 'Spawned';
+// const FUNC = '0xa0d3253f'; // spawn
+// const ARGS = 2;
+
+// const VENT = 'OwnerChanged';
+// const FUNC = '0x1e79a85b'; // transferPoint
+// const ARGS = 3;
+
+// const VENT = 'ChangedSpawnProxy';
+// const FUNC = '0xae326221'; // setSpawnProxy
+// const ARGS = 2;
+
+// const VENT = 'ChangedManagementProxy';
+// const FUNC = '0x8866bb2c'; // setManagementProxy
+// const ARGS = 2;
+
+// const VENT = 'ChangedTransferProxy';
+// const FUNC = '0x2c7ba564'; // setTransferProxy
+// const ARGS = 2;
+
+// const VENT = 'ChangedVotingProxy';
+// const FUNC = '0xa60e8bd6'; // setVotingProxy
+// const ARGS = 2;
+
+// const VENT = 'EscapeRequested';
+// const FUNC = '0xbf5772b9'; // escape
+// const ARGS = 2;
+
+// const VENT = 'EscapeCanceled';
+// const FUNC = '0xc6d761d4'; // cancelEscape
+// const ARGS = 1;
+
+// const VENT = 'EscapeAccepted';
+// const FUNC = '0xc1b9d98b'; // adopt
+// const ARGS = 1;
+
+// const VENT = 'EscapeCanceled';
+// const FUNC = '0xbbe21ca5'; // reject
+// const ARGS = 1;
+
+// const VENT = 'LostSponsor';
+// const FUNC = '0x073a7804'; // detach
+// const ARGS = 1;
+
+const LENT = 64 * ARGS + FUNC.length;
+
+const Web3 = require('web3');
+const azimuth = require('azimuth-js');
+
+(async () => {
+  const web3 = new Web3(
+    new Web3.providers.HttpProvider(
+      'https://mainnet.infura.io/v3/196a7f37c7d54211b4a07904ec73ad87'
+    )
+  );
+  const contracts = await azimuth.initContractsPartial(
+    web3,
+    '0x223c067f8cf28ae173ee5cafea60ca44c335fecb'
+  );
+
+  const keyEvents = await contracts.azimuth.getPastEvents(VENT, {
+    fromBlock: FROM,
+    toBlock: TO,
+  });
+
+  const txsBatch = new web3.BatchRequest();
+  keyEvents.map(vent => {
+    txsBatch.add(
+      web3.eth.getTransaction.request(vent.transactionHash, (err, res) => {})
+    );
+  });
+  const txs = await txsBatch.execute();
+  const keyTxs = txs.response.filter(tx => {
+    const head = tx.input.slice(0, 10) === FUNC;
+    const size = tx.input.length === LENT;
+    if (head && !size) {
+      console.log('weird inputs', tx.hash);
+    }
+    return head && size;
+  });
+
+  const receiptsBatch = new web3.BatchRequest();
+  keyTxs.map(tx => {
+    receiptsBatch.add(
+      web3.eth.getTransactionReceipt.request(tx.hash, (err, res) => {})
+    );
+  });
+  const recs = await receiptsBatch.execute();
+
+  let usage = {};
+  recs.response.map(rec => {
+    if (rec.status !== true) {
+      console.log('rejecting', rec.gasUsed);
+      return;
+    }
+    if (rec.gasUsed > 480000) {
+      console.log(rec.transactionHash);
+    }
+    if (rec.gasUsed in usage) {
+      usage[rec.gasUsed]++;
+    } else {
+      usage[rec.gasUsed] = 1;
+    }
+  });
+  console.log(usage);
+})();

--- a/find-gas-usage.js
+++ b/find-gas-usage.js
@@ -5,6 +5,9 @@
 const ORIGIN = 6784800; // launch ceremony begins
 const PUBLIC = 7033765; // azimuth becomes public
 const LATEST = 'latest';
+const AZIMUTH_ADDRESS = '0x223c067f8cf28ae173ee5cafea60ca44c335fecb';
+const ENDPOINT =
+  'https://mainnet.infura.io/v3/196a7f37c7d54211b4a07904ec73ad87';
 
 const FROM = ORIGIN;
 const TO = LATEST;
@@ -63,15 +66,8 @@ const Web3 = require('web3');
 const azimuth = require('azimuth-js');
 
 (async () => {
-  const web3 = new Web3(
-    new Web3.providers.HttpProvider(
-      'https://mainnet.infura.io/v3/196a7f37c7d54211b4a07904ec73ad87'
-    )
-  );
-  const contracts = await azimuth.initContractsPartial(
-    web3,
-    '0x223c067f8cf28ae173ee5cafea60ca44c335fecb'
-  );
+  const web3 = new Web3(new Web3.providers.HttpProvider(ENDPOINT));
+  const contracts = await azimuth.initContractsPartial(web3, AZIMUTH_ADDRESS);
 
   const keyEvents = await contracts.azimuth.getPastEvents(VENT, {
     fromBlock: FROM,

--- a/find-gas-usage.js
+++ b/find-gas-usage.js
@@ -108,9 +108,6 @@ const azimuth = require('azimuth-js');
       console.log('rejecting', rec.gasUsed);
       return;
     }
-    if (rec.gasUsed > 480000) {
-      console.log(rec.transactionHash);
-    }
     if (rec.gasUsed in usage) {
       usage[rec.gasUsed]++;
     } else {

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -13,12 +13,22 @@ const GALAXY_ENTROPY_BITS = 384;
 
 const SEED_ENTROPY_BITS = 128;
 
-//TODO properly research these, move into azimuth-js
+//TODO move into azimuth-js
 const GAS_LIMITS = {
-  TRANSFER: 500000,
-  CONFIGURE_KEYS: 150000,
-  SET_PROXY: 200000,
-  GIFT_PLANET: 400000, //TODO can maybe do 370000, see also commit  8c0ecaaa
+  SPAWN: 250000,
+  TRANSFER: 490000,
+  CONFIGURE_KEYS: 100000,
+  SET_PROXY: 119000,
+  //
+  ESCAPE: 115000, //NOTE low sample size
+  ADOPT: 100000, //NOTE low sample size
+  CANCEL_ESCAPE: 200000, //NOTE no samples
+  REJECT: 200000, //NOTE no samples
+  DETACH: 200000, //NOTE no samples
+  //
+  GIFT_PLANET: 400000, //NOTE low sample size
+  //
+  DEFAULT: 600000,
 };
 
 // TODO: this is walletgen-ui specific, move into a wallet router later

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -28,7 +28,7 @@ const GAS_LIMITS = {
   //
   GIFT_PLANET: 400000, //NOTE low sample size
   //
-  DEFAULT: 600000,
+  DEFAULT: 500000,
 };
 
 // TODO: this is walletgen-ui specific, move into a wallet router later


### PR DESCRIPTION
Also updates the constants to reflect results gained from it.

It ain't the prettiest, but it works. It filters for sane and successful transactions. Goes off events on the Azimuth contract initially because not all calls were made against the current instance of the Ecliptic contract (we had subtly different versions during launch ceremony).

In most cases, I just rounded up whatever was the highest gas usage that rolled out of this. In cases where we have low sample size, I rounded up a bit more aggressively.

The data you get from this is pretty interesting. Transactions tend to cluster around certain gas amounts, but there's almost always outliers on either side. Wonder why this is the way it is.

<img width="451" alt="image" src="https://user-images.githubusercontent.com/3829764/60726384-b03a2c00-9f3b-11e9-97cf-d9b5d0f549f2.png">

