### PR TITLE
copy: touch up urbit id actions copy

### DIFF
--- a/src/views/UrbitID/Home.js
+++ b/src/views/UrbitID/Home.js
@@ -88,7 +88,7 @@ export default function UrbitIDHome() {
             · Master Key Authentication required.
           </B>
         }>
-        Download Keys
+        Re-download Passport
       </Grid.Item>
       <Grid.Divider />
       <Grid.Item
@@ -136,7 +136,7 @@ export default function UrbitIDHome() {
             full
             as={ForwardButton}
             className="f6"
-            accessory={<span className="underline pointer">Set Keys</span>}>
+            accessory={<span className="underline pointer">Set Networking Keys</span>}>
             Network Keys Required
           </Grid.Item>
           <Grid.Divider />


### PR DESCRIPTION
currently:
![image](https://user-images.githubusercontent.com/3829764/84392051-1d4d4b80-abfa-11ea-8584-e469b538a076.png)

This page is a mess.

"Download keys"? What keys? People are often looking for networking keys, maybe this is it? Why would you need the master ticket? (Because it's not, it's the passport.)

"Networking keys required"? Required for what? It lets you "set keys", but why is that even on this page? Isn't it an urbit os thing?

Consider this more an RFC than a PR, happy to take better changes here.