### PR TITLE
Loading screen on points view

### DIFF
--- a/src/views/Points.js
+++ b/src/views/Points.js
@@ -206,6 +206,23 @@ export default function Points() {
     push,
   ]);
 
+  if (
+    loading ||
+    (allPoints.length === 1 &&
+      ownedPoints.length === 1 &&
+      outgoingPoints.length === 0)
+  ) {
+    return (
+      <View inset pop={pop}>
+        <Grid>
+          <Grid.Item full as={HelpText} className="mt8 t-center">
+            <Blinky /> Loading...
+          </Grid.Item>
+        </Grid>
+      </View>
+    );
+  }
+
   return (
     <View pop={pop} inset>
       <Grid>
@@ -214,12 +231,6 @@ export default function Points() {
             {abbreviateAddress(address)}
           </CopiableAddress>
         </Grid.Item>
-
-        {loading && (
-          <Grid.Item full as={HelpText} className="mt8 t-center">
-            <Blinky /> Loading...
-          </Grid.Item>
-        )}
 
         {displayEmptyState && (
           <Grid.Item full as={HelpText} className="mt8 t-center">

--- a/src/views/Points.js
+++ b/src/views/Points.js
@@ -209,7 +209,7 @@ export default function Points() {
   if (
     loading ||
     (allPoints.length === 1 &&
-      ownedPoints.length === 1 &&
+      incomingPoints.length === 0 &&
       outgoingPoints.length === 0)
   ) {
     return (

--- a/src/views/Points.js
+++ b/src/views/Points.js
@@ -11,7 +11,7 @@ import { usePointCursor } from 'store/pointCursor';
 import * as need from 'lib/need';
 import { isZeroAddress, abbreviateAddress } from 'lib/wallet';
 import useIsEclipticOwner from 'lib/useIsEclipticOwner';
-import { useSyncKnownPoints } from 'lib/useSyncPoints';
+import { useSyncKnownPoints, useSyncOwnedPoints } from 'lib/useSyncPoints';
 import useRejectedIncomingPointTransfers from 'lib/useRejectedIncomingPointTransfers';
 import pluralize from 'lib/pluralize';
 
@@ -195,6 +195,8 @@ export default function Points() {
     ...votingPoints,
     ...spawningPoints,
   ]);
+
+  useSyncOwnedPoints(ownedPoints);
 
   const goCreateGalaxy = useCallback(() => push(names.CREATE_GALAXY), [
     names.CREATE_GALAXY,


### PR DESCRIPTION
Shows a loading indicator when chain state is loading, so that
Urbit HD wallets immediately show the (only) point view instead
of flashing through the point select view.