### PR TITLE
npm run pilot flies again

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -74,6 +74,10 @@ of having to re-authenticate whenever you make a change or refresh the page):
   your initial state. You can provide a specific wallet,
   network type, and so on.
 
+- `npm run pilot` will check the `WITH_TEST_STATE` environment variable to setup
+  the initial chain state. Possible values are `STAR_RELEASE` or `INVITES`.
+  The state setup can be found in `migrations/1_migration.js`
+
 ## HTTPS
 
 For development, you can enable HTTPS on localhost without a certificate for

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,0 +1,18 @@
+pragma solidity >=0.4.21 <0.7.0;
+
+contract Migrations {
+  address public owner;
+  uint public last_completed_migration;
+
+  constructor() public {
+    owner = msg.sender;
+  }
+
+  modifier restricted() {
+    if (msg.sender == owner) _;
+  }
+
+  function setCompleted(uint completed) public restricted {
+    last_completed_migration = completed;
+  }
+}

--- a/migrations/1_migration.js
+++ b/migrations/1_migration.js
@@ -1,0 +1,125 @@
+var Azimuth = artifacts.require('azimuth-solidity/contracts/Azimuth.sol');
+var Polls = artifacts.require('azimuth-solidity/contracts/Polls.sol');
+var Claims = artifacts.require('azimuth-solidity/contracts/Claims.sol');
+var Censures = artifacts.require('azimuth-solidity/contracts/Censures.sol');
+var Ecliptic = artifacts.require('azimuth-solidity/contracts/Ecliptic.sol');
+var DelegatedSending = artifacts.require(
+  'azimuth-solidity/contracts/DelegatedSending.sol'
+);
+var LinearStarRelease = artifacts.require(
+  'azimuth-solidity/contracts/LinearStarRelease.sol'
+);
+var CSR = artifacts.require(
+  'azimuth-solidity/contracts/ConditionalStarRelease.sol'
+);
+
+const user1 = '0xD53208cf45fC9bd7938B200BFf8814A26146688f';
+const rateUnit = 50;
+
+const conditions = [
+  '0x00000000000000000000000000000000000000000000000000000000000000a0',
+  '0x00000000000000000000000000000000000000000000000000000000000001e0',
+  '0x0000000000000000000000000000000000000000000000000000000000000260',
+  '0x00000000000000000000000000000000000000000000000000000000621f23c4',
+  '0x0000000000000000000000000000000000000000000000000000000000000003',
+  '0x0000000000000000000000000000000000000000000000000000000000000060',
+  '0x00000000000000000000000000000000000000000000000000000000000000a0',
+];
+const minute = 60;
+const getLivelines = start => [
+  start - 5 * minute,
+  start + 10 * minute,
+  start + 15 * minute,
+  start + 20 * minute,
+  start + 25 * minute,
+  start + 30 * minute,
+  start + 35 * minute,
+];
+
+const getDeadlines = start => [
+  start + 10 * minute,
+  start + 15 * minute,
+  start + 20 * minute,
+  start + 25 * minute,
+  start + 30 * minute,
+  start + 35 * minute,
+  start + 40 * minute,
+];
+
+async function getChainTime() {
+  const block = await web3.eth.getBlock('latest');
+
+  return web3.utils.toDecimal(block.timestamp);
+}
+
+module.exports = async function(deployer) {
+  await deployer;
+
+  // setup contracts
+  const azimuth = await deployer.deploy(Azimuth);
+  const polls = await deployer.deploy(Polls, 1209600, 604800);
+  const claims = await deployer.deploy(Claims, azimuth.address);
+  const censures = await deployer.deploy(Censures, azimuth.address);
+
+  //NOTE  for real deployment, use a real ENS registry
+  const ecliptic = await deployer.deploy(
+    Ecliptic,
+    '0x0000000000000000000000000000000000000000',
+    azimuth.address,
+    polls.address,
+    claims.address
+  );
+
+  // configure contract ownership
+  await azimuth.transferOwnership(ecliptic.address);
+  await polls.transferOwnership(ecliptic.address);
+
+  // deploy secondary contracts
+  const sending = await deployer.deploy(DelegatedSending, azimuth.address);
+  const time = await getChainTime();
+  const livelines = getLivelines(time);
+  const deadlines = getDeadlines(time);
+
+  const escapeHatchDate = time + 200 * minute;
+
+  const csr = await deployer.deploy(
+    CSR,
+    azimuth.address,
+    conditions,
+    livelines,
+    deadlines,
+    escapeHatchDate
+  );
+
+  const lsr = await deployer.deploy(LinearStarRelease, azimuth.address);
+
+  const own = await ecliptic.owner();
+  switch (process.env.WITH_TEST_STATE) {
+    case 'STAR_RELEASE':
+      await ecliptic.createGalaxy(0, own);
+      await ecliptic.createGalaxy(1, own);
+
+      await ecliptic.configureKeys(0, '0x123', '0x456', 1, false);
+      await ecliptic.configureKeys(1, '0x123', '0x456', 1, false);
+      await ecliptic.spawn(256, own);
+
+      lsr.startReleasing();
+      await ecliptic.setSpawnProxy(0, lsr.address);
+      await ecliptic.setSpawnProxy(1, csr.address);
+      await ecliptic.setTransferProxy(256, lsr.address);
+      // Release 2 stars every 5 minutes, starting 2 minutes from now
+      // for a maximum of 8 stars
+      await lsr.register(user1, 2 * minute, 21, 2, 5 * minute);
+      // Release 1 star per minute for each completed batch
+      // 3 in each batch
+      await csr.register(user1, [3, 3, 3, 3, 3, 3, 3], 1, rateUnit);
+
+      for (let i = 2; i < 23; i++) {
+        const offset = 256 * i;
+        await lsr.deposit(user1, offset);
+        await csr.deposit(user1, offset + 1);
+      }
+    default:
+      return;
+  }
+};

