### PR TITLE
Auth Token support

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "checksum": "cd build && find . -exec shasum -a256 {} ';' > ../checksums.txt && cd ..",
     "zip": "zip -ur bridge-$npm_package_version.zip README.md bridge-https.py checksums.txt && cd build && zip -ur ../bridge-$npm_package_version.zip ./* && cd ..",
     "release": "npm install && npm run build && npm run checksum && npm run zip",
-    "pilot:ganache": "ganache-cli --blockTime 1 --networkId 1 --host '0.0.0.0' -m 'benefit crew supreme gesture quantum web media hazard theory mercy wing kitten' > /dev/null &",
+    "pilot:ganache": "ganache-cli --blockTime 1 --networkId 5 --host '0.0.0.0' -m 'benefit crew supreme gesture quantum web media hazard theory mercy wing kitten' > /dev/null &",
     "pilot:setup": "npm run pilot:ganache && truffle deploy",
     "pilot": "HTTPS=true npm-run-all pilot:setup start pilot:cleanup --continue-on-error",
     "pilot-invites": "WITH_TEST_STATE=INVITES npm run pilot",

--- a/src/lib/authToken.js
+++ b/src/lib/authToken.js
@@ -1,0 +1,14 @@
+import * as secp256k1 from 'secp256k1';
+
+import { keccak256 } from './wallet';
+
+const MESSAGE = 'Bridge Authentication Token';
+
+export const getAuthToken = ({ wallet, walletType, walletHdPath, web3 }) => {
+  const { signature } = secp256k1.sign(
+    keccak256('\x19Ethereum Signed Message:\n' + MESSAGE.length + MESSAGE),
+    wallet.privateKey
+  );
+
+  return signature;
+};

--- a/src/lib/authToken.js
+++ b/src/lib/authToken.js
@@ -20,15 +20,6 @@ function signMessage(privateKey) {
   return ethSignature;
 }
 
