### PR TITLE
input: allow pasting comma-separated email lists

### DIFF
--- a/src/form/EmailChipInput.js
+++ b/src/form/EmailChipInput.js
@@ -41,7 +41,7 @@ const EmailChipInput = ({ className, name, label, disabled }) => {
   );
 
   const addToChips = useCallback(() => {
-    fields.push(value);
+    fields.concat(value.split(/[, ]+/));
     setValue('');
   }, [value, fields, setValue]);
 

--- a/src/form/EmailChipInput.js
+++ b/src/form/EmailChipInput.js
@@ -41,7 +41,7 @@ const EmailChipInput = ({ className, name, label, disabled }) => {
   );
 
   const addToChips = useCallback(() => {
-    fields.concat(value.split(/[, ]+/));
+    fields.concat(value.split(/[\n\t, ]+/));
     setValue('');
   }, [value, fields, setValue]);
 


### PR DESCRIPTION
For easier sending of larger batches of invites. We already split on `,` and ` `  keypresses when writing these things, so pasting those in should count as separators, too.