### PR TITLE
ActivateCode: hide ticket input if it's implied

### DIFF
--- a/src/views/Activate/ActivateCode.js
+++ b/src/views/Activate/ActivateCode.js
@@ -157,7 +157,7 @@ export default function ActivateCode() {
         </Grid.Item>
         <Grid.Item full as={P} className="mb2">
           Someone has invited you to claim your Urbit identity and join the
-          network. Enter your activation code to continue.
+          network. {!impliedTicket && 'Enter your activation code to continue.'}
         </Grid.Item>
         <BridgeForm
           validate={validate}
@@ -166,21 +166,25 @@ export default function ActivateCode() {
           initialValues={initialValues}>
           {({ validating, values, submitting, handleSubmit }) => (
             <>
-              <Grid.Item
-                full
-                as={TicketInput}
-                type={values.showTicket ? 'text' : 'password'}
-                name="ticket"
-                label="Activation Code"
-                disabled={!activationAllowed}
-              />
+              {!impliedTicket && (
+                <>
+                  <Grid.Item
+                    full
+                    as={TicketInput}
+                    type={values.showTicket ? 'text' : 'password'}
+                    name="ticket"
+                    label="Activation Code"
+                    disabled={!activationAllowed}
+                  />
 
-              <Grid.Item
-                full
-                as={CheckboxInput}
-                name="showTicket"
-                label="Show"
-              />
+                  <Grid.Item
+                    full
+                    as={CheckboxInput}
+                    name="showTicket"
+                    label="Show"
+                  />
+                </>
+              )}
 
               <Grid.Item full as={FormError} />
 


### PR DESCRIPTION
Hides the ticket and changes the copy if there's an implied point
from the URL, in order to minimise user cognitive load. We don't
skip this page entirely because we have to make network and crypto
calls and doing this upon pageload would ruin time to interactive.

cc: @kennyrowe

Fixes #443
![localhost_3000_ (2)](https://user-images.githubusercontent.com/46801558/78609341-dfecda80-78a5-11ea-9b9c-a9f6a58deb36.png)