-function signatureToHex(v, r, s) {
-  const ethSignature = new Uint8Array(65);
-  ethSignature.set(Buffer.from(r, 'hex'));
-  ethSignature.set(Buffer.from(s, 'hex'), 32);
-  ethSignature[64] = v;
-
-  return `0x${Buffer.from(ethSignature).toString('hex')}`;
-}
-
 export const getAuthToken = async ({
   wallet,
   walletType,
@@ -39,8 +30,7 @@ export const getAuthToken = async ({
     return web3.eth.personal.sign(MESSAGE, wallet.address, '');
   }
   if (walletType === WALLET_TYPES.LEDGER) {
-    const { v, r, s } = await ledgerSignMessage(MESSAGE, walletHdPath);
-    return signatureToHex(v, r, s);
+    return ledgerSignMessage(MESSAGE, walletHdPath);
   }
   if (walletType === WALLET_TYPES.TREZOR) {
     return trezorSignMessage(MESSAGE, walletHdPath);

--- a/src/lib/authToken.js
+++ b/src/lib/authToken.js
@@ -1,10 +1,13 @@
 import * as secp256k1 from 'secp256k1';
 
-import { keccak256 } from './wallet';
+import { keccak256, WALLET_TYPES } from './wallet';
 
 const MESSAGE = 'Bridge Authentication Token';
 
 export const getAuthToken = ({ wallet, walletType, walletHdPath, web3 }) => {
+  if (walletType === WALLET_TYPES.METAMASK) {
+    return web3.eth.personal.sign(MESSAGE, wallet.address, '');
+  }
   const { signature } = secp256k1.sign(
     keccak256('\x19Ethereum Signed Message:\n' + MESSAGE.length + MESSAGE),
     wallet.privateKey

--- a/src/lib/authToken.js
+++ b/src/lib/authToken.js
@@ -4,14 +4,28 @@ import { keccak256, WALLET_TYPES } from './wallet';
 
 const MESSAGE = 'Bridge Authentication Token';
 
+function signMessage(privateKey) {
+  const { signature } = secp256k1.sign(
+    keccak256('\x19Ethereum Signed Message:\n' + MESSAGE.length + MESSAGE),
+    privateKey
+  );
+  // add key recovery parameter
+  const ethSignature = new Uint8Array(65);
+  ethSignature.set(signature);
+  const v = (ethSignature[32] & 1) + 27;
+  ethSignature[64] = v;
+
+  return ethSignature;
+}
+
 export const getAuthToken = ({ wallet, walletType, walletHdPath, web3 }) => {
   if (walletType === WALLET_TYPES.METAMASK) {
     return web3.eth.personal.sign(MESSAGE, wallet.address, '');
   }
-  const { signature } = secp256k1.sign(
-    keccak256('\x19Ethereum Signed Message:\n' + MESSAGE.length + MESSAGE),
-    wallet.privateKey
-  );
 
-  return signature;
+  const signature = signMessage(wallet.privateKey);
+
+  const token = `0x${Buffer.from(signature).toString('hex')}`;
+
+  return token;
 };

--- a/src/lib/authToken.js
+++ b/src/lib/authToken.js
@@ -2,6 +2,7 @@ import * as secp256k1 from 'secp256k1';
 
 import { keccak256, WALLET_TYPES } from './wallet';
 import { ledgerSignMessage } from './ledger';
+import { trezorSignMessage } from './trezor';
 
 const MESSAGE = 'Bridge Authentication Token';
 
@@ -40,6 +41,9 @@ export const getAuthToken = async ({
   if (walletType === WALLET_TYPES.LEDGER) {
     const { v, r, s } = await ledgerSignMessage(MESSAGE, walletHdPath);
     return signatureToHex(v, r, s);
+  }
+  if (walletType === WALLET_TYPES.TREZOR) {
+    return trezorSignMessage(MESSAGE, walletHdPath);
   }
 
   const signature = signMessage(wallet.privateKey);

--- a/src/lib/ledger.js
+++ b/src/lib/ledger.js
@@ -22,3 +22,11 @@ export const ledgerSignTransaction = async (txn, hdpath) => {
 
   return txn;
 };
+
+export const ledgerSignMessage = async (message, hdPath) => {
+  const transport = await Transport.create();
+  const eth = new Eth(transport);
+
+  const path = chopHdPrefix(hdPath);
+  return eth.signPersonalMessage(path, Buffer.from(message).toString('hex'));
+};

--- a/src/lib/ledger.js
+++ b/src/lib/ledger.js
@@ -8,11 +8,11 @@ export const chopHdPrefix = str =>
   str.slice(0, 2) === 'm/' ? str.slice(2) : str;
 export const addHdPrefix = str => (str.slice(0, 2) === 'm/' ? str : 'm/' + str);
 
-export const ledgerSignTransaction = async (txn, hdpath) => {
+export const ledgerSignTransaction = async (txn, hdPath) => {
   const transport = await Transport.create();
   const eth = new Eth(transport);
 
-  const path = chopHdPrefix(hdpath);
+  const path = chopHdPrefix(hdPath);
   const serializedTx = txn.serialize().toString('hex');
   const sig = await eth.signTransaction(path, serializedTx);
 
@@ -28,5 +28,14 @@ export const ledgerSignMessage = async (message, hdPath) => {
   const eth = new Eth(transport);
 
   const path = chopHdPrefix(hdPath);
-  return eth.signPersonalMessage(path, Buffer.from(message).toString('hex'));
+  const { r, s, v } = await eth.signPersonalMessage(
+    path,
+    Buffer.from(message).toString('hex')
+  );
+  const ethSignature = new Uint8Array(65);
+  ethSignature.set(Buffer.from(r, 'hex'));
+  ethSignature.set(Buffer.from(s, 'hex'), 32);
+  ethSignature[64] = v;
+
+  return `0x${Buffer.from(ethSignature).toString('hex')}`;
 };

--- a/src/lib/network.js
+++ b/src/lib/network.js
@@ -16,4 +16,15 @@ const renderNetworkType = network =>
     ? 'Local Node'
     : 'Offline';
 
-export { NETWORK_TYPES, renderNetworkType };
+const chainIdToNetworkType = chainId => {
+  switch (chainId) {
+    case '0x1':
+      return NETWORK_TYPES.MAINNET;
+    case '0x3':
+      return NETWORK_TYPES.ROPSTEN;
+    default:
+      return NETWORK_TYPES.LOCAL;
+  }
+};
+
+export { NETWORK_TYPES, renderNetworkType, chainIdToNetworkType };

--- a/src/lib/trezor.js
+++ b/src/lib/trezor.js
@@ -37,7 +37,7 @@ const trezorSignTransaction = async (txn, hdpath) => {
 };
 
 export const trezorSignMessage = async (message, hdPath) => {
-  const sig = await TrezorConnect.ethereumSignTransaction({
+  const sig = await TrezorConnect.signMessage({
     path: hdPath,
     message,
   });

--- a/src/lib/trezor.js
+++ b/src/lib/trezor.js
@@ -36,4 +36,19 @@ const trezorSignTransaction = async (txn, hdpath) => {
   return txn;
 };
 
+export const trezorSignMessage = async (message, hdPath) => {
+  const sig = await TrezorConnect.ethereumSignTransaction({
+    path: hdPath,
+    message,
+  });
+
+  if (!sig.success) {
+    throw new Error(sig.payload.error);
+  }
+
+  const { signature } = sig.payload;
+
+  return signature;
+};
+
 export { TREZOR_PATH, trezorSignTransaction };

--- a/src/lib/wallet.js
+++ b/src/lib/wallet.js
@@ -22,6 +22,12 @@ export const WALLET_TYPES = {
   METAMASK: Symbol('METAMASK'),
 };
 
+export const NONCUSTODIAL_WALLETS = new Set([
+  WALLET_TYPES.METAMASK,
+  WALLET_TYPES.TREZOR,
+  WALLET_TYPES.LEDGER,
+]);
+
 export function EthereumWallet(privateKey) {
   this.privateKey = privateKey;
   this.publicKey = secp256k1.publicKeyCreate(this.privateKey);

--- a/src/store/wallet.js
+++ b/src/store/wallet.js
@@ -4,6 +4,7 @@ import React, {
   useCallback,
   useContext,
   useState,
+  useEffect,
 } from 'react';
 import { Just, Nothing } from 'folktale/maybe';
 import { includes } from 'lodash';
@@ -14,7 +15,10 @@ import {
   addressFromSecp256k1Public,
   walletFromMnemonic,
 } from 'lib/wallet';
+import { getAuthToken } from 'lib/authToken';
 import { BRIDGE_ERROR } from 'lib/error';
+
+import { useNetwork } from 'store/network';
 
 export const WalletContext = createContext(null);
 
@@ -45,6 +49,26 @@ function _useWallet(initialWallet = Nothing(), initialMnemonic = Nothing()) {
   const [authMnemonic, setAuthMnemonic] = useState(initialMnemonic);
   const [networkSeed, setNetworkSeed] = useState(Nothing());
   const [networkRevision, setNetworkRevision] = useState(Nothing());
+
+  const [authToken, setAuthToken] = useState(Nothing());
+
+  const { web3 } = useNetwork();
+
+  useEffect(() => {
+    if (!Just.hasInstance(wallet) || !Just.hasInstance(web3)) {
+      return;
+    }
+    const _wallet = wallet.value;
+    const _web3 = web3.value;
+    const token = getAuthToken({
+      wallet: _wallet,
+      walletType,
+      walletHdPath,
+      web3: _web3,
+    });
+
+    setAuthToken(token);
+  }, [wallet, walletType, walletHdPath, web3]);
 
   const setWalletType = useCallback(
     walletType => {

--- a/src/store/wallet.js
+++ b/src/store/wallet.js
@@ -14,6 +14,7 @@ import {
   DEFAULT_HD_PATH,
   addressFromSecp256k1Public,
   walletFromMnemonic,
+  NONCUSTODIAL_WALLETS,
 } from 'lib/wallet';
 import { getAuthToken } from 'lib/authToken';
 import { BRIDGE_ERROR } from 'lib/error';
@@ -56,7 +57,11 @@ function _useWallet(initialWallet = Nothing(), initialMnemonic = Nothing()) {
 
   useEffect(() => {
     (async () => {
-      if (!Just.hasInstance(wallet) || !Just.hasInstance(web3)) {
+      if (
+        !Just.hasInstance(wallet) ||
+        !Just.hasInstance(web3) ||
+        NONCUSTODIAL_WALLETS.has(walletType)
+      ) {
         return;
       }
       const _wallet = wallet.value;
@@ -158,6 +163,9 @@ function _useWallet(initialWallet = Nothing(), initialMnemonic = Nothing()) {
     setNetworkRevision,
     //
     resetWallet,
+    //
+    authToken,
+    setAuthToken,
   };
 }
 

--- a/src/store/wallet.js
+++ b/src/store/wallet.js
@@ -55,19 +55,21 @@ function _useWallet(initialWallet = Nothing(), initialMnemonic = Nothing()) {
   const { web3 } = useNetwork();
 
   useEffect(() => {
-    if (!Just.hasInstance(wallet) || !Just.hasInstance(web3)) {
-      return;
-    }
-    const _wallet = wallet.value;
-    const _web3 = web3.value;
-    const token = getAuthToken({
-      wallet: _wallet,
-      walletType,
-      walletHdPath,
-      web3: _web3,
-    });
+    (async () => {
+      if (!Just.hasInstance(wallet) || !Just.hasInstance(web3)) {
+        return;
+      }
+      const _wallet = wallet.value;
+      const _web3 = web3.value;
+      const token = await getAuthToken({
+        wallet: _wallet,
+        walletType,
+        walletHdPath,
+        web3: _web3,
+      });
 
-    setAuthToken(token);
+      setAuthToken(token);
+    })();
   }, [wallet, walletType, walletHdPath, web3]);
 
   const setWalletType = useCallback(

--- a/src/views/Login/Ledger.js
+++ b/src/views/Login/Ledger.js
@@ -164,7 +164,8 @@ export default function Ledger({ className, goHome }) {
         application. If you're running on older firmware, make sure the "browser
         support" option is turned on. To sign transactions, you'll also need to
         enable the "contract data" option. You will be prompted to sign a
-        message. This allows Bridge to operate correctly.
+        message. This allows Bridge to operate correctly. Never sign this hash
+        outside of Bridge.
       </Grid.Item>
 
       <BridgeForm

--- a/src/views/Login/Ledger.js
+++ b/src/views/Login/Ledger.js
@@ -173,7 +173,7 @@ export default function Ledger({ className, goHome }) {
         onSubmit={onSubmit}
         afterSubmit={goHome}
         initialValues={initialValues}>
-        {({ handleSubmit }) => (
+        {({ handleSubmit, submitting }) => (
           <>
             <Condition when="useCustomPath" is={true}>
               <Grid.Item full as={HdPathInput} name="hdpath" label="HD Path" />
@@ -214,7 +214,8 @@ export default function Ledger({ className, goHome }) {
             <Grid.Item full as={FormError} />
 
             <Grid.Item full as={SubmitButton} handleSubmit={handleSubmit}>
-              Authenticate
+              {!submitting && 'Authenticate'}
+              {submitting && 'Please check your device'}
             </Grid.Item>
           </>
         )}

--- a/src/views/Login/Ledger.js
+++ b/src/views/Login/Ledger.js
@@ -19,6 +19,7 @@ import {
 import { WALLET_TYPES } from 'lib/wallet';
 import useLoginView from 'lib/useLoginView';
 import useBreakpoints from 'lib/useBreakpoints';
+
 import {
   composeValidator,
   buildCheckboxValidator,
@@ -31,6 +32,7 @@ import SubmitButton from 'form/SubmitButton';
 import Condition from 'form/Condition';
 import { FORM_ERROR } from 'final-form';
 import { HdPathInput } from 'form/Inputs';
+import { getAuthToken } from 'lib/authToken';
 
 const PATH_OPTIONS = [
   { text: 'Ledger Live', value: LEDGER_LIVE_PATH },
@@ -45,7 +47,7 @@ const ACCOUNT_OPTIONS = times(20, i => ({
 export default function Ledger({ className, goHome }) {
   useLoginView(WALLET_TYPES.LEDGER);
 
-  const { setWallet, setWalletHdPath } = useWallet();
+  const { setWallet, setWalletHdPath, setAuthToken } = useWallet();
 
   const validate = useMemo(
     () =>
@@ -70,14 +72,21 @@ export default function Ledger({ className, goHome }) {
         const chainCode = Buffer.from(info.chainCode, 'hex');
         const pub = secp256k1.publicKeyConvert(publicKey, true);
         const hd = bip32.fromPublicKey(pub, chainCode);
+        const authToken = await getAuthToken({
+          wallet: hd,
+          walletType: WALLET_TYPES.LEDGER,
+          walletHdPath: addHdPrefix(values.hdpath),
+        });
 
+        setAuthToken(authToken);
         setWallet(Just(hd));
         setWalletHdPath(addHdPrefix(values.hdpath));
       } catch (error) {
+        console.error(error);
         return { [FORM_ERROR]: error.message };
       }
     },
-    [setWallet, setWalletHdPath]
+    [setAuthToken, setWallet, setWalletHdPath]
   );
 
   const onValues = useCallback(({ valid, values, form }) => {
@@ -154,7 +163,8 @@ export default function Ledger({ className, goHome }) {
         Connect and authenticate to your Ledger, and then open the "Ethereum"
         application. If you're running on older firmware, make sure the "browser
         support" option is turned on. To sign transactions, you'll also need to
-        enable the "contract data" option.
+        enable the "contract data" option. You will be prompted to sign a
+        message. This allows Bridge to operate correctly.
       </Grid.Item>
 
       <BridgeForm

--- a/src/views/Login/Ledger.js
+++ b/src/views/Login/Ledger.js
@@ -164,8 +164,8 @@ export default function Ledger({ className, goHome }) {
         application. If you're running on older firmware, make sure the "browser
         support" option is turned on. To sign transactions, you'll also need to
         enable the "contract data" option. You will be prompted to sign a
-        message. This allows Bridge to operate correctly. Never sign this hash
-        outside of Bridge.
+        message. This allows Bridge to operate correctly. Never sign this
+        message outside of Bridge.
       </Grid.Item>
 
       <BridgeForm

--- a/src/views/Login/Metamask.js
+++ b/src/views/Login/Metamask.js
@@ -6,7 +6,7 @@ import { FORM_ERROR } from 'final-form';
 import { useWallet } from 'store/wallet';
 import { useNetwork } from 'store/network';
 
-import { WALLET_TYPES } from 'lib/wallet';
+import { WALLET_TYPES, abbreviateAddress } from 'lib/wallet';
 import { MetamaskWallet } from 'lib/metamask';
 import { getAuthToken } from 'lib/authToken';
 import useLoginView from 'lib/useLoginView';
@@ -76,7 +76,7 @@ function Login({ onSubmit, goHome }) {
           <Grid.Item full as={SubmitButton} handleSubmit={handleSubmit}>
             Login
             {window.ethereum.selectedAddress &&
-              ' as ' + window.ethereum.selectedAddress}
+              ' as ' + abbreviateAddress(window.ethereum.selectedAddress)}
           </Grid.Item>
         )}
       </BridgeForm>

--- a/src/views/Login/Metamask.js
+++ b/src/views/Login/Metamask.js
@@ -1,26 +1,46 @@
 import React, { useCallback } from 'react';
 import { Grid, Text, LinkButton, H5 } from 'indigo-react';
 import { Just } from 'folktale/maybe';
+import { FORM_ERROR } from 'final-form';
 
 import { useWallet } from 'store/wallet';
+import { useNetwork } from 'store/network';
 
 import { WALLET_TYPES } from 'lib/wallet';
 import { MetamaskWallet } from 'lib/metamask';
+import { getAuthToken } from 'lib/authToken';
 import useLoginView from 'lib/useLoginView';
+import * as need from 'lib/need';
 
 import SubmitButton from 'form/SubmitButton';
 import BridgeForm from 'form/BridgeForm';
 
 export default function Metamask({ className, goHome }) {
   useLoginView(WALLET_TYPES.METAMASK);
-  const { setWallet, setWalletType } = useWallet();
+  const { setWallet, setWalletType, setAuthToken } = useWallet();
+
+  const { web3 } = useNetwork();
+  const _web3 = need.web3(web3);
 
   const onSubmit = useCallback(async () => {
-    const accounts = await window.ethereum.enable();
-    const wallet = new MetamaskWallet(accounts[0]);
-    setWallet(Just(wallet));
-    setWalletType(WALLET_TYPES.METAMASK);
-  }, [setWallet, setWalletType]);
+    try {
+      const accounts = await window.ethereum.enable();
+      const wallet = new MetamaskWallet(accounts[0]);
+
+      const authToken = await getAuthToken({
+        wallet,
+        walletType: WALLET_TYPES.METAMASK,
+        web3: _web3,
+      });
+
+      setAuthToken(authToken);
+      setWallet(Just(wallet));
+      setWalletType(WALLET_TYPES.METAMASK);
+    } catch (e) {
+      console.error(e);
+      return { [FORM_ERROR]: e.message };
+    }
+  }, [_web3, setAuthToken, setWallet, setWalletType]);
 
   return (
     <Grid className={className}>

--- a/src/views/Login/Trezor.js
+++ b/src/views/Login/Trezor.js
@@ -8,9 +8,10 @@ import { Text, Grid, H5, CheckboxInput, SelectInput } from 'indigo-react';
 
 import { useWallet } from 'store/wallet';
 
-import { TREZOR_PATH } from 'lib/trezor';
+import { TREZOR_PATH, trezorSignMessage } from 'lib/trezor';
 import { WALLET_TYPES } from 'lib/wallet';
 import useLoginView from 'lib/useLoginView';
+import { getAuthToken } from 'lib/authToken';
 
 import {
   composeValidator,
@@ -35,7 +36,7 @@ const ACCOUNT_OPTIONS = times(20, i => ({
 export default function Trezor({ className, goHome }) {
   useLoginView(WALLET_TYPES.TREZOR);
 
-  const { setWallet, setWalletHdPath } = useWallet();
+  const { setWallet, setWalletHdPath, setAuthToken } = useWallet();
 
   const validate = useMemo(
     () =>
@@ -67,10 +68,17 @@ export default function Trezor({ className, goHome }) {
       const pub = secp256k1.publicKeyConvert(publicKey, true);
       const hd = bip32.fromPublicKey(pub, chainCode);
 
+      const authToken = await getAuthToken({
+        wallet: hd,
+        walletType: WALLET_TYPES.TREZOR,
+        walletHdPath: values.hdPath,
+      });
+
+      setAuthToken(authToken);
       setWallet(Just(hd));
       setWalletHdPath(values.hdPath);
     },
-    [setWallet, setWalletHdPath]
+    [setAuthToken, setWallet, setWalletHdPath]
   );
 
   const onValues = useCallback(({ valid, values, form }) => {

--- a/src/views/Login/Trezor.js
+++ b/src/views/Login/Trezor.js
@@ -104,7 +104,9 @@ export default function Trezor({ className, goHome }) {
     <Grid className={className}>
       <Grid.Item full as={Text} className="f6 gray4 mb3">
         Connect and authenticate to your Trezor. If you'd like to use a custom
-        derivation path, you may enter it below.
+        derivation path, you may enter it below. Upon login, you will prompted
+        to sign the message "Bridge Authentication Token". This allows Bridge to
+        operate correctly. Never sign this message outside of Bridge.
       </Grid.Item>
 
       <BridgeForm

--- a/src/views/Login/Trezor.js
+++ b/src/views/Login/Trezor.js
@@ -8,7 +8,7 @@ import { Text, Grid, H5, CheckboxInput, SelectInput } from 'indigo-react';
 
 import { useWallet } from 'store/wallet';
 
-import { TREZOR_PATH, trezorSignMessage } from 'lib/trezor';
+import { TREZOR_PATH } from 'lib/trezor';
 import { WALLET_TYPES } from 'lib/wallet';
 import useLoginView from 'lib/useLoginView';
 import { getAuthToken } from 'lib/authToken';
@@ -113,7 +113,7 @@ export default function Trezor({ className, goHome }) {
         onSubmit={onSubmit}
         afterSubmit={goHome}
         initialValues={initialValues}>
-        {({ handleSubmit }) => (
+        {({ handleSubmit, submitting }) => (
           <>
             <Condition when="useCustomPath" is={true}>
               <Grid.Item full as={HdPathInput} name="hdPath" label="HD Path" />
@@ -141,7 +141,8 @@ export default function Trezor({ className, goHome }) {
             <Grid.Item full as={FormError} />
 
             <Grid.Item full as={SubmitButton} handleSubmit={handleSubmit}>
-              Authenticate
+              {!submitting && 'Authenticate'}
+              {submitting && 'Please check your device'}
             </Grid.Item>
           </>
         )}


### PR DESCRIPTION
Adds auth token support. Generated as part of login. Supports all wallet types. 

Also reworks metamask support so that if present and enabled, it is used as a provider for web3, instead of the infura provider.

Some questions:
- Copy re: login methods, hardware/metamask wallet users will need to sign the auth request before login
- Thinking about maybe deprecating direct hardware support and making hardware wallets go through metamask. If we did this we could use [EIP712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md) which is better suited to our usecase. 