--- a/migrations/1_migration.js
+++ b/migrations/1_migration.js
@@ -119,6 +119,17 @@ module.exports = async function(deployer) {
         await lsr.deposit(user1, offset);
         await csr.deposit(user1, offset + 1);
       }
+    case 'INVITES':
+      await ecliptic.createGalaxy(0, own);
+      await ecliptic.configureKeys(0, '0x123', '0x456', 1, false);
+      await ecliptic.spawn(256, own);
+      await ecliptic.configureKeys(256, '0x456', '0x789', 1, false);
+      // set transfer proxy to delegated sending, very brittle
+      await ecliptic.setSpawnProxy(256, sending.address);
+      await ecliptic.spawn(65792, own);
+      await ecliptic.spawn(131328, own);
+      await ecliptic.spawn(512, own);
+      await sending.setPoolSize(256, 65792, 1000);
     default:
       return;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2243,6 +2243,12 @@
         "normalize-path": "^2.1.1"
       }
     },
+    "app-module-path": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
+      "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU=",
+      "dev": true
+    },
     "append-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
@@ -2678,13 +2684,76 @@
               "bundled": true
             }
           }
+        },
+        "browser-stdout": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+          "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "diff": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+        },
+        "growl": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+          "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "mocha": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+          "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+          "requires": {
+            "browser-stdout": "1.3.0",
+            "commander": "2.11.0",
+            "debug": "3.1.0",
+            "diff": "3.3.1",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.1.2",
+            "growl": "1.10.3",
+            "he": "1.1.1",
+            "mkdirp": "0.5.1",
+            "supports-color": "4.4.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "requires": {
+            "has-flag": "^2.0.0"
+          }
+        },
+        "truffle": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.11.tgz",
+          "integrity": "sha512-VNhc6jexZeM92sNJJr4U8ln3uJ/mJEQO/0y9ZLYc4pccyIskPtl+3r4mzymgGM/Mq5v6MpoQVD6NZgHUVKX+Dw==",
+          "requires": {
+            "mocha": "^4.1.0",
+            "original-require": "^1.0.1",
+            "solc": "0.4.24"
+          }
         }
       }
     },
     "azimuth-solidity": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/azimuth-solidity/-/azimuth-solidity-1.2.0.tgz",
