### PR TITLE
Bridge: Integrating next urbit.org navigation

### DIFF
--- a/src/Bridge.js
+++ b/src/Bridge.js
@@ -3,6 +3,8 @@ import { hot } from 'react-hot-loader/root';
 import { Just, Nothing } from 'folktale/maybe';
 import { IndigoApp } from 'indigo-react';
 
+import Header from 'components/Header';
+
 import Router from 'components/Router';
 
 import Provider from 'store/Provider';
@@ -71,6 +73,7 @@ function Bridge() {
       initialWallet={INITIAL_WALLET}
       initialMnemonic={INITIAL_MNEMONIC}
       initialPointCursor={INITIAL_POINT_CURSOR}>
+      <Header />
       <IndigoApp>
         <Router />
       </IndigoApp>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,0 +1,17 @@
+import React, { Component } from 'react';
+
+export class Header extends Component {
+  render() {
+    return (
+      <nav class="absolute-ns mb2-ns pl6 pt7 f5">
+        <a class="gray3" href="/">
+          Urbit
+        </a>
+        <span class="gray3"> / </span>
+        <a href="/">Bridge</a>
+      </nav>
+    );
+  }
+}
+
+export default Header;

--- a/src/views/Login.js
+++ b/src/views/Login.js
@@ -78,7 +78,7 @@ export default function Login() {
   return (
     <View pop={pop} inset>
       <Grid>
-        <Grid.Item full as={Crumbs} routes={[{ text: 'Bridge' }]} />
+        <Grid.Item full as={Crumbs} />
         <Grid.Item full as={H4} className="mt4">
           Login
         </Grid.Item>


### PR DESCRIPTION
Unifying navigation across our sites by integrating the next urbit.org nav style into the header of Bridge. [Example](https://boring-turing-42360d.netlify.com/posts/essays/).

- Removes "Bridge" monospace crumb.
- Adds a header component on all pages.
- Positioned absolute on desktop, static on smaller viewports to prevent margin and overlap issues. 

Desktop and mobile example:
<img width="1420" alt="Screen Shot 2019-09-04 at 1 15 21 PM" src="https://user-images.githubusercontent.com/20846414/64276788-c3a34c80-cf16-11e9-94e2-276313fdbe90.png">

<img width="501" alt="Screen Shot 2019-09-04 at 1 15 12 PM" src="https://user-images.githubusercontent.com/20846414/64276801-c8680080-cf16-11e9-9533-ed62ba3d2c95.png">


