### PR TITLE
constants: bump planet invite gas limit

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -31,7 +31,7 @@ const GAS_LIMITS = {
   REJECT: 200000, //NOTE no samples
   DETACH: 200000, //NOTE no samples
   //
-  GIFT_PLANET: 420000, //NOTE low sample size, //NOTE also update in gas tank
+  GIFT_PLANET: 450000, //NOTE low sample size, //NOTE also update in gas tank
   //
   SEND_ETH: 21000,
   //


### PR DESCRIPTION
[Looking at the delegated sending contract on mainnet](https://etherscan.io/address/0xf7908ab1f1e352f83c5ebc75051c0565aeaea5fb), looks like transactions are occasionally just running out of gas, despite successful transactions not hitting this limit. Another case of transaction logic needing some breathing room, I guess. This bumps the limit up a bit. The relevant change on the gas-tank side has already been made.