### PR TITLE
Link to raw proposal documents instead of Github page

### DIFF
--- a/src/views/Senate.js
+++ b/src/views/Senate.js
@@ -140,7 +140,7 @@ export default function Senate() {
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href={`https://github.com/urbit/azimuth/blob/master/proposals/${doc}.txt`}>
+            href={`https://raw.githubusercontent.com/urbit/azimuth/master/proposals/${doc}.txt`}>
             <code>{doc}</code>↗
           </a>
         </Grid.Item>


### PR DESCRIPTION
Seems slightly cleaner, especially considering long lines actually wrap within the browser window this way.