### PR TITLE
Reticket end-of-flow bugs

### DIFF
--- a/src/lib/reticket.js
+++ b/src/lib/reticket.js
@@ -216,27 +216,28 @@ export async function reticketPointBetweenWallets({
   const gasLimit = GAS_LIMITS.SEND_ETH;
   const sendEthCost = gasPriceWeiBN.mul(toBN(gasLimit));
   if (transferEth && balance.gt(sendEthCost)) {
-    const value = balance.sub(sendEthCost);
-    const txn = {
-      to: toWallet.ownership.keys.address,
-      value: value,
-    };
-    const stx = await signTransaction({
-      wallet: fromWallet,
-      walletType: fromWalletType,
-      walletHdPath: fromWalletHdPath,
-      txn,
-      chainId,
-      networkType,
-      gasPrice: gasPriceGwei,
-      gasLimit,
-      nonce: inviteNonce,
-    });
-    // let stx = new Tx(tx);
-    // stx.sign(fromWallet.privateKey);
-    sendSignedTransaction(web3, stx).catch(err => {
-      console.log('error sending value tx, who cares', err);
-    });
+    try {
+      const value = balance.sub(sendEthCost);
+      const txn = {
+        to: toWallet.ownership.keys.address,
+        value: value,
+      };
+      const stx = await signTransaction({
+        wallet: fromWallet,
+        walletType: fromWalletType,
+        walletHdPath: fromWalletHdPath,
+        txn,
+        chainId,
+        networkType,
+        gasPrice: gasPriceGwei,
+        gasLimit,
+        nonce: inviteNonce,
+      });
+      sendSignedTransaction(web3, stx);
+    } catch (err) {
+      console.log('error sending value tx, safely ignored:');
+      console.log(err);
+    }
   }
 
   progress(TRANSACTION_PROGRESS.DONE);

--- a/src/lib/reticket.js
+++ b/src/lib/reticket.js
@@ -148,13 +148,12 @@ export async function reticketPointBetweenWallets({
 
   progress(TRANSACTION_PROGRESS.SIGNING);
 
-  const suggestedGasPrice = await getSuggestedGasPrice(networkType);
+  const gasPriceGwei = (await getSuggestedGasPrice(networkType)).toFixed();
   const chainId = await web3.eth.net.getId();
-  const gasPrice = safeToWei(suggestedGasPrice.toFixed(), 'gwei');
-  const gasPriceBN = toBN(gasPrice);
+  const gasPriceWeiBN = toBN(safeToWei(gasPriceGwei, 'gwei'));
   let inviteNonce = await web3.eth.getTransactionCount(fromWallet.address);
   const totalCost = txs.reduce(
-    (acc, tx) => acc.add(gasPriceBN.mul(toBN(tx.gas))),
+    (acc, tx) => acc.add(gasPriceWeiBN.mul(toBN(tx.gas))),
     toBN(0)
   );
 
@@ -170,7 +169,7 @@ export async function reticketPointBetweenWallets({
       txn: txs[i],
       nonce: inviteNonce + i,
       chainId,
-      gasPrice: suggestedGasPrice.toFixed(),
+      gasPrice: gasPriceGwei,
       gasLimit: txs[i].gas,
     });
     txPairs.push({
@@ -215,7 +214,7 @@ export async function reticketPointBetweenWallets({
   // if non-trivial eth left in invite wallet, transfer to new ownership
   let balance = toBN(await web3.eth.getBalance(fromWallet.address));
   const gasLimit = GAS_LIMITS.SEND_ETH;
-  const sendEthCost = gasPriceBN.mul(toBN(gasLimit));
+  const sendEthCost = gasPriceWeiBN.mul(toBN(gasLimit));
   if (transferEth && balance.gt(sendEthCost)) {
     const value = balance.sub(sendEthCost);
     const txn = {
@@ -229,7 +228,7 @@ export async function reticketPointBetweenWallets({
       txn,
       chainId,
       networkType,
-      gasPrice: gasPriceBN,
+      gasPrice: gasPriceGwei,
       gasLimit,
       nonce: inviteNonce++,
     });

--- a/src/lib/reticket.js
+++ b/src/lib/reticket.js
@@ -221,7 +221,7 @@ export async function reticketPointBetweenWallets({
       to: toWallet.ownership.keys.address,
       value: value,
     };
-    const stx = signTransaction({
+    const stx = await signTransaction({
       wallet: fromWallet,
       walletType: fromWalletType,
       walletHdPath: fromWalletHdPath,

--- a/src/lib/reticket.js
+++ b/src/lib/reticket.js
@@ -230,7 +230,7 @@ export async function reticketPointBetweenWallets({
       networkType,
       gasPrice: gasPriceGwei,
       gasLimit,
-      nonce: inviteNonce++,
+      nonce: inviteNonce,
     });
     // let stx = new Tx(tx);
     // stx.sign(fromWallet.privateKey);

--- a/src/lib/txn.js
+++ b/src/lib/txn.js
@@ -127,20 +127,20 @@ const sendSignedTransaction = (web3, stx, doubtNonceError) => {
         // if there's a nonce error, but we used the gas tank, it's likely
         // that it's because the tank already submitted our transaction.
         // we just wait for first confirmation here.
-        console.error(err);
-        const isKnownError = (err.message || '').includes(
-          'known transaction: '
-        );
-        const isNonceError = (err.message || '').includes(
-          "the tx doesn't have the correct nonce."
-        );
+        const message = err.message || '';
+        const isKnownError = message.includes('known transaction: ');
+        const isNonceError =
+          message.includes("the tx doesn't have the correct nonce.") ||
+          message.includes('nonce too low');
         if (isKnownError || (doubtNonceError && isNonceError)) {
           console.log(
-            'tx send error likely from gas tank submission, ignoring'
+            'tx send error likely from gas tank submission, ignoring:',
+            message
           );
           const txHash = web3.utils.keccak256(rawTx);
           resolve(txHash);
         } else {
+          console.error(err);
           reject(err.message || 'Transaction sending failed!');
         }
       });


### PR DESCRIPTION
Please review. Want to get these out soon.

Primary issues solved by this PR:

- Nonce errors with a `nonce too low` message weren't being caught. We should ignore those if we used the gas tank, it likely means the gas tank has already submitted our transactions for us.
- The "transfer remaining funds" transaction wasn't using the right gas price, and we weren't `await`ing its signing.

Both of these would result in user-presented errors, even though the activation/reticket flow actually succeeded.