### PR TITLE
a11y pass

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,11 +2,13 @@
   "extends": [
     "react-app",
     "prettier",
-    "prettier/react"
+    "prettier/react",
+    "plugin:jsx-a11y/recommended"
   ],
   "plugins": [
     "prettier",
-    "react-hooks"
+    "react-hooks",
+    "jsx-a11y"
   ],
   "rules": {
     "prettier/prettier": "error"

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,7 @@
     "react-app",
     "prettier",
     "prettier/react",
-    "plugin:jsx-a11y/recommended"
+    "plugin:jsx-a11y/strict"
   ],
   "plugins": [
     "prettier",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6254,10 +6254,12 @@
       }
     },
     "eslint-plugin-jsx-a11y": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
-      "integrity": "sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
+      "integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
+      "dev": true,
       "requires": {
+        "@babel/runtime": "^7.4.5",
         "aria-query": "^3.0.0",
         "array-includes": "^3.0.3",
         "ast-types-flow": "^0.0.7",
@@ -6265,7 +6267,28 @@
         "damerau-levenshtein": "^1.0.4",
         "emoji-regex": "^7.0.2",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^2.0.1"
+        "jsx-ast-utils": "^2.2.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+          "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "jsx-ast-utils": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
+          "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
+          "dev": true,
+          "requires": {
+            "array-includes": "^3.0.3",
+            "object.assign": "^4.1.0"
+          }
+        }
       }
     },
     "eslint-plugin-prettier": {
@@ -14680,6 +14703,21 @@
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        },
+        "eslint-plugin-jsx-a11y": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
+          "integrity": "sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==",
+          "requires": {
+            "aria-query": "^3.0.0",
+            "array-includes": "^3.0.3",
+            "ast-types-flow": "^0.0.7",
+            "axobject-query": "^2.0.2",
+            "damerau-levenshtein": "^1.0.4",
+            "emoji-regex": "^7.0.2",
+            "has": "^1.0.3",
+            "jsx-ast-utils": "^2.0.1"
+          }
         },
         "fs-extra": {
           "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "eslint-config-prettier": "^5.0.0",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react-hooks": "^1.6.0",
     "ganache-cli": "^6.2.1",

--- a/src/Bridge.js
+++ b/src/Bridge.js
@@ -18,7 +18,7 @@ import useHasDisclaimed from 'lib/useHasDisclaimed';
 import 'style/index.scss';
 
 const INITIAL_NETWORK_TYPE = isDevelopment
-  ? NETWORK_TYPES.LOCAL
+  ? NETWORK_TYPES.OFFLINE
   : NETWORK_TYPES.MAINNET;
 
 // NB(shrugs): modify these variables to change the default local state.

--- a/src/Bridge.js
+++ b/src/Bridge.js
@@ -15,10 +15,24 @@ import { isDevelopment } from 'lib/flags';
 import useImpliedTicket from 'lib/useImpliedTicket';
 import useHasDisclaimed from 'lib/useHasDisclaimed';
 
-import 'style/index.scss';
+/* Form Reset */
+import 'style/form-reset.scss';
+
+/* Indigo */
+import 'style/indigo-reset.scss';
+import 'indigo-react/indigo.css';
+import 'style/indigo-proposals.scss';
+
+/* Fonts */
+/* we need to load these as base64 (inline) to avoid lazy loading
+   see also #218 */
+import 'style/font64.scss';
+
+/* Bridge Styles */
+import 'style/bridge.scss';
 
 const INITIAL_NETWORK_TYPE = isDevelopment
-  ? NETWORK_TYPES.OFFLINE
+  ? NETWORK_TYPES.LOCAL
   : NETWORK_TYPES.MAINNET;
 
 // NB(shrugs): modify these variables to change the default local state.

--- a/src/components/Accordion.js
+++ b/src/components/Accordion.js
@@ -23,10 +23,12 @@ export default function Accordion({
           <React.Fragment key={option.value}>
             <Grid.Item
               full
-              className={cn('f5 pv3 rel', {
+              as="button"
+              className={cn('button f5 pv3 rel', {
                 pointer: !option.disabled,
                 gray3: option.disabled,
               })}
+              tabIndex="0"
               onClick={
                 option.disabled
                   ? null

--- a/src/components/Crumbs.js
+++ b/src/components/Crumbs.js
@@ -2,9 +2,11 @@ import React from 'react';
 import cn from 'classnames';
 import { Flex, Breadcrumb } from 'indigo-react';
 
+const ButtonCrumb = props => <Breadcrumb as="button" {...props} />;
+
 export default function Crumbs({ className, routes = [] }) {
   const lastIndex = routes.length - 1;
-  const textStyle = 'gray4 mono';
+  const textStyle = 'button gray4 mono';
   return (
     <Flex className={className} row wrap>
       {routes.map((route, i) => {
@@ -13,7 +15,8 @@ export default function Crumbs({ className, routes = [] }) {
         return (
           <React.Fragment key={route.text}>
             <Flex.Item
-              as={Breadcrumb}
+              as={route.action ? ButtonCrumb : Breadcrumb}
+              tabIndex={route.action ? '0' : '-1'}
               onClick={route.action}
               disabled={disabled}
               className={cn(textStyle, { 'pointer underline': !disabled })}>

--- a/src/components/NoticeBox.js
+++ b/src/components/NoticeBox.js
@@ -4,7 +4,10 @@ import { Flex, Text } from 'indigo-react';
 
 export default function NoticeBox({ className, children }) {
   return (
-    <Flex className={cn('bg-gray2 pv3 ph4', className)} align="center">
+    <Flex
+      className={cn('bg-gray2 pv3 ph4', className)}
+      align="center"
+      role="alert">
       <Text className="f6 fw-bold gray4">{children}</Text>
     </Flex>
   );

--- a/src/components/Passport.js
+++ b/src/components/Passport.js
@@ -127,9 +127,10 @@ Passport.Mini = function MiniPassport({ point, className, inverted, ...rest }) {
 
   return (
     <Grid
+      as="button"
       gap={4}
       className={cn(
-        'r8 p4',
+        'button r8 p4',
         {
           'bg-black': !inverted,
           'bg-white b-gray4 b1': inverted,

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -23,9 +23,11 @@ export default function Tabs({
             return (
               <Flex.Item
                 key={option.value}
+                as="button"
+                tabIndex="0"
                 onClick={() => onTabChange(option.value)}
                 className={cn(
-                  'f5 pv3 pointer nowrap',
+                  'button f5 pv3 pointer nowrap',
                   {
                     'black b-black bb1': isActive,
                     gray3: !isActive,

--- a/src/components/UploadButton.js
+++ b/src/components/UploadButton.js
@@ -5,8 +5,8 @@ export default function UploadButton({ children, onChange, ...rest }) {
   const button = useRef();
 
   return (
-    <label htmlFor="file" {...rest}>
-      <Button accessory="↑" solid>
+    <label role="button" tabIndex="0" htmlFor="file" {...rest}>
+      <Button accessory="↑" solid className="w-full">
         {children}
       </Button>
       <input

--- a/src/components/View.js
+++ b/src/components/View.js
@@ -7,6 +7,8 @@ import useBreakpoints from 'lib/useBreakpoints';
 import MiniBackButton from './MiniBackButton';
 import { useHistory } from 'store/history';
 
+const MainFlex = props => <Flex as="main" {...props} />;
+
 // View is a top-level component that all Views must render to inherit styling
 function View({
   className,
@@ -50,14 +52,14 @@ function View({
         className={cn(insetPadding)}>
         {showBackButton && (
           <MiniBackButton
-            hpadding={!isMobile}
-            vpadding={isMobile}
+            hspacing={!isMobile}
+            vspacing={isMobile}
             onClick={goBack}
           />
         )}
       </Flex.Item>
 
-      <Flex.Item flex={1} as={Flex} col justify="between">
+      <Flex.Item flex={1} as={MainFlex} col justify="between">
         <Flex.Item className={cn('pb5', insetPadding)}>{children}</Flex.Item>
         <Flex.Item as={Footer.Target} />
       </Flex.Item>

--- a/src/components/WarningBox.js
+++ b/src/components/WarningBox.js
@@ -4,7 +4,10 @@ import { Flex, Text } from 'indigo-react';
 
 export default function WarningBox({ className, children }) {
   return (
-    <Flex className={cn('bg-red1 pv3 ph4', className)} align="center">
+    <Flex
+      className={cn('bg-red1 pv3 ph4', className)}
+      align="center"
+      role="alert">
       <Text className="f6 fw-bold red3">{children}</Text>
     </Flex>
   );

--- a/src/indigo-react/components/Button.js
+++ b/src/indigo-react/components/Button.js
@@ -6,7 +6,7 @@ import Flex from './Flex';
 import { HelpText } from './Typography';
 
 export default function Button({
-  as: As = 'span',
+  as: As = 'button',
   solid = false,
   success = false,
   disabled = false,
@@ -23,9 +23,10 @@ export default function Button({
   return (
     <Grid
       as={As}
+      tabIndex="0"
       gap={1}
       className={cn(
-        'rel pointer pv4 truncate flex-row justify-between us-none',
+        'button rel pointer pv4 truncate flex-row justify-between us-none',
         {
           p4: solid,
         },
@@ -50,6 +51,8 @@ export default function Button({
         }),
       }}
       onClick={!disabled && onClick ? onClick : undefined}
+      aria-disabled={disabled}
+      disabled={disabled}
       {...rest}>
       {background}
       <Grid.Item full as={Flex} justify="between" className="z2">

--- a/src/indigo-react/components/CheckboxInput.js
+++ b/src/indigo-react/components/CheckboxInput.js
@@ -39,6 +39,8 @@ export default function CheckboxInput({
       <Flex.Item
         flex
         as="label"
+        tabIndex="0"
+        aria-pressed={input.value ? 'true' : 'false'}
         className="f6 mr3 lh-tall us-none pointer flex-row align-center"
         htmlFor={name}>
         <Flex

--- a/src/indigo-react/components/IconButton.js
+++ b/src/indigo-react/components/IconButton.js
@@ -4,26 +4,28 @@ import cn from 'classnames';
 import Flex from './Flex';
 
 export default function IconButton({
+  as: As = 'button',
   children,
   className,
   onClick,
   disabled = false,
   secondary = false,
   solid = false,
-  hpadding = true,
-  vpadding = true,
+  hspacing = true,
+  vspacing = true,
   ...rest
 }) {
   return (
     <Flex
-      as="a"
+      as="button"
+      tabIndex="0"
       align="center"
       justify="center"
       className={cn(
         'pointer',
         {
-          ph2: hpadding,
-          pv2: vpadding,
+          mh2: hspacing,
+          mv2: vspacing,
         },
         {
           'bg-black': solid && !secondary && !disabled,

--- a/src/indigo-react/components/Input.js
+++ b/src/indigo-react/components/Input.js
@@ -53,6 +53,7 @@ export default function Input({
   const showError = !!error;
   const showSubmitError = !!submitError && !dirtySinceLastSubmit;
   const indicateError = touched && !active && (showError || showSubmitError);
+  const errorId = `${name}-error`;
 
   return (
     <Flex
@@ -66,17 +67,20 @@ export default function Input({
       }}>
       <Flex.Item
         as="label"
+        htmlFor={name}
         className={cn('f6 lh-tall', {
           black: !disabled,
           gray4: disabled,
-        })}
-        htmlFor={name}>
+        })}>
         {label}
       </Flex.Item>
       <Flex.Item as={Flex} row className="rel">
         <Flex.Item
           flex
           as={BaseComponent}
+          aria-label={label}
+          aria-labelledby={errorId}
+          aria-invalid={indicateError}
           {...rest}
           // NOTE: 1.15 from input line-height, 24px = 12px * 2 (from p3 styling)
           style={type === 'textarea' ? { minHeight: 'calc(1.5rem * 3)' } : {}}
@@ -119,7 +123,7 @@ export default function Input({
       </Flex.Item>
 
       {indicateError && (
-        <Flex.Item as={ErrorText} className="mv1">
+        <Flex.Item id={errorId} as={ErrorText} className="mv1">
           {error || submitError}
         </Flex.Item>
       )}

--- a/src/indigo-react/components/LinkButton.js
+++ b/src/indigo-react/components/LinkButton.js
@@ -2,7 +2,7 @@ import React from 'react';
 import cn from 'classnames';
 
 export default function LinkButton({
-  as: As = 'a',
+  as: As = 'button',
   disabled = false,
   className,
   onClick,
@@ -11,6 +11,7 @@ export default function LinkButton({
 }) {
   return (
     <As
+      tabIndex="0"
       onClick={!disabled && onClick ? onClick : undefined}
       style={{
         ...(disabled && {
@@ -19,7 +20,7 @@ export default function LinkButton({
         }),
       }}
       className={cn(
-        'us-none pointer underline',
+        'button us-none pointer underline',
         {
           // NOTE: inherit styling from parent otherwise
           gray4: disabled,

--- a/src/indigo-react/components/SelectInput.js
+++ b/src/indigo-react/components/SelectInput.js
@@ -20,7 +20,16 @@ export default function SelectInput({
 }) {
   const {
     input,
-    meta: { active, error, submitting, submitSucceeded, touched, valid },
+    meta: {
+      active,
+      error,
+      submitting,
+      submitSucceeded,
+      submitError,
+      dirtySinceLastSubmit,
+      touched,
+      valid,
+    },
   } = useField(name, {
     type: 'select',
   });
@@ -47,6 +56,11 @@ export default function SelectInput({
 
   const text = options.find(o => o.value === input.value).text;
 
+  const showError = !!error;
+  const showSubmitError = !!submitError && !dirtySinceLastSubmit;
+  const indicateError = touched && !active && (showError || showSubmitError);
+  const errorId = `${name}-error`;
+
   return (
     <Flex
       ref={ref}
@@ -58,12 +72,16 @@ export default function SelectInput({
           cursor: 'not-allowed',
         }),
       }}>
-      <Flex.Item as="label" className="f6 lh-tall" htmlFor={name}>
+      <Flex.Item as="label" htmlFor={name} className="f6 lh-tall">
         {label}
       </Flex.Item>
       <Flex.Item as={Flex} row className="rel pointer" onClick={toggleOpen}>
         <Flex.Item
           flex
+          aria-invalid={indicateError}
+          aria-describedBy={errorId}
+          aria-haspopup="true"
+          aria-expanded={isOpen}
           className={cn(
             'b b1 p3 outline-none',
             { mono },
@@ -101,6 +119,7 @@ export default function SelectInput({
           <Flex
             col
             className="abs bg-white b-black b1 z10"
+            role="menu"
             style={{
               top: 'calc(100% + 4px)',
               left: 0,
@@ -111,6 +130,7 @@ export default function SelectInput({
             {options.map(option => (
               <Flex.Item
                 key={option.value}
+                role="menuitem"
                 className="pv2 ph3 hover-bg-grey3"
                 onClick={e => {
                   e.stopPropagation();
@@ -129,8 +149,8 @@ export default function SelectInput({
         </Flex.Item>
       )}
 
-      {touched && !active && error && (
-        <Flex.Item as={ErrorText} className="mv1">
+      {indicateError && (
+        <Flex.Item id={errorId} as={ErrorText} className="mv1">
           {error}
         </Flex.Item>
       )}

--- a/src/indigo-react/components/ToggleInput.js
+++ b/src/indigo-react/components/ToggleInput.js
@@ -54,6 +54,7 @@ export default function ToggleInput({
         })}
         htmlFor={name}>
         <LinkButton
+          as="span"
           disabled={disabled}
           className={cn('f5', {
             black: !input.checked,

--- a/src/indigo-react/components/Typography.js
+++ b/src/indigo-react/components/Typography.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import cn from 'classnames';
 
-const typeWith = (DefaultComponent, defaultClassName) =>
+const typeWith = (DefaultComponent, defaultClassName, props = {}) =>
   function({ as: As = DefaultComponent, className, ...rest }) {
-    return <As className={cn(defaultClassName, className)} {...rest} />;
+    return (
+      <As className={cn(defaultClassName, className)} {...props} {...rest} />
+    );
   };
 
 export const H1 = typeWith('h1');
@@ -19,4 +21,4 @@ export const B = typeWith('b', 'fw-bold');
 export const Breadcrumb = typeWith('span', 'f6');
 export const Text = typeWith('span');
 export const HelpText = typeWith('span', 'f6 gray4');
-export const ErrorText = typeWith('span', 'f6 red3');
+export const ErrorText = typeWith('span', 'f6 red3', { role: 'alert' });

--- a/src/style/form-reset.scss
+++ b/src/style/form-reset.scss
@@ -18,11 +18,11 @@ select {
   border-radius: 0;
   -webkit-appearance: none;
 
-  &:focus,
-  &:hover,
-  &:active {
-    outline: 0;
-  }
+  // &:focus,
+  // &:hover,
+  // &:active {
+  //   outline: 0;
+  // }
 
   &::-moz-focus-inner {
     border: 0;

--- a/src/style/indigo-reset.scss
+++ b/src/style/indigo-reset.scss
@@ -1,0 +1,6 @@
+
+.button {
+  background-color: inherit; // FF reset
+  text-align: inherit; // chrome, FF reset
+  -webkit-appearance: none; // chrome reset
+}

--- a/src/views/Activate/PassportTransfer.js
+++ b/src/views/Activate/PassportTransfer.js
@@ -145,8 +145,8 @@ export default function PassportTransfer({ className, resetActivateRouter }) {
     if (generalError) {
       return (
         <>
-          <Grid.Item full className="mt8">
-            <ErrorText>{generalError.message.toString()}</ErrorText>
+          <Grid.Item full as={ErrorText} className="mt8">
+            {generalError.message.toString()}
           </Grid.Item>
           <Grid.Item
             full

--- a/src/views/Admin/Reticket/ReticketExecute.js
+++ b/src/views/Admin/Reticket/ReticketExecute.js
@@ -112,8 +112,8 @@ export default function ReticketExecute({ newWallet, setNewWallet }) {
     if (generalError) {
       return (
         <>
-          <Grid.Item full className="mt4">
-            <ErrorText>{generalError.message.toString()}</ErrorText>
+          <Grid.Item full as={ErrorText} className="mt4">
+            {generalError.message.toString()}
           </Grid.Item>
           <Grid.Item
             full

--- a/src/views/Invite/InviteEmail.js
+++ b/src/views/Invite/InviteEmail.js
@@ -564,6 +564,8 @@ export default function InviteEmail() {
                             full
                             as={Grid}
                             gap={3}
+                            onFocus={() => setHovered({ [name]: true })}
+                            onBlur={() => setHovered({ [name]: false })}
                             onMouseOver={() => setHovered({ [name]: true })}
                             onMouseLeave={() => setHovered({ [name]: false })}>
                             <Grid.Item

--- a/src/views/Login/PrivateKey.js
+++ b/src/views/Login/PrivateKey.js
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
+import cn from 'classnames';
 import { Just, Nothing } from 'folktale/maybe';
 import { Grid } from 'indigo-react';
 
@@ -41,7 +42,7 @@ export default function PrivateKey({ className, goHome }) {
   );
 
   return (
-    <Grid className={className}>
+    <Grid className={cn(className, 'mb4')}>
       <BridgeForm validate={validate} onValues={onValues} afterSubmit={goHome}>
         {({ handleSubmit }) => (
           <>

--- a/src/views/Points.js
+++ b/src/views/Points.js
@@ -202,11 +202,6 @@ export default function Points() {
     push,
   ]);
 
-  const goViewPoint = useCallback(() => push(names.VIEW_POINT), [
-    names.VIEW_POINT,
-    push,
-  ]);
-
   return (
     <View pop={pop} inset>
       <Grid>
@@ -324,13 +319,6 @@ export default function Points() {
                 <Grid.Divider />
               </>
             )}
-            <Grid.Item
-              full
-              as={ForwardButton}
-              detail="View a point"
-              onClick={goViewPoint}>
-              View a point
-            </Grid.Item>
           </Grid>
         </Footer>
       </Grid>


### PR DESCRIPTION
I'm doing an accessibility pass, mostly around forms and navigation. learning a11y as I go, so please double check my work.

notes:
- `aria-required` is tough to add since our 'required' validation is in the client-side validators, not within our view layer at all. plus some fields are conditionally required, which makes things a bit harder.
- because of our design token approach, it's impossible to implement generalized selectors for resetting `button` styles, since the `button { background-color: inherit; }` selector is more specific than `bg-red`. So 

references:
- https://bitsofco.de/using-aria-live/
  - using this site as a reference, I chose not to add the aria-live attribute to our warning messages, since they only recommend adding the attribute to static elements, and our warnings are not static at all. my hunch is that the new `role="alert"` on `ErrorText` will help a lot for screenreaders and handling errors.
- https://developer.mozilla.org/en-US/docs/Learn/Accessibility/HTML
- https://www.w3.org/WAI/tutorials/forms/notifications/
- https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA21.html
- https://webaim.org/techniques/formvalidation/
- https://webaim.org/techniques/keyboard/