### PR TITLE
fix partially deposited release contracts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2653,9 +2653,9 @@
       }
     },
     "azimuth-js": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/azimuth-js/-/azimuth-js-0.17.0.tgz",
-      "integrity": "sha512-g1/4gfhMHrj6NjCp96c5FBS202nIBnGiXcGTl9i0kh3rB6AE85rd0Un+z+qOhrVJbUdJF0axTvw3xsB5o5u+7Q==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/azimuth-js/-/azimuth-js-0.18.0.tgz",
+      "integrity": "sha512-i8mkXIfWN9GKQcd8KsjQNbf393HVOadIMN6v40KgRnMIjM6dMgUP5zoEbCsG2Zn0SgLRgw0kiNyXHGVitdumiw==",
       "requires": {
         "azimuth-solidity": "1.2.1",
         "ethereumjs-util": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@ledgerhq/hw-transport-u2f": "^5.5.0",
     "@welldone-software/why-did-you-render": "^3.2.3",
     "async-retry": "^1.2.3",
-    "azimuth-js": "^0.17.0",
+    "azimuth-js": "^0.18.0",
     "azimuth-solidity": "^1.2.0",
     "bip32": "^1.0.2",
     "bip39": "^2.5.0",


### PR DESCRIPTION
Previously, if the contracts contained less stars than were promised,
then the starRelease store would misreport the number of stars
currently available for withdraw and allow for an erroneous tx to be
attempted.

Fixes: #397