### PR TITLE
generate keyfile as part of network key tx

### DIFF
--- a/src/views/Admin/AdminNetworkingKeys.js
+++ b/src/views/Admin/AdminNetworkingKeys.js
@@ -74,6 +74,7 @@ function useSetKeys() {
 
   const {
     available: keyfileAvailable,
+    generating: keyfileGenerating,
     filename,
     bind: keyfileBind,
   } = useKeyfileGenerator(ndNetworkSeed);
@@ -133,7 +134,7 @@ function useSetKeys() {
   );
 
   // only treat the transaction as completed once we also have keys to download
-  const completed = _completed && keyfileAvailable;
+  const completed = _completed && keyfileAvailable && !keyfileGenerating;
 
   return {
     completed,


### PR DESCRIPTION
We generate the keyfile as part of the network key transaction to
hopefully prevent downloading stale.

Hopefully mitigates #346 and #137 although I am unable to reproduce
it.