-      "integrity": "sha512-5k50PJtJAXqZFFb0BWH6CxYGfodLNnG9VVJtjAnTxrLl8tO4qQSYWSb1nf39Q0MLT4e+rrUf5JIubZXKckmA3g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/azimuth-solidity/-/azimuth-solidity-1.2.1.tgz",
+      "integrity": "sha512-T2tnvxKQ2tbmnCt0qSH2tjCiTee+A1XdHCFimU48CqdUimuYR8Mmj2mRe9GHqY0x6C8TX0ifwJL5pnR996sJLw==",
       "requires": {
         "babel-polyfill": "^6.26.0",
         "babel-register": "^6.26.0",
@@ -2692,10 +2761,72 @@
         "truffle": "4.1.11"
       },
       "dependencies": {
+        "browser-stdout": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+          "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "diff": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+        },
+        "growl": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+          "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "mocha": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+          "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+          "requires": {
+            "browser-stdout": "1.3.0",
+            "commander": "2.11.0",
+            "debug": "3.1.0",
+            "diff": "3.3.1",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.1.2",
+            "growl": "1.10.3",
+            "he": "1.1.1",
+            "mkdirp": "0.5.1",
+            "supports-color": "4.4.0"
+          }
+        },
         "openzeppelin-solidity": {
           "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.12.0.tgz",
-          "integrity": "sha512-WlorzMXIIurugiSdw121RVD5qA3EfSI7GybTn+/Du0mPNgairjt29NpVTAaH8eLjAeAwlw46y7uQKy0NYem/gA=="
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "requires": {
+            "has-flag": "^2.0.0"
+          }
+        },
+        "truffle": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.11.tgz",
+          "integrity": "sha512-VNhc6jexZeM92sNJJr4U8ln3uJ/mJEQO/0y9ZLYc4pccyIskPtl+3r4mzymgGM/Mq5v6MpoQVD6NZgHUVKX+Dw==",
+          "requires": {
+            "mocha": "^4.1.0",
+            "original-require": "^1.0.1",
+            "solc": "0.4.24"
+          }
         }
       }
     },
@@ -3562,9 +3693,10 @@
       }
     },
     "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
     },
     "browserify-aes": {
       "version": "1.2.0",
@@ -5187,9 +5319,10 @@
       }
     },
     "diff": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
     },
     "diff-sequences": {
       "version": "24.9.0",
@@ -8456,9 +8589,10 @@
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "growl": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
     },
     "growly": {
       "version": "1.3.0",
@@ -8622,9 +8756,10 @@
       }
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbol-support-x": {
       "version": "1.4.2",
@@ -12027,36 +12162,46 @@
       }
     },
     "mocha": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
       "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.11.0",
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
         "debug": "3.1.0",
-        "diff": "3.3.1",
+        "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.2",
-        "growl": "1.10.3",
+        "growl": "1.10.5",
         "he": "1.1.1",
+        "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "supports-color": "4.4.0"
+        "supports-color": "5.4.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -17621,13 +17766,14 @@
       }
     },
     "truffle": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.11.tgz",
-      "integrity": "sha512-VNhc6jexZeM92sNJJr4U8ln3uJ/mJEQO/0y9ZLYc4pccyIskPtl+3r4mzymgGM/Mq5v6MpoQVD6NZgHUVKX+Dw==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.1.16.tgz",
+      "integrity": "sha512-McY2AKicKIdIclpclIXluWtCf1yj2cTJGS0ghStHkklw7XYk3ZL4MoftNyfqiYCjIjGs24qoEF9o/JlRp5qnmQ==",
+      "dev": true,
       "requires": {
-        "mocha": "^4.1.0",
-        "original-require": "^1.0.1",
-        "solc": "0.4.24"
+        "app-module-path": "^2.2.0",
+        "mocha": "5.2.0",
+        "original-require": "1.0.1"
       }
     },
     "ts-essentials": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-app-rewired": "^2.1.3",
     "serve": "^11.0.1",
     "source-map-explorer": "^2.0.0",
