### PR TITLE
/lib/txn improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2573,6 +2573,14 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
+    "async-retry": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.2.3.tgz",
+      "integrity": "sha512-tfDb02Th6CE6pJUF2gjW5ZVjsgwlucVXOEQMvEX9JgSJMs9gAX+Nz3xRuJBKuUYjTSYORqvDBORdAQ3LU59g7Q==",
+      "requires": {
+        "retry": "0.12.0"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -14926,6 +14934,11 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "rgb-regex": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@ledgerhq/hw-app-eth": "^4.61.0",
     "@ledgerhq/hw-transport-u2f": "^4.61.0",
     "PaperCollateralRenderer": "github:urbit/PaperCollateralRenderer",
+    "async-retry": "^1.2.3",
     "azimuth-js": "^0.15.0",
     "azimuth-solidity": "^1.2.0",
     "bip32": "^1.0.2",

--- a/src/components/old/StatelessTransaction.js
+++ b/src/components/old/StatelessTransaction.js
@@ -494,7 +494,13 @@ class StatelessTransaction extends React.Component {
         prop-size={'lg wide'}
         prop-color={signerButtonColor}
         onClick={() =>
-          signTransaction({ ...this.props, ...this.state, setStx: this.setStx })
+          signTransaction({
+            ...this.props,
+            ...this.state,
+            setStx: this.setStx,
+            wallet: this.props.wallet.value,
+            txn: txn.value,
+          })
         }>
         {'Sign Transaction'}
       </Button>

--- a/src/components/old/StatelessTransaction.js
+++ b/src/components/old/StatelessTransaction.js
@@ -233,12 +233,7 @@ class StatelessTransaction extends React.Component {
     } else {
       this.setState({ txStatus: SUBMISSION_STATES.SENDING });
 
-      sendSignedTransaction(
-        web3,
-        state.stx,
-        usedTank,
-        props.setTxnConfirmations
-      )
+      sendSignedTransaction(web3, stx, usedTank, props.setTxnConfirmations)
         .then(txHash => {
           props.setTxnCursor(Just(Ok(txHash)));
 

--- a/src/components/old/StatelessTransaction.js
+++ b/src/components/old/StatelessTransaction.js
@@ -185,7 +185,7 @@ class StatelessTransaction extends React.Component {
     const stx = state.stx.matchWith({
       Just: tx => tx.value,
       Nothing: () => {
-        throw BRIDGE_ERROR.MISSING_TXN;
+        throw new Error(BRIDGE_ERROR.MISSING_TXN);
       },
     });
 

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -16,7 +16,7 @@ const SEED_ENTROPY_BITS = 128;
 //TODO move into azimuth-js
 const GAS_LIMITS = {
   SPAWN: 250000,
-  TRANSFER: 490000,
+  TRANSFER: 550000,
   CONFIGURE_KEYS: 100000,
   SET_PROXY: 120000,
   //
@@ -28,7 +28,7 @@ const GAS_LIMITS = {
   //
   GIFT_PLANET: 400000, //NOTE low sample size
   //
-  DEFAULT: 500000,
+  DEFAULT: 550000,
 };
 
 // TODO: this is walletgen-ui specific, move into a wallet router later

--- a/src/lib/error.js
+++ b/src/lib/error.js
@@ -1,15 +1,15 @@
 const BRIDGE_ERROR = {
-  MISSING_WEB3: new Error('no web3 object found'),
-  MISSING_WALLET: new Error('no wallet found'),
-  MISSING_TXN: new Error('no transaction found'),
-  MISSING_CONTRACTS: new Error('no contracts found'),
-  MISSING_KEYSTORE: new Error('no keystore text found'),
-  MISSING_MNEMONIC: new Error('no authentication mnemonic found'),
-  MISSING_URBIT_WALLET: new Error('no urbit wallet found'),
-  MISSING_POINT: new Error('no point found'),
-  INVALID_ROUTE: new Error('invalid route'),
-  INVALID_NETWORK_TYPE: new Error('invalid network type'),
-  INVALID_WALLET_TYPE: new Error('invalid wallet type'),
+  MISSING_WEB3: 'no web3 object found',
+  MISSING_WALLET: 'no wallet found',
+  MISSING_TXN: 'no transaction found',
+  MISSING_CONTRACTS: 'no contracts found',
+  MISSING_KEYSTORE: 'no keystore text found',
+  MISSING_MNEMONIC: 'no authentication mnemonic found',
+  MISSING_URBIT_WALLET: 'no urbit wallet found',
+  MISSING_POINT: 'no point found',
+  INVALID_ROUTE: 'invalid route',
+  INVALID_NETWORK_TYPE: 'invalid network type',
+  INVALID_WALLET_TYPE: 'invalid wallet type',
 };
 
 const renderTxnError = (web3, msg) => {

--- a/src/lib/invite.js
+++ b/src/lib/invite.js
@@ -258,7 +258,7 @@ async function claimPointFromInvite({
 
   progress(TRANSACTION_STATES.CLAIMING);
 
-  await sendAndAwaitAll(web3, txPairs.map(p => Just(p.signed)), usedTank);
+  await sendAndAwaitAll(web3, txPairs.map(p => p.signed), usedTank);
 
   //
   // move leftover eth

--- a/src/lib/invite.js
+++ b/src/lib/invite.js
@@ -9,7 +9,7 @@ import * as tank from './tank';
 import JSZip from 'jszip';
 import saveAs from 'file-saver';
 
-import { sendSignedTransaction, hexify } from './txn';
+import { sendAndAwaitAll, hexify } from './txn';
 import { attemptNetworkSeedDerivation } from './keys';
 import { addHexPrefix, WALLET_TYPES } from './wallet';
 import { GAS_LIMITS } from './constants';
@@ -258,7 +258,7 @@ async function claimPointFromInvite({
 
   progress(TRANSACTION_STATES.CLAIMING);
 
-  await sendAndAwaitConfirm(web3, txPairs.map(p => Just(p.signed)), usedTank);
+  await sendAndAwaitAll(web3, txPairs.map(p => Just(p.signed)), usedTank);
 
   //
   // move leftover eth
@@ -289,16 +289,6 @@ async function claimPointFromInvite({
   }
 
   progress(TRANSACTION_STATES.DONE);
-}
-
-async function sendAndAwaitConfirm(web3, signedTxs, usedTank) {
-  await Promise.all(
-    signedTxs.map(tx => {
-      return new Promise((resolve, reject) => {
-        sendSignedTransaction(web3, tx, usedTank, resolve);
-      });
-    })
-  );
 }
 
 export {

--- a/src/lib/keys.js
+++ b/src/lib/keys.js
@@ -89,7 +89,7 @@ const attemptNetworkSeedDerivation = async (next, args) => {
     const uwal = urbitWallet.matchWith({
       Just: uw => uw.value,
       Nothing: _ => {
-        throw BRIDGE_ERROR.MISSING_URBIT_WALLET;
+        throw new Error(BRIDGE_ERROR.MISSING_URBIT_WALLET);
       },
     });
 
@@ -100,7 +100,7 @@ const attemptNetworkSeedDerivation = async (next, args) => {
     const mnemonic = authMnemonic.matchWith({
       Just: mnem => mnem.value,
       Nothing: _ => {
-        throw BRIDGE_ERROR.MISSING_MNEMONIC;
+        throw new Error(BRIDGE_ERROR.MISSING_MNEMONIC);
       },
     });
 

--- a/src/lib/need.js
+++ b/src/lib/need.js
@@ -19,26 +19,26 @@ export const web3 = needBuilder(() => {
 });
 
 export const contracts = needBuilder(() => {
-  throw new Error(BRIDGE_ERROR.MISSING_CONTRACTS.message);
+  throw new Error(BRIDGE_ERROR.MISSING_CONTRACTS);
 });
 
 export const wallet = needBuilder(() => {
-  throw new Error(BRIDGE_ERROR.MISSING_WALLET.message);
+  throw new Error(BRIDGE_ERROR.MISSING_WALLET);
 });
 
 export const addressFromWallet = obj => wallet(obj).address;
 
 export const point = needBuilder(() => {
-  throw new Error(BRIDGE_ERROR.MISSING_POINT.message);
+  throw new Error(BRIDGE_ERROR.MISSING_POINT);
 });
 
 export const pointCache = needBuilder(() => {
-  throw new Error(BRIDGE_ERROR.MISSING_POINT.message);
+  throw new Error(BRIDGE_ERROR.MISSING_POINT);
 });
 
 export const fromPointCache = (cache, point) => {
   if (!(point in cache)) {
-    throw new Error(BRIDGE_ERROR.MISSING_POINT.message);
+    throw new Error(BRIDGE_ERROR.MISSING_POINT);
   }
 
   return cache[point];
@@ -49,7 +49,7 @@ export const keystore = obj => {
   return ks.value.matchWith({
     Ok: result => result.value,
     Error: _ => {
-      throw BRIDGE_ERROR.MISSING_KEYSTORE;
+      throw new Error(BRIDGE_ERROR.MISSING_KEYSTORE);
     },
   });
 };

--- a/src/lib/txn.js
+++ b/src/lib/txn.js
@@ -172,14 +172,12 @@ const waitForTransactionConfirm = (web3, txHash) => {
   }, RETRY_OPTIONS);
 };
 
-const sendAndAwaitAll = async (web3, stxs, doubtNonceError) => {
-  await Promise.all(
-    stxs.map(tx => {
-      return new Promise(async (resolve, reject) => {
-        const txHash = await sendSignedTransaction(web3, tx, doubtNonceError);
-        await waitForTransactionConfirm(web3, txHash);
-        resolve();
-      });
+// returns a Promise that resolves when all stxs have been sent & confirmed
+const sendAndAwaitAll = (web3, stxs, doubtNonceError) => {
+  return Promise.all(
+    stxs.map(async tx => {
+      const txHash = await sendSignedTransaction(web3, tx, doubtNonceError);
+      await waitForTransactionConfirm(web3, txHash);
     })
   );
 };

--- a/src/lib/txn.js
+++ b/src/lib/txn.js
@@ -63,6 +63,7 @@ const signTransaction = async config => {
     gasLimit,
   } = config;
 
+  //TODO require these in txn object
   nonce = toHex(nonce);
   chainId = toHex(chainId);
   gasPrice = toHex(toWei(gasPrice, 'gwei'));
@@ -117,6 +118,9 @@ const signTransaction = async config => {
 
   const stx = new Tx(utx);
 
+  //TODO should try-catch and display error message to user,
+  //     ie ledger's "pls enable contract data"
+  //     needs to maybe happen at call-site though
   if (walletType === WALLET_TYPES.LEDGER) {
     await ledgerSignTransaction(stx, walletHdPath);
   } else if (walletType === WALLET_TYPES.TREZOR) {
@@ -166,7 +170,7 @@ const sendSignedTransaction = (web3, stx, doubtNonceError) => {
 const waitForTransactionConfirm = (web3, txHash) => {
   return retry(async (bail, n) => {
     const receipt = await web3.eth.getTransactionReceipt(txHash);
-    let confirmed = receipt !== null;
+    const confirmed = receipt !== null;
     if (confirmed) return receipt.status === true;
     else throw new Error('retrying');
   }, RETRY_OPTIONS);

--- a/src/lib/txn.js
+++ b/src/lib/txn.js
@@ -4,7 +4,6 @@ import Tx from 'ethereumjs-tx';
 import { toWei, fromWei, toHex } from 'web3-utils';
 import * as retry from 'async-retry';
 
-import { BRIDGE_ERROR } from './error';
 import { NETWORK_TYPES } from './network';
 import { ledgerSignTransaction } from './ledger';
 import { trezorSignTransaction } from './trezor';
@@ -114,21 +113,7 @@ const signTransaction = async config => {
     ? Object.assign(txParams, eip155Params)
     : txParams;
 
-  const wal = wallet.matchWith({
-    Just: w => w.value,
-    Nothing: () => {
-      throw BRIDGE_ERROR.MISSING_WALLET;
-    },
-  });
-
-  const sec = wal.privateKey;
-
-  const utx = txn.matchWith({
-    Just: tx => Object.assign(tx.value, signingParams),
-    Nothing: () => {
-      throw BRIDGE_ERROR.MISSING_TXN;
-    },
-  });
+  const utx = Object.assign(txn, signingParams);
 
   const stx = new Tx(utx);
 
@@ -137,7 +122,7 @@ const signTransaction = async config => {
   } else if (walletType === WALLET_TYPES.TREZOR) {
     await trezorSignTransaction(stx, walletHdPath);
   } else {
-    stx.sign(sec);
+    stx.sign(wallet.privateKey);
   }
 
   setStx(Just(stx));

--- a/src/lib/txn.js
+++ b/src/lib/txn.js
@@ -145,14 +145,7 @@ const signTransaction = async config => {
 };
 
 const sendSignedTransaction = (web3, stx, doubtNonceError) => {
-  const txn = stx.matchWith({
-    Just: tx => tx.value,
-    Nothing: () => {
-      throw BRIDGE_ERROR.MISSING_TXN;
-    },
-  });
-
-  const rawTx = hexify(txn.serialize());
+  const rawTx = hexify(stx.serialize());
 
   return new Promise(async (resolve, reject) => {
     web3.eth

--- a/src/lib/txn.js
+++ b/src/lib/txn.js
@@ -191,10 +191,16 @@ const waitForTransactionConfirm = (web3, txHash) => {
   });
 };
 
-const isTransactionConfirmed = async (web3, txHash) => {
-  const receipt = await web3.eth.getTransactionReceipt(txHash);
-  console.log('got confirm state', receipt !== null, receipt.confirmations);
-  return receipt !== null;
+const sendAndAwaitAll = async (web3, stxs, doubtNonceError) => {
+  await Promise.all(
+    stxs.map(tx => {
+      return new Promise(async (resolve, reject) => {
+        const txHash = await sendSignedTransaction(web3, tx, doubtNonceError);
+        await waitForTransactionConfirm(web3, txHash);
+        resolve();
+      });
+    })
+  );
 };
 
 const hexify = val => addHexPrefix(val.toString('hex'));
@@ -231,7 +237,7 @@ export {
   signTransaction,
   sendSignedTransaction,
   waitForTransactionConfirm,
-  isTransactionConfirmed,
+  sendAndAwaitAll,
   TXN_PURPOSE,
   getTxnInfo,
   renderTxnPurpose,

--- a/src/store/network.js
+++ b/src/store/network.js
@@ -20,7 +20,7 @@ function _useNetwork(initialNetworkType = null) {
 
   const setNetworkType = networkType => {
     if (!includes(NETWORK_TYPES, networkType)) {
-      throw BRIDGE_ERROR.INVALID_NETWORK_TYPE;
+      throw new Error(BRIDGE_ERROR.INVALID_NETWORK_TYPE);
     }
     _setNetworkType(networkType);
   };

--- a/src/store/wallet.js
+++ b/src/store/wallet.js
@@ -44,7 +44,7 @@ function _useWallet(initialWallet = Nothing(), initialMnemonic = Nothing()) {
   const setWalletType = useCallback(
     walletType => {
       if (!includes(WALLET_TYPES, walletType)) {
-        throw BRIDGE_ERROR.INVALID_WALLET_TYPE;
+        throw new Error(BRIDGE_ERROR.INVALID_WALLET_TYPE);
       }
 
       _setWalletType(walletType);

--- a/src/views/Invite/InviteEmail.js
+++ b/src/views/Invite/InviteEmail.js
@@ -320,7 +320,7 @@ export default function InviteEmail() {
       try {
         const txHash = await sendSignedTransaction(
           _web3,
-          Just(invite.signedTx),
+          invite.signedTx,
           tankWasUsed,
           () => {}
         );

--- a/src/views/Invite/InviteEmail.js
+++ b/src/views/Invite/InviteEmail.js
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import cn from 'classnames';
-import { Just } from 'folktale/maybe';
 import * as azimuth from 'azimuth-js';
 import {
   Grid,
@@ -247,12 +246,12 @@ export default function InviteEmail() {
           owner.keys.address
         );
         const signedTx = await signTransaction({
-          wallet,
+          wallet: _wallet,
           walletType,
           walletHdPath,
           networkType,
           // TODO: ^ make a useTransactionSigner to encapsulate this logic
-          txn: Just(inviteTx),
+          txn: inviteTx,
           gasPrice: GAS_PRICE_GWEI.toString(),
           gasLimit: GAS_LIMIT.toString(),
           nonce: nonce + i,

--- a/src/views/SentTransaction.js
+++ b/src/views/SentTransaction.js
@@ -125,7 +125,7 @@ function SentTransaction(props) {
 
   const result = txnCursor.matchWith({
     Nothing: _ => {
-      throw BRIDGE_ERROR.MISSING_TXN;
+      throw new Error(BRIDGE_ERROR.MISSING_TXN);
     },
     Just: res => res.value,
   });


### PR DESCRIPTION
As discussed yesterday with @shrugs.

Async-retry seems unreliable when using `Infinity` retries, so we settle for `99999` instead.

`signTransaction` still needs its interface cleaned up. @shrugs I'm thinking the `txn` unsigned transaction object should just contain all of `nonce`, `gas`, etc. instead of passing those in as separate arguments.

We might still care about doing the `toHex` on those arguments though, since we're using `ethereumjs-tx`? Related, we might be able to get rid of the EIP-155 logic here if we [use ethereumjs-tx correctly](https://github.com/ethereumjs/ethereumjs-tx/#chain-and-hardfork-support).