### PR TITLE
Allow for batching of transactions

### DIFF
--- a/src/components/InlineEthereumTransaction.js
+++ b/src/components/InlineEthereumTransaction.js
@@ -10,8 +10,9 @@ import {
   Text,
 } from 'indigo-react';
 
-import { useExploreTxUrl } from 'lib/explorer';
+import { useExploreTxUrl, useExploreTxUrls } from 'lib/explorer';
 import { hexify } from 'lib/txn';
+import pluralize from 'lib/pluralize';
 
 import { composeValidator, buildCheckboxValidator } from 'form/validators';
 import BridgeForm from 'form/BridgeForm';
@@ -38,11 +39,11 @@ export default function InlineEthereumTransaction({
   gasPrice,
   setGasPrice,
   resetGasPrice,
-  txHash,
+  txHashes,
   nonce,
   chainId,
   needFunds,
-  signedTransaction,
+  signedTransactions,
   confirmationProgress,
 
   // additional from parent
@@ -60,8 +61,6 @@ export default function InlineEthereumTransaction({
   const canBroadcast = signed && !needFunds;
   // show signed tx only when signing (for offline usage)
   const showSignedTx = signed;
-
-  const exploreTxUrl = useExploreTxUrl(txHash);
 
   const validate = useMemo(
     () =>
@@ -131,9 +130,11 @@ export default function InlineEthereumTransaction({
     }
   };
 
-  const serializedTxHex = useMemo(
-    () => signedTransaction && hexify(signedTransaction.serialize()),
-    [signedTransaction]
+  const serializedTxsHex = useMemo(
+    () =>
+      signedTransactions &&
+      signedTransactions.map(stx => hexify(stx.serialize())),
+    [signedTransactions]
   );
 
   return (
@@ -218,37 +219,11 @@ export default function InlineEthereumTransaction({
                   disabled={!showSignedTx}
                 />
                 <Condition when="viewSigned" is={true}>
-                  <Grid.Divider />
-                  <Grid.Item
-                    full
-                    as={Flex}
-                    justify="between"
-                    className="pv4 black f5">
-                    <Flex.Item>Nonce</Flex.Item>
-                    <Flex.Item>{nonce}</Flex.Item>
-                  </Grid.Item>
-                  <Grid.Divider />
-                  <Grid.Item
-                    full
-                    as={Flex}
-                    justify="between"
-                    className="pv4 black f5">
-                    <Flex.Item>Gas Price</Flex.Item>
-                    <Flex.Item>{gasPrice.toFixed()} Gwei</Flex.Item>
-                  </Grid.Item>
-                  <Grid.Divider />
-                  <Grid.Item
-                    full
-                    as={Flex}
-                    justify="between"
-                    className="mt3 mb2">
-                    <Flex.Item as={H5}>Signed Transaction Hex</Flex.Item>
-                    <Flex.Item as={CopyButton} text={serializedTxHex} />
-                  </Grid.Item>
-                  <Grid.Item full as="code" className="mb4 f6 mono gray4 wrap">
-                    {serializedTxHex}
-                  </Grid.Item>
-                  <Grid.Divider />
+                  <SignedTransactionList
+                    serializedTxsHex={serializedTxsHex}
+                    gasPrice={gasPrice}
+                    nonce={nonce}
+                  />
                 </Condition>
               </>
             )}
@@ -256,20 +231,8 @@ export default function InlineEthereumTransaction({
             {showReceipt && (
               <>
                 <Grid.Divider />
-                <Grid.Item full as={Flex} col className="pv4">
-                  <Flex.Item as={Flex} row justify="between">
-                    <Flex.Item as={H5}>Transaction Hash</Flex.Item>
-                    <Flex.Item as={LinkButton} href={exploreTxUrl}>
-                      Etherscan↗
-                    </Flex.Item>
-                  </Flex.Item>
-                  <Flex.Item as={Flex}>
-                    <Flex.Item flex as="code" className="f6 mono gray4 wrap">
-                      {txHash}
-                    </Flex.Item>
-                    <Flex.Item flex />
-                  </Flex.Item>
-                </Grid.Item>
+                <HashReceiptList txHashes={txHashes} />
+
                 <Grid.Divider />
               </>
             )}
@@ -286,5 +249,63 @@ export default function InlineEthereumTransaction({
         )}
       </BridgeForm>
     </Grid>
+  );
+}
+
+function SignedTransactionList({ serializedTxsHex, nonce, gasPrice }) {
+  return serializedTxsHex.map((serializedTxHex, i) => (
+    <React.Fragment key="i">
+      <Grid.Divider />
+      <Grid.Item full as={Flex} justify="between" className="pv4 black f5">
+        <Flex.Item>Nonce</Flex.Item>
+        <Flex.Item>{nonce + i}</Flex.Item>
+      </Grid.Item>
+      <Grid.Divider />
+      <Grid.Item full as={Flex} justify="between" className="pv4 black f5">
+        <Flex.Item>Gas Price</Flex.Item>
+        <Flex.Item>{gasPrice.toFixed()} Gwei</Flex.Item>
+      </Grid.Item>
+      <Grid.Divider />
+      <Grid.Item full as={Flex} justify="between" className="mt3 mb2">
+        <Flex.Item as={H5}>Signed Transaction Hex</Flex.Item>
+        <Flex.Item as={CopyButton} text={serializedTxHex} />
+      </Grid.Item>
+      <Grid.Item full as="code" className="mb4 f6 mono gray4 wrap">
+        {serializedTxHex}
+      </Grid.Item>
+      <Grid.Divider />
+    </React.Fragment>
+  ));
+}
+
+function HashReceiptList({ txHashes }) {
+  const txUrls = useExploreTxUrls(txHashes);
+  const header = pluralize(txHashes.length, 'Hash', 'Hashes');
+  return (
+    <>
+      <Grid.Divider />
+      <Grid.Item full as={Flex} col className="pv4">
+        <Flex.Item as={H5}>Transaction {header}</Flex.Item>
+
+        {txHashes &&
+          txHashes.map((txHash, i) => (
+            <Flex.Item as={Flex}>
+              <>
+                <Flex.Item
+                  key={i}
+                  flex
+                  as="code"
+                  className="f6 mono gray4 wrap">
+                  {txHash}
+                </Flex.Item>
+                <Flex.Item as={LinkButton} href={txUrls[i]}>
+                  Etherscan↗
+                </Flex.Item>
+              </>
+            </Flex.Item>
+          ))}
+      </Grid.Item>
+      <Grid.Divider />
+    </>
   );
 }

--- a/src/lib/explorer.js
+++ b/src/lib/explorer.js
@@ -20,6 +20,11 @@ export function useExploreTxUrl(txHash) {
 
   return `${domain}/tx/${txHash}`;
 }
+export function useExploreTxUrls(txHashes = []) {
+  const domain = useEtherscanDomain();
+
+  return txHashes.map(txHash => `${domain}/tx/${txHash}`);
+}
 
 export function useExploreAddressUrl(address) {
   const domain = useEtherscanDomain();

--- a/src/lib/useEthereumTransaction.js
+++ b/src/lib/useEthereumTransaction.js
@@ -66,14 +66,14 @@ export default function useEthereumTransaction(
   const [nonce, setNonce] = useState();
   const { gasPrice, setGasPrice, resetGasPrice } = useGasPrice(initialGasPrice);
   const [gasLimit] = useState(initialGasLimit);
-  const [unsignedTransaction, setUnsignedTransaction] = useState();
-  const [signedTransaction, setSignedTransaction] = useState();
-  const [txHash, setTxHash] = useState();
+  const [unsignedTransactions, setUnsignedTransactions] = useState();
+  const [signedTransactions, setSignedTransactions] = useState();
+  const [txHashes, setTxHashes] = useState();
   const [needFunds, setNeedFunds] = useState();
   const [confirmationProgress, setConfirmationProgress] = useState(0.0);
 
   const initializing = nonce === undefined || chainId === undefined;
-  const constructed = !!unsignedTransaction;
+  const constructed = !!unsignedTransactions;
   const isDefaultState = state === STATE.NONE;
   const signed = state === STATE.SIGNED;
   const broadcasted = state === STATE.BROADCASTED;
@@ -88,31 +88,39 @@ export default function useEthereumTransaction(
 
   const construct = useCallback(
     async (...args) =>
-      setUnsignedTransaction(await transactionBuilder(...args)),
+      setUnsignedTransactions(await transactionBuilder(...args)),
     [transactionBuilder]
   );
 
-  const unconstruct = useCallback(() => setUnsignedTransaction(undefined), [
-    setUnsignedTransaction,
+  const unconstruct = useCallback(() => setUnsignedTransactions(undefined), [
+    setUnsignedTransactions,
   ]);
 
   const generateAndSign = useCallback(async () => {
     try {
       setError(undefined);
 
-      const txn = await signTransaction({
-        wallet: _wallet,
-        walletType,
-        walletHdPath,
-        networkType,
-        txn: unsignedTransaction,
-        nonce,
-        chainId,
-        gasPrice: gasPrice.toFixed(0),
-        gasLimit,
-      });
+      const utxs = Array.isArray(unsignedTransactions)
+        ? unsignedTransactions
+        : [unsignedTransactions];
 
-      setSignedTransaction(txn);
+      const txns = await Promise.all(
+        utxs.map((utx, i) =>
+          signTransaction({
+            wallet: _wallet,
+            walletType,
+            walletHdPath,
+            networkType,
+            txn: utx,
+            nonce: nonce + i,
+            chainId,
+            gasPrice: gasPrice.toFixed(0),
+            gasLimit,
+          })
+        )
+      );
+
+      setSignedTransactions(txns);
       setState(STATE.SIGNED);
     } catch (error) {
       setError(error);
@@ -125,7 +133,7 @@ export default function useEthereumTransaction(
     networkType,
     nonce,
     setError,
-    unsignedTransaction,
+    unsignedTransactions,
     walletHdPath,
     walletType,
   ]);
@@ -135,10 +143,12 @@ export default function useEthereumTransaction(
       setConfirmationProgress(0.0);
       setError(undefined);
 
-      const rawTx = hexify(signedTransaction.serialize());
-      const costGwei = toBN(gasLimit).mul(toBN(gasPrice));
-      const cost = toWei(costGwei.toString(), 'gwei');
+      const rawTxs = signedTransactions.map(stx => hexify(stx.serialize()));
 
+      const costGwei = toBN(gasLimit)
+        .mul(toBN(gasPrice))
+        .mul(toBN(rawTxs.length));
+      const cost = toWei(costGwei.toString(), 'gwei');
       let usedTank = false;
       // if this ethereum transaction is being executed by a specific point
       // see if we can use the tank
@@ -148,27 +158,35 @@ export default function useEthereumTransaction(
           pointCursor.value,
           _wallet.address,
           cost,
-          [rawTx],
+          rawTxs,
           (address, minBalance, balance) =>
             setNeedFunds({ address, minBalance, balance }),
           () => setNeedFunds(undefined)
         );
       }
 
-      const txHash = await sendSignedTransaction(
-        _web3,
-        signedTransaction,
-        /* doubtNonceError */ usedTank
+      const txHashes = await signedTransactions.reduce(
+        (acc, stx) =>
+          acc.then(hashes =>
+            sendSignedTransaction(
+              _web3,
+              stx,
+              /* doubtNonceError */ usedTank
+            ).then(hash => [...hashes, hash])
+          ),
+        Promise.resolve([])
       );
 
+      setTxHashes(txHashes);
       setState(STATE.BROADCASTED);
-      setTxHash(txHash);
 
       await timeout(PROGRESS_ANIMATION_DELAY_MS);
 
       setConfirmationProgress(0.2);
 
-      await waitForTransactionConfirm(_web3, txHash);
+      await Promise.all(
+        txHashes.map(txHash => waitForTransactionConfirm(_web3, txHash))
+      );
 
       setConfirmationProgress(0.9);
 
@@ -183,12 +201,12 @@ export default function useEthereumTransaction(
     gasPrice,
     pointCursor,
     setError,
-    signedTransaction,
+    signedTransactions,
   ]);
 
   const reset = useCallback(() => {
-    setTxHash(undefined);
-    setSignedTransaction(undefined);
+    setTxHashes(undefined);
+    setSignedTransactions(undefined);
     setNonce(undefined);
     setChainId(undefined);
     resetGasPrice();
@@ -283,8 +301,8 @@ export default function useEthereumTransaction(
     error,
     inputsLocked,
     confirmationProgress,
-    txHash,
-    signedTransaction,
+    txHashes,
+    signedTransactions,
     gasPrice,
     setGasPrice,
     resetGasPrice,


### PR DESCRIPTION
The Azimuth delayed release contracts only allow for one star to be
withdrawn at a time. This change reworks the ethereum transaction
logic to allow for a batch of transactions to be executed at once.
---
Will these changes break anything ethereum-wise? Is there anything 
else I should be concerned about when batching transactions?
Happy to merge this separately to the linear-release work or both
together.