### PR TITLE
InviteEmail hacks

### DIFF
--- a/src/views/Invite/InviteEmail.js
+++ b/src/views/Invite/InviteEmail.js
@@ -413,6 +413,7 @@ export default function InviteEmail() {
       setGeneralError(new Error(`Duplicate email.`));
     } else {
       setGeneralError(null);
+      setStatus(STATUS.INPUT);
     }
   }, [inputs]);
 

--- a/src/views/Invite/InviteEmail.js
+++ b/src/views/Invite/InviteEmail.js
@@ -194,15 +194,14 @@ export default function InviteEmail() {
     await Promise.all(
       inputs.map(async input => {
         const email = input.data;
-        const hasReceived = getHasReceived(email).matchWith({
-          Nothing: () => 'unknown', // loading
-          Just: p => p.value,
+        getHasReceived(email).matchWith({
+          Nothing: () => {
+            knowAll = false;
+          },
+          Just: p => {
+            if (p.value) alreadyReceived.push(email);
+          },
         });
-        if (hasReceived === 'unknown') {
-          knowAll = false;
-        } else if (hasReceived) {
-          alreadyReceived.push(email);
-        }
       })
     );
     if (!knowAll) {


### PR DESCRIPTION
Still haven't managed to fix the "live async email checking" thing. It's weird. When I include `getHasReceived` as a hook dependency, the hook fires when that changes, but doesn't include the new value.

This PR contains two smaller fixes to the user flow for InviteEmail that should make the lack of the above more bearable.