### PR TITLE
Remove Points view from post-Activate stack

### DIFF
--- a/src/views/Activate/PassportTransfer.js
+++ b/src/views/Activate/PassportTransfer.js
@@ -60,7 +60,6 @@ export default function PassportTransfer({ className, resetActivateRouter }) {
     () =>
       replaceWith([
         { key: names.LOGIN },
-        { key: names.POINTS },
         { key: names.POINT },
       ]),
     [replaceWith, names]


### PR DESCRIPTION
We wouldn't display this to them when they log in normally (brand new wallet, only owns a single point), so we shouldn't display it to them when they get routed into Bridge post-activation.

("display" as in put on the router stack)