### PR TITLE
Display disclaimer only on first run

### DIFF
--- a/src/Bridge.js
+++ b/src/Bridge.js
@@ -12,6 +12,7 @@ import { ROUTES } from 'lib/router';
 import { NETWORK_TYPES } from 'lib/network';
 import { walletFromMnemonic } from 'lib/wallet';
 import { isDevelopment } from 'lib/flags';
+import { hasDisclaimed } from 'lib/disclaimerCookie';
 
 import 'style/index.scss';
 
@@ -24,7 +25,9 @@ const SHOULD_STUB_LOCAL = process.env.REACT_APP_STUB_LOCAL === 'true';
 const IS_STUBBED = isDevelopment && SHOULD_STUB_LOCAL;
 const INITIAL_ROUTES = IS_STUBBED
   ? [{ key: ROUTE_NAMES.LANDING }, { key: ROUTE_NAMES.LOGIN }]
-  : [{ key: ROUTE_NAMES.LANDING }];
+  : hasDisclaimed()
+  ? [{ key: ROUTE_NAMES.LANDING }]
+  : [{ key: ROUTE_NAMES.DISCLAIMER }];
 
 const INITIAL_WALLET = IS_STUBBED
   ? walletFromMnemonic(

--- a/src/lib/disclaimerCookie.js
+++ b/src/lib/disclaimerCookie.js
@@ -1,0 +1,9 @@
+const COOKIE_ID = 'bridge_disclaimed';
+
+export const hasDisclaimed = () => {
+  return document.cookie.includes(COOKIE_ID);
+};
+
+export const setDisclaimerCookie = () => {
+  document.cookie = COOKIE_ID;
+};

--- a/src/lib/routeNames.js
+++ b/src/lib/routeNames.js
@@ -1,5 +1,6 @@
 export const ROUTE_NAMES = {
   DEFAULT: Symbol('DEFAULT'),
+  DISCLAIMER: Symbol('DISCLAIMER'),
   //
   ACTIVATE: Symbol('ACTIVATE'),
   INVITE_TRANSACTIONS: Symbol('INVITE_TRANSACTIONS'),

--- a/src/lib/router.js
+++ b/src/lib/router.js
@@ -1,4 +1,5 @@
 import Landing from '../views/Landing';
+import Disclaimer from '../views/Disclaimer';
 import Login from '../views/Login.js';
 import InvitesManage from '../views/InvitesManage.js';
 import Admin from '../views/Admin';
@@ -28,6 +29,7 @@ import { ROUTE_NAMES } from './routeNames';
 
 export const ROUTES = {
   [ROUTE_NAMES.LANDING]: Landing,
+  [ROUTE_NAMES.DISCLAIMER]: Disclaimer,
   [ROUTE_NAMES.ACTIVATE]: Activate,
   [ROUTE_NAMES.INVITE]: Invite,
   [ROUTE_NAMES.INVITES_MANAGE]: InvitesManage,

--- a/src/views/Activate.js
+++ b/src/views/Activate.js
@@ -5,7 +5,6 @@ import useRouter from 'lib/useRouter';
 import { ActivateFlowProvider } from './Activate/ActivateFlow';
 import useActivateFlowState from './Activate/useActivateFlowState';
 import ActivateCode from './Activate/ActivateCode';
-import ActivateDisclaimer from './Activate/ActivateDisclaimer';
 import { LocalRouterProvider } from 'lib/LocalRouter';
 import ActivatePassport from './Activate/ActivatePassport';
 
@@ -17,7 +16,6 @@ const NAMES = {
 
 const VIEWS = {
   [NAMES.CODE]: ActivateCode,
-  [NAMES.DISCLAIMER]: ActivateDisclaimer,
   [NAMES.PASSPORT]: ActivatePassport,
 };
 

--- a/src/views/Activate/ActivateCode.js
+++ b/src/views/Activate/ActivateCode.js
@@ -48,10 +48,7 @@ export default function ActivateCode() {
   const goToLogin = useCallback(() => history.popAndPush(ROUTE_NAMES.LOGIN), [
     history,
   ]);
-  const goToDisclaimer = useCallback(() => push(names.DISCLAIMER), [
-    names,
-    push,
-  ]);
+  const goToPassport = useCallback(() => push(names.PASSPORT), [names, push]);
 
   const pass = derivedWallet.matchWith({
     Nothing: () => false,
@@ -142,7 +139,7 @@ export default function ActivateCode() {
           className="mt4"
           disabled={!pass || deriving}
           accessory={deriving ? <Blinky /> : undefined}
-          onClick={goToDisclaimer}
+          onClick={goToPassport}
           solid
           full>
           {deriving && 'Deriving...'}

--- a/src/views/Disclaimer.js
+++ b/src/views/Disclaimer.js
@@ -3,7 +3,8 @@ import cn from 'classnames';
 import { Grid, H3, B, Text, CheckboxInput } from 'indigo-react';
 
 import { useCheckboxInput } from 'lib/useInputs';
-import { useLocalRouter } from 'lib/LocalRouter';
+import { useHistory } from 'store/history';
+import { setDisclaimerCookie } from 'lib/disclaimerCookie';
 
 import View from 'components/View';
 import { ForwardButton } from 'components/Buttons';
@@ -12,13 +13,16 @@ import WarningBox from 'components/WarningBox';
 const TEXT_STYLE = 'f5';
 
 export default function ActivateDisclaimer() {
-  const { push, names } = useLocalRouter();
+  const { popAndPush, names } = useHistory();
   const [understoodInput, { data: isUnderstood }] = useCheckboxInput({
     name: 'checkbox',
     label: 'I acknowledge and understand these rights',
   });
 
-  const goToPassport = useCallback(() => push(names.PASSPORT), [push, names]);
+  const goToPassport = useCallback(() => {
+    setDisclaimerCookie();
+    popAndPush(names.LANDING);
+  }, [popAndPush, names]);
 
   return (
     <View>

--- a/src/views/Landing.js
+++ b/src/views/Landing.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { H1, P } from 'indigo-react';
 
-import { ROUTE_NAMES } from '../lib/routeNames';
 import { useHistory } from '../store/history';
 import useImpliedPoint from 'lib/useImpliedPoint';
 import useImpliedTicket from 'lib/useImpliedTicket';
@@ -12,9 +11,11 @@ import { ForwardButton } from 'components/Buttons';
 function Landing() {
   const { push, names } = useHistory();
 
-  if (useImpliedPoint()) {
+  const impliedPoint = useImpliedPoint();
+  const impliedTicket = useImpliedTicket();
+  if (impliedPoint) {
     push(names.LOGIN);
-  } else if (useImpliedTicket()) {
+  } else if (impliedTicket) {
     push(names.ACTIVATE);
   }
 


### PR DESCRIPTION
Uses super dumb cookie logic to make that happen. If we ever do anything more with cookies (unlikely imo), we'll want a `/lib/cookies` or whatever.

Yes, this works for localhost. No, this doesn't work across hosts.