### PR TITLE
Pass number instead of string to azimuth-js

### DIFF
--- a/src/views/IssueChild.js
+++ b/src/views/IssueChild.js
@@ -78,7 +78,7 @@ class IssueChild extends React.Component {
     const validContracts = need.contracts(this.props.contracts);
 
     azimuth
-      .getUnspawnedChildren(validContracts, Number(issuingPoint))
+      .getUnspawnedChildren(validContracts, parseInt(issuingPoint, 10))
       .then(ps => this.setState({ validChildren: new Set(ps.map(ob.patp)) }));
   }
 

--- a/src/views/IssueChild.js
+++ b/src/views/IssueChild.js
@@ -78,7 +78,7 @@ class IssueChild extends React.Component {
     const validContracts = need.contracts(this.props.contracts);
 
     azimuth
-      .getUnspawnedChildren(validContracts, issuingPoint)
+      .getUnspawnedChildren(validContracts, Number(issuingPoint))
       .then(ps => this.setState({ validChildren: new Set(ps.map(ob.patp)) }));
   }
 


### PR DESCRIPTION
This worked at some point. Pretty sure we're flip-flopping types all over the place.