### PR TITLE
(re)ticket: Ensure the generalError has a message to print

### DIFF
--- a/src/views/Activate/PassportTransfer.js
+++ b/src/views/Activate/PassportTransfer.js
@@ -144,6 +144,8 @@ export default function PassportTransfer({ className, resetActivateRouter }) {
 
   const renderAdditionalInfo = () => {
     if (generalError) {
+      console.log(generalError);
+      generalError.message = generalError.message || 'Something went wrong!';
       return (
         <>
           <Grid.Item full className="mt8">

--- a/src/views/Admin/Reticket/ReticketExecute.js
+++ b/src/views/Admin/Reticket/ReticketExecute.js
@@ -121,6 +121,8 @@ export default function ReticketExecute({ newWallet, setNewWallet }) {
 
   const renderAdditionalInfo = () => {
     if (generalError) {
+      console.log(generalError);
+      generalError.message = generalError.message || 'Something went wrong!';
       return (
         <>
           <Grid.Item full className="mt4">


### PR DESCRIPTION
Should fix #382. Guess it isn't guaranteed that the error we set here has a `.message` property. Perhaps there's something else we can do that would get more information from it out to the user?