### PR TITLE
Only validate number upper bound if specified

### DIFF
--- a/src/form/validators.js
+++ b/src/form/validators.js
@@ -104,8 +104,13 @@ export const buildAddressValidator = () =>
     validateNotNullAddress,
     validateEthereumAddress,
   ]);
-export const buildNumberValidator = (min = 0, max = NaN) =>
-  buildValidator([validateGreaterThan(min), validateLessThan(max)]);
+export const buildNumberValidator = (min = 0, max = null) => {
+  let validators = [validateGreaterThan(min)];
+  if (max !== null) {
+    validators.push(validateLessThan(max));
+  }
+  return buildValidator(validators);
+};
 
 export const buildEmailValidator = validate =>
   buildValidator([validateNotEmpty, validateEmail], validate);


### PR DESCRIPTION
Fixes #363.

I tried keeping `NaN` in place but behavior around, but `NaN !== NaN` is `true`, making the check here confusing to read. Just using `null` instead. JS is a world-class language, folks.

Going to self-merge because this is relatively trivial and fixes an issue people are currently hitting, but happy to receive comments about this if anything seems worth discussing. (The validator is currently exclusive of the specified ranges, which seems a bit unusual...)