### PR TITLE
Use latest urbit-key-generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17845,9 +17845,9 @@
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
     "urbit-key-generation": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/urbit-key-generation/-/urbit-key-generation-0.17.3.tgz",
-      "integrity": "sha512-9mtWS10WS/OEMzaW9C0m0rDmtuCJ9BMHF4tSyJfjIDlf97pxTz6MNIMGlXP8CrRs3Z3rTVgb3eU9I69KcAc7cg==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/urbit-key-generation/-/urbit-key-generation-0.17.4.tgz",
+      "integrity": "sha512-cheWFbCm9IhLmLLrR7uN/liySYwb/6VBuThDoDXHOb/hHt5yckri5MFq4RK+s0pe5RVEs2psbGKpUgyg3c2UWg==",
       "requires": {
         "argon2-wasm": "^0.9.0",
         "bip32": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-teleporter": "^1.1.0",
     "secp256k1": "^3.5.2",
     "trezor-connect": "^7.0.1",
-    "urbit-key-generation": "^0.17.3",
+    "urbit-key-generation": "^0.17.4",
     "urbit-ob": "^4.1.4",
     "urbit-paper-renderer": "^2.0.9",
     "urbit-sigil-js": "^1.3.5",


### PR DESCRIPTION
Gonna go ahead and self-merge this, as it seems trivial enough, and I want to pull it into a release build. Have tested that networking keygen (prime motivator for the keygen-js update) works fine.