### PR TITLE
Warn about unset networking keys when setting up pools

### DIFF
--- a/src/views/Party/PartySetPoolSize.js
+++ b/src/views/Party/PartySetPoolSize.js
@@ -13,6 +13,7 @@ import { GAS_LIMITS } from 'lib/constants';
 import { useLocalRouter } from 'lib/LocalRouter';
 import useCurrentPermissions from 'lib/useCurrentPermissions';
 import patp2dec from 'lib/patp2dec';
+import convertToInt from 'lib/convertToInt';
 
 import ViewHeader from 'components/ViewHeader';
 import InlineEthereumTransaction from 'components/InlineEthereumTransaction';
@@ -56,6 +57,15 @@ function useSetPoolSize() {
 export default function PartySetPoolSize() {
   const { pop } = useLocalRouter();
   const { contracts } = useNetwork();
+  const { pointCursor } = usePointCursor();
+  const { getDetails } = usePointCache();
+
+  const _point = need.point(pointCursor);
+  const _details = need.details(getDetails(_point));
+  const hasKeysSet =
+    0 !== convertToInt(_details.encryptionKey, 16) &&
+    0 !== convertToInt(_details.authenticationKey, 16) &&
+    0 !== _details.cryptoSuiteVersion;
 
   const _contracts = need.contracts(contracts);
 
@@ -104,7 +114,14 @@ export default function PartySetPoolSize() {
             <CopiableAddress>
               {_contracts.delegatedSending.address}
             </CopiableAddress>{' '}
-            for invitations to be available.
+            for invitations to be available for use.
+          </Grid.Item>
+        )}
+
+        {!hasKeysSet && (
+          <Grid.Item full as={WarningBox} className="mb4 f6">
+            Networking keys must be configured for invitations to be available
+            for use.
           </Grid.Item>
         )}
 


### PR DESCRIPTION
The Delegated Sending contract requires that networking keys for the star have been configured at least once. We weren't warning the user about that. This PR makes it so that we do. To avoid nasty star-isn't-live situations, we also warn if keys are _currently_ unconfigured.

(Yes, this means two separate warnings can show. Also idk why these are red instead of yellow. They don't actually stop you from doing this flow.)

<img width="490" alt="image" src="https://user-images.githubusercontent.com/3829764/70364712-036b2e80-188e-11ea-9921-6ea0758e4945.png">

This is the Bridge-side half of urbit/azimuth-js#55. Once that's merged and assimilated  into Bridge, the meaning of "available for use" here will change from "invite tx could crash" to "won't count as usable invite".