### PR TITLE
Better point "deduction" in Points view

### DIFF
--- a/src/views/Points.js
+++ b/src/views/Points.js
@@ -130,14 +130,14 @@ export default function Points() {
       Just: r => {
         r.value.matchWith({
           Error: () => null,
-          Ok: p => {
+          Ok: c => {
             let all = [
-              ...p.value.ownedPoints,
-              ...p.value.votingPoints,
-              ...p.value.managingPoints,
-              ...p.value.spawningPoints,
+              ...c.value.ownedPoints,
+              ...c.value.votingPoints,
+              ...c.value.managingPoints,
+              ...c.value.spawningPoints,
             ];
-            const incoming = p.value.incomingPoints.filter(
+            const incoming = c.value.incomingPoints.filter(
               p => !rejectedPoints.includes(p)
             );
             if (

--- a/src/views/Points.js
+++ b/src/views/Points.js
@@ -88,19 +88,16 @@ export default function Points() {
     addRejectedPoint,
   ] = useRejectedIncomingPointTransfers();
 
-  const maybeOutgoingPoints = useMemo(() => {
-    return controlledPoints.matchWith({
-      Nothing: () => Nothing(),
-      Just: r =>
-        r.value.matchWith({
+  const maybeOutgoingPoints = useMemo(
+    () =>
+      controlledPoints.chain(points =>
+        points.matchWith({
           Error: () => Nothing(),
           Ok: c => {
             const points = c.value.ownedPoints.map(point =>
-              getDetails(point).matchWith({
-                Nothing: () => Nothing(),
-                Just: p =>
-                  Just({ point: point, has: hasTransferProxy(p.value) }),
-              })
+              getDetails(point).chain(details =>
+                Just({ point: point, has: hasTransferProxy(details) })
+              )
             );
             // if we have details for every point,
             // return the array of pending transfers.
@@ -113,9 +110,10 @@ export default function Points() {
               return Nothing();
             }
           },
-        }),
-    });
-  }, [getDetails, controlledPoints]);
+        })
+      ),
+    [getDetails, controlledPoints]
+  );
 
   // if we can only interact with a single point, forget about the existence
   // of this page and jump to the point page.


### PR DESCRIPTION
By moving the deduction logic into the Points view, we simplify the Login view and avoid looking up owned points twice.

The Points view can then decide what to do.
- If there's more than one point we can interact with, display the points list
- If we can only interact with one point, and it isn't a pending transfer, forward to the Point page, and remove the Points page from history

Remaining work:
- [x] Account for outgoing transfers in the above logic. Need to think a little bit more about how to do that elegantly. Very tempted to just slap `useMemo` on top of everything in Points.js and hook it up that way.