### PR TITLE
tx: catch more "tx known" errors

### DIFF
--- a/src/lib/txn.js
+++ b/src/lib/txn.js
@@ -120,7 +120,9 @@ const sendSignedTransaction = (web3, stx, doubtNonceError) => {
         // that it's because the tank already submitted our transaction.
         // we just wait for first confirmation here.
         const message = typeof err === 'string' ? err : err.message || '';
-        const isKnownError = message.includes('known transaction: ');
+        const isKnownError =
+          message.includes('known transaction') ||
+          message.includes('already known');
         const isNonceError =
           message.includes("the tx doesn't have the correct nonce.") ||
           message.includes('nonce too low');


### PR DESCRIPTION
Fixes #497.

Whoever made it so that error codes are always the same for every error, but messages vary per node implementation, needs to be trialed.