### PR TITLE
useInviter: include wallet type in ensureFundsFor call

### DIFF
--- a/src/lib/useInviter.js
+++ b/src/lib/useInviter.js
@@ -149,6 +149,7 @@ const useInviter = () => {
         _web3,
         point,
         _wallet.address,
+        walletType,
         safeToWei(totalCost, 'gwei'),
         Object.keys(invites).map(name => invites[name].rawTx),
         (address, minBalance, balance) =>


### PR DESCRIPTION
The ensureFundsFor function had been updated, along with _most_ its
callsites... but not this one.

I'll go ahead and self-merge this, since it's a straightforward fix, has been tested locally, and desperately wants to go out to production.

@liam-fitzgerald what's up with the code duplication between `/lib/useInviter` and `/views/Invite/InviteEmail`? Makes me feel uneasy. Seems like `/views/Invite/InviteEmail` is deprecated in favor of the new screens, which use `useInviter`? pls confirm