### PR TITLE
fix: parseInt returns NaN, but we expected it to throw

### DIFF
--- a/src/components/InlineEthereumTransaction.js
+++ b/src/components/InlineEthereumTransaction.js
@@ -23,6 +23,7 @@ import WarningBox from './WarningBox';
 import CopyButton from './CopyButton';
 import ProgressButton from './ProgressButton';
 import CopiableAddress from './CopiableAddress';
+import convertToInt from 'lib/convertToInt';
 
 export default function InlineEthereumTransaction({
   // from useEthereumTransaction.bind
@@ -191,7 +192,9 @@ export default function InlineEthereumTransaction({
                     min="1"
                     max="100"
                     value={gasPrice}
-                    onChange={e => setGasPrice(parseInt(e.target.value, 10))}
+                    onChange={e =>
+                      setGasPrice(convertToInt(e.target.value, 10))
+                    }
                   />
                   <Grid.Item
                     full

--- a/src/form/formatters.js
+++ b/src/form/formatters.js
@@ -1,4 +1,5 @@
 import { compose, strSplice } from 'lib/lib';
+import convertToInt from 'lib/convertToInt';
 
 const HEX_PREFIX = '0x';
 const TICKET_MAX_BYTE_LEN = 32; // tickets can be as large as 32 bytes
@@ -48,8 +49,12 @@ export const ensureHexPrefix = s => {
 };
 
 export const convertToNumber = s => {
+  if (!s) {
+    return s || '';
+  }
+
   try {
-    return parseInt(s, 10);
+    return convertToInt(s, 10);
   } catch {
     return 0;
   }

--- a/src/lib/convertToInt.js
+++ b/src/lib/convertToInt.js
@@ -1,0 +1,17 @@
+import { isNaN } from 'lodash';
+
+/**
+ * a version of parseInt that throws for NaN
+ * fun fact, parseInt also handles 0x-prefixed hex strings, assuming the radix
+ * to be 16
+ *
+ * @throws
+ * @returns {number}
+ */
+export default (num, radix) => {
+  const res = parseInt(num, radix);
+  if (isNaN(res)) {
+    throw new Error('NaN');
+  }
+  return res;
+};

--- a/src/lib/patp2dec.js
+++ b/src/lib/patp2dec.js
@@ -1,9 +1,11 @@
 import * as ob from 'urbit-ob';
 
+import convertToInt from './convertToInt';
+
 /**
  * Convert a patp string into a number, or throw.
  *
  * @throws
  * @return number
  */
-export default patp => parseInt(ob.patp2dec(patp), 10);
+export default patp => convertToInt(ob.patp2dec(patp), 10);

--- a/src/lib/trezor.js
+++ b/src/lib/trezor.js
@@ -1,9 +1,11 @@
 import TrezorConnect from 'trezor-connect';
+import convertToInt from './convertToInt';
 
 const TREZOR_PATH = "m/44'/60'/0'/0/x";
 
+// handles 0x-prefixed hex string as well as number type
 const formatChainId = val =>
-  typeof val === 'number' ? val : parseInt(val.slice(2), 16); // assume 0x-prefixed hex string
+  typeof val === 'number' ? val : convertToInt(val.slice(2), 16);
 
 const trezorSignTransaction = async (txn, hdpath) => {
   const trezorFormattedTxn = {

--- a/src/lib/useKeyfileGenerator.js
+++ b/src/lib/useKeyfileGenerator.js
@@ -16,6 +16,7 @@ import {
   compileNetworkingKey,
 } from './keys';
 import useCurrentPermissions from './useCurrentPermissions';
+import convertToInt from './convertToInt';
 
 export default function useKeyfileGenerator(manualNetworkSeed) {
   const { urbitWallet, wallet, authMnemonic } = useWallet();
@@ -30,7 +31,7 @@ export default function useKeyfileGenerator(manualNetworkSeed) {
   const _point = need.point(pointCursor);
   const _details = need.details(getDetails(_point));
 
-  const networkRevision = parseInt(_details.keyRevisionNumber, 10);
+  const networkRevision = convertToInt(_details.keyRevisionNumber, 10);
   const { isOwner, isManagementProxy } = useCurrentPermissions();
 
   const hasNetworkingKeys = networkRevision > 0;

--- a/src/views/Activate/ActivateCode.js
+++ b/src/views/Activate/ActivateCode.js
@@ -37,6 +37,7 @@ import FormError from 'form/FormError';
 
 import { useActivateFlow } from './ActivateFlow';
 import { WARNING } from 'form/helpers';
+import convertToInt from 'lib/convertToInt';
 
 export default function ActivateCode() {
   const history = useHistory();
@@ -121,7 +122,7 @@ export default function ActivateCode() {
           };
         }
 
-        const point = parseInt(incoming[0], 10);
+        const point = convertToInt(incoming[0], 10);
 
         setDerivedPoint(Just(point));
         setInviteWallet(inviteWallet);

--- a/src/views/Admin/AdminEditPermissions.js
+++ b/src/views/Admin/AdminEditPermissions.js
@@ -19,6 +19,7 @@ import ViewHeader from 'components/ViewHeader';
 import { ForwardButton } from 'components/Buttons';
 import { matchBlinkyDate } from 'components/Blinky';
 import CopyButton from 'components/CopyButton';
+import convertToInt from 'lib/convertToInt';
 
 export default function AdminEditPermissions() {
   const { push, names } = useLocalRouter();
@@ -34,7 +35,7 @@ export default function AdminEditPermissions() {
   const isSenate = pointSize === azimuth.PointSize.Galaxy;
 
   const details = need.details(getDetails(point));
-  const networkRevision = parseInt(details.keyRevisionNumber, 10);
+  const networkRevision = convertToInt(details.keyRevisionNumber, 10);
   const { canManage, isOwner } = useCurrentPermissions();
 
   const goSetProxy = useCallback(

--- a/src/views/Admin/AdminNetworkingKeys.js
+++ b/src/views/Admin/AdminNetworkingKeys.js
@@ -40,6 +40,7 @@ import {
 import BridgeForm from 'form/BridgeForm';
 import Condition from 'form/Condition';
 import FormError from 'form/FormError';
+import convertToInt from 'lib/convertToInt';
 
 const chainKeyProp = name => d =>
   d[name] === CURVE_ZERO_ADDR ? Nothing() : Just(d[name]);
@@ -64,7 +65,7 @@ function useSetKeys() {
   const _contracts = need.contracts(contracts);
   const _details = need.details(getDetails(_point));
 
-  const networkRevision = parseInt(_details.keyRevisionNumber, 10);
+  const networkRevision = convertToInt(_details.keyRevisionNumber, 10);
   const randomSeed = useRef();
 
   // NOTE: nd = 'nondeterministic' (can also be a 'manual' seed)
@@ -151,6 +152,8 @@ export default function AdminNetworkingKeys() {
   const hasKeys = details.matchWith({
     Nothing: () => false,
     Just: ({ value: details }) => parseInt(details.keyRevisionNumber, 10) > 0,
+    // we actually don't mind the default NaN behavior of parseInt here,
+    // since NaN > 0 === false and that's a reasonable result
   });
 
   const {

--- a/src/views/Admin/Reticket/ReticketExecute.js
+++ b/src/views/Admin/Reticket/ReticketExecute.js
@@ -22,6 +22,7 @@ import LoadingBar from 'components/LoadingBar';
 import Highlighted from 'components/Highlighted';
 import { WALLET_TYPES } from 'lib/wallet';
 import CopiableAddress from 'components/CopiableAddress';
+import convertToInt from 'lib/convertToInt';
 
 const labelForProgress = progress => {
   if (progress <= 0) {
@@ -58,7 +59,7 @@ export default function ReticketExecute({ newWallet, setNewWallet }) {
     (async () => {
       const point = need.point(pointCursor);
       const details = need.details(getDetails(point));
-      const networkRevision = parseInt(details.keyRevisionNumber, 10);
+      const networkRevision = convertToInt(details.keyRevisionNumber, 10);
       try {
         await reticketPointBetweenWallets({
           fromWallet: need.wallet(wallet),

--- a/src/views/IssueChild.js
+++ b/src/views/IssueChild.js
@@ -29,6 +29,7 @@ import {
 import BridgeForm from 'form/BridgeForm';
 import FormError from 'form/FormError';
 import CopiableAddress from 'components/CopiableAddress';
+import convertToInt from 'lib/convertToInt';
 
 function useIssueChild() {
   const { contracts } = useNetwork();
@@ -60,7 +61,7 @@ export default function IssueChild() {
   const { pointCursor } = usePointCursor();
 
   const _contracts = need.contracts(contracts);
-  const _point = parseInt(need.point(pointCursor), 10);
+  const _point = convertToInt(need.point(pointCursor), 10);
 
   const availablePointsPromise = useConstant(() =>
     azimuth.azimuth


### PR DESCRIPTION
I was getting a weird behavior around forms when a number input was totally cleared and realized that parseInt doesn't throw, it returns `NaN` when it fails. Which means all of our error handling assumptions about parseInt throughout the app were wrong (i.e., my assumption). 

So this creates a throwing version of parseInt and then uses it everywhere that seems reasonable. 