### PR TITLE
Email invite fixes

### DIFF
--- a/src/components/old/StatelessTransaction.js
+++ b/src/components/old/StatelessTransaction.js
@@ -8,6 +8,7 @@ import { Button } from './Base';
 import { CheckboxButton, Input, InnerLabel, InnerLabelDropdown } from './Base';
 import { Warning } from './Base';
 
+import { GAS_LIMITS } from '../../lib/constants';
 import { BRIDGE_ERROR } from '../../lib/error';
 import { ROUTE_NAMES } from '../../lib/routeNames';
 import { compose } from '../../lib/lib';
@@ -40,7 +41,7 @@ class StatelessTransaction extends React.Component {
 
     this.state = {
       gasPrice: '5',
-      gasLimit: '600000',
+      gasLimit: '' + GAS_LIMITS.DEFAULT,
       showGasDetails: false,
       userApproval: false,
       chainId: '1',

--- a/src/components/old/StatelessTransaction.js
+++ b/src/components/old/StatelessTransaction.js
@@ -41,7 +41,7 @@ class StatelessTransaction extends React.Component {
 
     this.state = {
       gasPrice: '5',
-      gasLimit: '' + GAS_LIMITS.DEFAULT,
+      gasLimit: GAS_LIMITS.DEFAULT.toString(),
       showGasDetails: false,
       userApproval: false,
       chainId: '1',

--- a/src/indigo-react/index.js
+++ b/src/indigo-react/index.js
@@ -2,6 +2,7 @@ export { default as IndigoApp } from './components/IndigoApp';
 export { default as Grid } from './components/Grid';
 export { default as Flex } from './components/Flex';
 export { default as Input } from './components/Input';
+export { default as SelectInput } from './components/SelectInput';
 export { default as CheckboxInput } from './components/CheckboxInput';
 export { default as AccessoryIcon } from './components/AccessoryIcon';
 export { default as Button } from './components/Button';

--- a/src/lib/useMailer.js
+++ b/src/lib/useMailer.js
@@ -43,14 +43,10 @@ export default function useMailer(emails) {
   const _sendMail = useCallback(async (email, ticket, rawTx) => {
     if (STUB_MAILER) {
       console.log(`${email} - ${ticket}`);
-      return;
+      return true;
     }
 
-    const mailSuccess = await sendMail(email, ticket, rawTx);
-
-    if (!mailSuccess) {
-      throw new Error(`Internal mailing error when mailing ${email}`);
-    }
+    return await sendMail(email, ticket, rawTx);
   }, []);
 
   return { ...hasReceivedCache, sendMail: _sendMail };

--- a/src/lib/useMailer.js
+++ b/src/lib/useMailer.js
@@ -9,14 +9,14 @@ const STUB_MAILER = process.env.REACT_APP_STUB_MAILER === 'true';
 function useHasReceivedCache() {
   const [cache, addToCache] = useSetState();
 
-  const getHasRecieved = useCallback(
+  const getHasReceived = useCallback(
     email => cache[email] || Nothing(), //
     [cache]
   );
 
   const syncHasReceivedForEmail = useCallback(
     async email => {
-      if (Just.hasInstance(getHasRecieved(email))) {
+      if (Just.hasInstance(getHasReceived(email))) {
         // never update the cache after we know about it
         return;
       }
@@ -29,10 +29,10 @@ function useHasReceivedCache() {
       const _hasReceived = await hasReceived(email);
       addToCache({ [email]: Just(_hasReceived) });
     },
-    [getHasRecieved, addToCache]
+    [getHasReceived, addToCache]
   );
 
-  return { getHasRecieved, syncHasReceivedForEmail };
+  return { getHasReceived, syncHasReceivedForEmail };
 }
 
 export default function useMailer(emails) {

--- a/src/views/Invite/InviteEmail.js
+++ b/src/views/Invite/InviteEmail.js
@@ -318,7 +318,12 @@ export default function InviteEmail() {
       }
 
       try {
-        await sendMail(invite.email, invite.ticket, invite.rawTx);
+        const success = await sendMail(
+          invite.email,
+          invite.ticket,
+          invite.rawTx
+        );
+        if (!success) throw new Error('Failed to send mail');
       } catch (error) {
         console.error(error);
         errorCount++;

--- a/src/views/Invite/InviteEmail.js
+++ b/src/views/Invite/InviteEmail.js
@@ -347,8 +347,9 @@ export default function InviteEmail() {
       } catch (error) {
         console.error(error);
         errorCount++;
+        //TODO make sure this actually gets displayed
         addError({
-          [input.name]: `Mailing Failure for ${invite.email}`,
+          [input.name]: `Mailing Failure for ${invite.email}, please send them this code manually: ${invite.ticket}`,
         });
       }
 

--- a/src/views/Invite/InviteEmail.js
+++ b/src/views/Invite/InviteEmail.js
@@ -101,7 +101,7 @@ export default function InviteEmail() {
   const { syncInvites, getInvites } = usePointCache();
   const { pointCursor } = usePointCursor();
   const point = need.point(pointCursor);
-  const { getHasRecieved, syncHasReceivedForEmail, sendMail } = useMailer();
+  const { getHasReceived, syncHasReceivedForEmail, sendMail } = useMailer();
 
   const { availableInvites } = getInvites(point);
   const maxInvitesToSend = availableInvites.matchWith({
@@ -142,14 +142,14 @@ export default function InviteEmail() {
     () =>
       inputConfigs.map(config => {
         config.disabled = !canInput;
-        const hasReceivedError = getHasRecieved(config.name).matchWith({
+        const hasReceivedError = getHasReceived(config.name).matchWith({
           Nothing: () => null, // loading
           Just: p => p.value && HAS_RECEIVED_TEXT,
         });
         config.error = hasReceivedError || errors[config.name];
         return config;
       }),
-    [inputConfigs, errors, canInput, getHasRecieved]
+    [inputConfigs, errors, canInput, getHasReceived]
   );
 
   // construct the state of the set of inputs we're rendering below

--- a/src/views/Invite/InviteEmail.js
+++ b/src/views/Invite/InviteEmail.js
@@ -189,21 +189,21 @@ export default function InviteEmail() {
 
     //TODO want to do this on-input, but that gets weird. see #188
     let errorCount = 0;
-    const mailsVerified = inputs.map(async input => {
-      console.log('aaa', invites);
-      const email = input.data;
-      const hasReceived = getHasReceived(email).matchWith({
-        Nothing: () => false, // loading
-        Just: p => p.value,
-      });
-      if (hasReceived) {
-        errorCount++;
-        addError({
-          [input.name]: `${email} has already received an invite.`,
+    await Promise.all(
+      inputs.map(async input => {
+        const email = input.data;
+        const hasReceived = getHasReceived(email).matchWith({
+          Nothing: () => false, // loading
+          Just: p => p.value,
         });
-      }
-    });
-    await Promise.all(mailsVerified);
+        if (hasReceived) {
+          errorCount++;
+          addError({
+            [input.name]: `${email} has already received an invite.`,
+          });
+        }
+      })
+    );
     if (errorCount > 0) {
       throw new Error(`Some of these already have a point!`);
     }


### PR DESCRIPTION
Also an unrelated indigo-react export addition that was missing. I _think_ I'm fine just adding that in, but feel free to yell at me @shrugs.

Draft because I'm still trying to fix an issue in this code:

https://github.com/urbit/bridge/blob/a531c3055d3d83bc7057a613209e9ee5361c99b3/src/views/Invite/InviteEmail.js#L141-L156

Note how line 145 checks if `config.name` has received an invite yet, instead of using the actual value from the input. `config` doesn't contain that. `inputs`, a couple lines below, does, but it's out of scope for the logic that needs changing. @shrugs I've thought about doing just `.map` over `dynamicConfigs` _after_ `inputs` is defined, but I get the feeling that would mess this up. Can you recommend an approach?