-    "truffle": "4.1.11"
+    "truffle": "5.1.16"
   },
   "scripts": {
     "start": "react-app-rewired start",
@@ -82,8 +82,7 @@
     "zip": "zip -ur bridge-$npm_package_version.zip README.md bridge-https.py checksums.txt && cd build && zip -ur ../bridge-$npm_package_version.zip ./* && cd ..",
     "release": "npm install && npm run build && npm run checksum && npm run zip",
     "pilot:ganache": "ganache-cli --blockTime 1 --networkId 1 --host '0.0.0.0' -m 'benefit crew supreme gesture quantum web media hazard theory mercy wing kitten' > /dev/null &",
-    "pilot:deploy": "cd node_modules/azimuth-solidity && truffle deploy",
-    "pilot:setup": "npm run pilot:ganache && npm run pilot:deploy",
+    "pilot:setup": "npm run pilot:ganache && truffle deploy",
     "pilot": "HTTPS=true npm-run-all pilot:setup start pilot:cleanup --continue-on-error",
     "pilot:cleanup": "pkill -f ganache-cli",
     "lint:check": "eslint 'src/**/*.js'",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,8 @@
     "pilot:ganache": "ganache-cli --blockTime 1 --networkId 1 --host '0.0.0.0' -m 'benefit crew supreme gesture quantum web media hazard theory mercy wing kitten' > /dev/null &",
     "pilot:setup": "npm run pilot:ganache && truffle deploy",
     "pilot": "HTTPS=true npm-run-all pilot:setup start pilot:cleanup --continue-on-error",
+    "pilot-invites": "WITH_TEST_STATE=INVITES npm run pilot",
+    "pilot-release": "WITH_TEST_STATE=STAR_RELEASE npm run pilot",
     "pilot:cleanup": "pkill -f ganache-cli",
     "lint:check": "eslint 'src/**/*.js'",
     "lint:fix": "eslint --fix 'src/**/*.js'",

--- a/src/lib/contracts.js
+++ b/src/lib/contracts.js
@@ -4,7 +4,7 @@ const CONTRACT_ADDRESSES = {
     azimuth: '0x863d9c2e5c4c133596cfac29d55255f0d0f86381',
     polls: '0x935452c45eda2958976a429c9733c40302995efd',
     delegatedSending: '0xb71c0b6cee1bcae56dfe95cd9d3e41ddd7eafc43',
-    linearSR: '0xa32c3019b256880A8c5458379188eea6F3934e2F',
+    linearSR: '0x03C3dC12BE658158D1d7F9e66E08ec4099c568e4',
     conditionalSR: '0x35EB3B102d9C1B69Ac1469C1B1FE1799850CD3EB',
   },
   ROPSTEN: {

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,0 +1,34 @@
+require('babel-register');
+require('babel-polyfill');
+
+module.exports = {
+  networks: {
+    development: {
+      host: 'localhost',
+      port: 8545,
+      network_id: '*', // Any network (default: none)
+      gas: 6000000,
+      skipDryRun: true,
+    },
+  },
+
+  // Set default mocha options here, use special reporters etc.
+  mocha: {},
+
+  // Configure your compilers
+  compilers: {
+    solc: {
+      version: '0.4.24',
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+    },
+  },
+  solc: {
+    optimizer: {
+      enabled: true,
+      runs: 200,
+    },
+  },
+};


### PR DESCRIPTION
Finally make npm run pilot usable again.

Move local chain deployment logic to Bridge and provide optional state setup. State setup is done by setting the `WITH_TEST_STATE` env var. e.g. `WITH_TEST_STATE=STAR_RELEASE npm run pilot` will setup the star release contracts with deposited stars. 

State setup is modularised to prevent the chain from getting too large as ganache-cli gets really slow with large chains. 

Also changes the conditional star release setup to match the mainnet state. 

Fixes #425 fixes #426 