### PR TITLE
Fix numbers-as-string bug on Senate page

### DIFF
--- a/src/views/Senate.js
+++ b/src/views/Senate.js
@@ -90,7 +90,7 @@ export default function Senate() {
     let polls = {};
     for (let doc of proposals) {
       let poll = await azimuth.polls.getDocumentPoll(_contracts, doc);
-      poll.endTime = polls.start + poll.duration;
+      poll.endTime = convertToInt(poll.start) + convertToInt(poll.duration);
       poll.hasVoted = await azimuth.polls.hasVotedOnDocumentPoll(
         _contracts,
         _point,


### PR DESCRIPTION
Gonna go ahead and self-merge this because it's a trivial fix for a dumb issue. This way it won't show expired polls.