### PR TITLE
Use toBN for balances in NeedFundsNotice

### DIFF
--- a/src/components/NeedFundsNotice.js
+++ b/src/components/NeedFundsNotice.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fromWei } from 'web3-utils';
+import { fromWei, toBN } from 'web3-utils';
 
 import Highlighted from './Highlighted';
 import CopiableAddress from './CopiableAddress';
@@ -16,9 +16,9 @@ export default function NeedFundsNotice({
     <WarningBox {...rest}>
       <Highlighted warning>
         Your ownership address <CopiableAddress>{address}</CopiableAddress>{' '}
-        needs at least {fromWei(minBalance)} ETH and currently has{' '}
-        {fromWei(balance)} ETH. The transaction will automatically resume once
-        enough ETH is available. Waiting... <Blinky />
+        needs at least {fromWei(toBN(minBalance))} ETH and currently has{' '}
+        {fromWei(toBN(balance))} ETH. The transaction will automatically resume
+        once enough ETH is available. Waiting... <Blinky />
       </Highlighted>
     </WarningBox>
   );


### PR DESCRIPTION
In a somewhat similar vein as #239, we need to make sure arguments to `fromWei` aren't of the 
`number` type.

This wraps the arguments to `fromWei` calls in `NeedFundsNotice` in `toBN`, which should ensure always-sane behavior here, and should fix the issue described in #291. (Instead displaying the notice properly, as is expected behavior.)