### PR TITLE
increase block retry interval

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,6 +1,6 @@
 import { isDevelopment } from './flags';
 
-const CHECK_BLOCK_EVERY_MS = isDevelopment ? 1000 : 5000;
+const CHECK_BLOCK_EVERY_MS = isDevelopment ? 1000 : 10000;
 const DEFAULT_GAS_PRICE_GWEI = 20;
 
 const MIN_GALAXY = 0;


### PR DESCRIPTION
Too enthusiastic block polling was causing 429 responses from infura.
Doubles the interval to remedy this.