### PR TITLE
greeting: point to new invite screen

### DIFF
--- a/src/components/Greeting.js
+++ b/src/components/Greeting.js
@@ -22,7 +22,7 @@ export default function ActivateDisclaimer({ point }) {
     setWasGreeted(true);
   }, [setWasGreeted]);
 
-  const goInvite = useCallback(() => push(names.INVITE), [push, names]);
+  const goInvite = useCallback(() => push(names.INVITE_COHORT), [push, names]);
 
   return (
     !wasGreeted && (

--- a/src/components/Greeting.js
+++ b/src/components/Greeting.js
@@ -22,8 +22,6 @@ export default function ActivateDisclaimer({ point }) {
     setWasGreeted(true);
   }, [setWasGreeted]);
 
-  const goInvite = useCallback(() => push(names.INVITE_COHORT), [push, names]);
-
   return (
     !wasGreeted && (
       <Grid gap={4} className="mb10">
@@ -44,18 +42,6 @@ export default function ActivateDisclaimer({ point }) {
             Right now you can:
           </Text>
         </Grid.Item>
-
-        {isActiveOwner && (
-          <Grid.Item
-            full
-            as={LinkButton}
-            onClick={goInvite}
-            className={'yellow4'}>
-            <Text className={cn(TEXT_STYLE, 'block mb2')}>
-              Invite your friends
-            </Text>
-          </Grid.Item>
-        )}
 
         <Grid.Item
           full


### PR DESCRIPTION
The `INVITE` route got renamed to `INVITE_COHORT` during #369. Just `INVITE` points to the sigil page somehow...