### PR TITLE
Networking keys config: hex lengths

### DIFF
--- a/src/views/Admin/AdminNetworkingKeys.js
+++ b/src/views/Admin/AdminNetworkingKeys.js
@@ -355,7 +355,7 @@ export default function AdminNetworkingKeys() {
                     full
                     as={HexInput}
                     name="networkSeed"
-                    label="Network Seed (64 bytes)"
+                    label="Network Seed (32 bytes)"
                     disabled={inputsLocked}
                   />
                 </Condition>

--- a/src/views/Admin/AdminNetworkingKeys.js
+++ b/src/views/Admin/AdminNetworkingKeys.js
@@ -97,7 +97,7 @@ function useSetKeys() {
           return networkSeed.value;
         }
 
-        randomSeed.current = randomSeed.current || randomHex(64);
+        randomSeed.current = randomSeed.current || randomHex(32); // 32 bytes
         setNdNetworkSeed(randomSeed.current);
 
         return randomSeed.current;
@@ -178,7 +178,7 @@ export default function AdminNetworkingKeys() {
       composeValidator(
         {
           useNetworkSeed: buildCheckboxValidator(),
-          networkSeed: buildHexValidator(32),
+          networkSeed: buildHexValidator(64), // 64 chars
           useDiscontinuity: buildCheckboxValidator(),
         },
         validateForm


### PR DESCRIPTION
Web3's randomHex generates bytes, not characters. This makes sure we generate random seeds at a length consistent with the seeds produced by keygen.

Our buildHexValidator takes a length in characters, not bytes. This makes sure we validate accordingly.

(Arguably, hexValidator should take length in bytes also, but I don't want to go up-end that right now.)