### PR TITLE
Use eject script from react-scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "start": "react-app-rewired start",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test --env=jsdom",
-    "eject": "react-app-rewired eject",
+    "eject": "react-scripts eject",
     "checksum": "cd build && find . -exec shasum -a256 {} ';' > ../checksums.txt && cd ..",
     "zip": "zip -ur bridge-$npm_package_version.zip README.md bridge-https.py checksums.txt && cd build && zip -ur ../bridge-$npm_package_version.zip ./* && cd ..",
     "release": "npm install && npm run build && npm run checksum && npm run zip",


### PR DESCRIPTION
From the [react-app-rewired](https://github.com/timarney/react-app-rewired) readme:

> Note: Do NOT flip the call for the eject script. That gets run only once for a project, after which you are given full control over the webpack configuration making react-app-rewired no longer required. There are no configuration options to rewire for the eject script.

The current `eject` script doesn't work. The one in this PR does.