### PR TITLE
fix: use visibility hidden complementary column

### DIFF
--- a/src/components/View.js
+++ b/src/components/View.js
@@ -90,7 +90,13 @@ function View({
       </Flex.Item>
 
       <Flex.Item style={{ visibility: 'hidden' }}>
-        {showBackButton && !backIsLogout && <MiniBackButton />}
+        {showBackButton && !backIsLogout && (
+          <MiniBackButton
+            hpadding={!isMobile}
+            vpadding={isMobile}
+            isExit={backIsLogout}
+          />
+        )}
       </Flex.Item>
     </Flex>
   );

--- a/src/components/View.js
+++ b/src/components/View.js
@@ -89,7 +89,9 @@ function View({
         <Flex.Item as={Footer.Target} />
       </Flex.Item>
 
-      <Flex.Item style={{ width: '48px' }} />
+      <Flex.Item style={{ visibility: 'hidden' }}>
+        {showBackButton && !backIsLogout && <MiniBackButton />}
+      </Flex.Item>
     </Flex>
   );
 }


### PR DESCRIPTION
...so that it takes up the same amount of space

before:

<img width="605" alt="image" src="https://user-images.githubusercontent.com/1535001/78464579-1addeb00-76b9-11ea-8f28-384d3e49f655.png">

after:

<img width="605" alt="image" src="https://user-images.githubusercontent.com/1535001/78464591-30ebab80-76b9-11ea-9ca5-1cb82e74d2bd.png">
