### PR TITLE
Remove noisy printf from Passport

### DIFF
--- a/src/components/Passport.js
+++ b/src/components/Passport.js
@@ -22,8 +22,6 @@ function makeSigil(size, patp, colors) {
     renderer: reactRenderer,
   };
 
-  console.log(patp);
-
   // Planet
   if (patp.length === 14) {
     return sigil({


### PR DESCRIPTION
This thing is _loud_. It gets called on every re-render of the passport, and we aren't conservative with our re-rendering at all, so...