### PR TITLE
fix: disclaimer freezing because of incorrect router and mount order

### DIFF
--- a/src/Bridge.js
+++ b/src/Bridge.js
@@ -48,12 +48,15 @@ function useInitialRoutes() {
     ];
   }
 
-  return hasImpliedTicket
-    ? [{ key: ROUTE_NAMES.ACTIVATE }]
-    : [
-        { key: ROUTE_NAMES.LOGIN },
-        ...(!hasDisclaimed ? [{ key: ROUTE_NAMES.DISCLAIMER }] : []),
-      ];
+  if (hasImpliedTicket) {
+    return [{ key: ROUTE_NAMES.ACTIVATE }];
+  }
+
+  if (!hasDisclaimed) {
+    return [{ key: ROUTE_NAMES.DISCLAIMER, data: { next: ROUTE_NAMES.LOGIN } }];
+  }
+
+  return [{ key: ROUTE_NAMES.LOGIN }];
 }
 
 function Bridge() {

--- a/src/views/Activate/ActivateCode.js
+++ b/src/views/Activate/ActivateCode.js
@@ -64,10 +64,10 @@ export default function ActivateCode() {
   ]);
 
   const goToPassport = useCallback(() => {
-    push(names.PASSPORT);
-
     if (!hasDisclaimed) {
-      push(names.DISCLAIMER);
+      push(names.DISCLAIMER, { next: names.PASSPORT });
+    } else {
+      push(names.PASSPORT);
     }
   }, [hasDisclaimed, names.DISCLAIMER, names.PASSPORT, push]);
 

--- a/src/views/Disclaimer.js
+++ b/src/views/Disclaimer.js
@@ -2,8 +2,8 @@ import React, { useCallback, useMemo } from 'react';
 import cn from 'classnames';
 import { Grid, H3, B, Text, CheckboxInput } from 'indigo-react';
 
-import { useHistory } from 'store/history';
 import useHasDisclaimed from 'lib/useHasDisclaimed';
+import { useLocalRouter } from 'lib/LocalRouter';
 
 import View from 'components/View';
 import WarningBox from 'components/WarningBox';
@@ -14,7 +14,7 @@ import { composeValidator, buildCheckboxValidator } from 'form/validators';
 const TEXT_STYLE = 'f5';
 
 export default function ActivateDisclaimer() {
-  const { pop } = useHistory();
+  const { pop, popAndPush, data } = useLocalRouter();
   const [, setHasDisclaimed] = useHasDisclaimed();
 
   const validate = useMemo(
@@ -24,10 +24,14 @@ export default function ActivateDisclaimer() {
 
   const initialValues = useMemo(() => ({ checkbox: false }), []);
 
-  const goBack = useCallback(async () => {
+  const goNext = useCallback(async () => {
     setHasDisclaimed(true);
-    pop();
-  }, [pop, setHasDisclaimed]);
+    if (data.next) {
+      popAndPush(data.next);
+    } else {
+      pop();
+    }
+  }, [data, pop, popAndPush, setHasDisclaimed]);
 
   return (
     <View>
@@ -81,7 +85,7 @@ export default function ActivateDisclaimer() {
         </Grid.Item>
         <BridgeForm
           validate={validate}
-          afterSubmit={goBack}
+          afterSubmit={goNext}
           initialValues={initialValues}>
           {({ handleSubmit }) => (
             <>


### PR DESCRIPTION
1) we were mounting PaperCollatteralRenderer and then immediate unmounting it, which I don't think it liked
2) when you follow an activate link, your history stack looks like `[{key: ACTIVATE}]` and your activate router stack looks like `[{key: CODE}]` and then we do something like `[{key: CODE}, {key: PASSPORT}, {key: DISCLAIMER}]` but the disclaimer was always trying to pop `history` not the local router.

So I'd be surprised if activation ever worked for anyone that had not accepted the disclaimer already.

So now we use the `data` parameter in each route to tell the disclaimer page about the next route that should be pushed. that way they 1) mount in the right order and 2) disclaimer just uses its local router (which could also be `history`) to push or pop the next route