### PR TITLE
prevent users bailing midway through activate

### DIFF
--- a/src/lib/useBlockWindowClose.js
+++ b/src/lib/useBlockWindowClose.js
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+
+function onBeforeUnload(e) {
+  e.preventDefault();
+
+  e.returnValue = '';
+}
+
+export default function useBlockWindowClose() {
+  return useEffect(() => {
+    window.addEventListener('beforeunload', onBeforeUnload);
+
+    return function cleanup() {
+      window.removeEventListener('beforeunload', onBeforeUnload);
+    };
+  });
+}

--- a/src/views/Activate/PassportTransfer.js
+++ b/src/views/Activate/PassportTransfer.js
@@ -8,6 +8,7 @@ import { usePointCursor } from 'store/pointCursor';
 
 import * as need from 'lib/need';
 import useLifecycle from 'lib/useLifecycle';
+import useBlockWindowClose from 'lib/useBlockWindowClose';
 import {
   reticketPointBetweenWallets,
   TRANSACTION_PROGRESS,
@@ -59,6 +60,8 @@ export default function PassportTransfer({ className, resetActivateRouter }) {
     () => replaceWith([{ key: names.LOGIN }, { key: names.POINT }]),
     [replaceWith, names]
   );
+
+  useBlockWindowClose();
 
   const goToRestart = useCallback(() => {
     // NOTE: because we're already on the ACTIVATE view in the history,

--- a/src/views/Admin/Reticket/ReticketExecute.js
+++ b/src/views/Admin/Reticket/ReticketExecute.js
@@ -10,6 +10,7 @@ import * as need from 'lib/need';
 import useLifecycle from 'lib/useLifecycle';
 import { WALLET_TYPES } from 'lib/wallet';
 import convertToInt from 'lib/convertToInt';
+import useBlockWindowClose from 'lib/useBlockWindowClose';
 
 import { useNetwork } from 'store/network';
 import { useWallet } from 'store/wallet';
@@ -51,6 +52,8 @@ export default function ReticketExecute({ newWallet, setNewWallet }) {
   const [progress, setProgress] = useState(0);
   const [needFunds, setNeedFunds] = useState();
   const isDone = progress >= 1.0;
+
+  useBlockWindowClose();
 
   // start reticketing transactions on mount
   useLifecycle(() => {


### PR DESCRIPTION
Tries to stop users bailing midway through the activation flow. [Sadly](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload) we can't give any custom warning message.