### PR TITLE
indigo-react: use checkbox's .checked

### DIFF
--- a/src/indigo-react/components/CheckboxInput.js
+++ b/src/indigo-react/components/CheckboxInput.js
@@ -55,15 +55,15 @@ export default function CheckboxInput({
             mr3: !inline,
             mr1: inline,
             'bg-gray1': disabled,
-            'bg-black white b-black': !disabled && (input.value || white),
-            'bg-white black b-black': !disabled && !input.value,
+            'bg-black white b-black': !disabled && (input.checked || white),
+            'bg-white black b-black': !disabled && !input.checked,
           })}
           style={{
             height: '14px',
             width: '14px',
             ...style,
           }}>
-          {input.value && '✓'}
+          {input.checked && '✓'}
         </Flex>
         {label}
       </Flex.Item>


### PR DESCRIPTION
Instead of .value, which was coming up undefined.

Fixes #499.

I don't know why this suddenly broke. Maybe it's a weird local environment things wrt dependencies etc? I've been diligently wiping and re-installing `npm_modules` though...