### PR TITLE
constants: higher default gas price

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,7 +1,7 @@
 import { isDevelopment } from './flags';
 
 const CHECK_BLOCK_EVERY_MS = isDevelopment ? 1000 : 10000;
-const DEFAULT_GAS_PRICE_GWEI = 20;
+const DEFAULT_GAS_PRICE_GWEI = 40;
 
 const MIN_GALAXY = 0;
 const MAX_GALAXY = 255;

--- a/src/lib/getSuggestedGasPrice.js
+++ b/src/lib/getSuggestedGasPrice.js
@@ -24,7 +24,7 @@ export default async function getSuggestedGasPrice(networkType) {
         // more than gwei. see: https://docs.ethgasstation.info
         const suggestedGasPrice = Math.ceil(json.fast / 10); // to gwei
 
-        // we don't want to charge users more than our default 20 gwei
+        // we don't want to charge users more than our default gwei
         return Math.min(suggestedGasPrice, DEFAULT_GAS_PRICE_GWEI);
       } catch (e) {
         return DEFAULT_GAS_PRICE_GWEI;


### PR DESCRIPTION
Considering the average gas price for [the past couple weeks](https://etherscan.io/chart/gasprice) has been above 20 gwei, that the current [recommended "safe low"](https://www.ethgasstation.info/) is at 26 gwei, and that people are [actively getting bitten](https://etherscan.io/address/ecliptic.eth) by this, we should [step on the gas](https://www.youtube.com/watch?v=atuFSv2bLa8).

<img width="430" alt="image" src="https://user-images.githubusercontent.com/3829764/82591754-1ce40680-9ba0-11ea-867b-c20940b42bbf.png">

A _doubling_ of the original value feels a bit drastic, but the user experience of endlessly waiting on transactions isn't nice at all. In practice, we use whatever the gasstation-recommended value is though, and we can always pull this back down later.

(This change will, of course, have to be reflected in the gas tank as well.)