### PR TITLE
keyfiles: make all keyfiles deterministic

### DIFF
--- a/migrations/1_migration.js
+++ b/migrations/1_migration.js
@@ -119,6 +119,7 @@ module.exports = async function(deployer) {
         await lsr.deposit(user1, offset);
         await csr.deposit(user1, offset + 1);
       }
+      break;
     case 'INVITES':
       await ecliptic.createGalaxy(0, own);
       await ecliptic.configureKeys(0, '0x123', '0x456', 1, false);
@@ -130,6 +131,7 @@ module.exports = async function(deployer) {
       await ecliptic.spawn(131328, own);
       await ecliptic.spawn(512, own);
       await sending.setPoolSize(256, 65792, 1000);
+      break;
     case 'RESIDENTS':
       await ecliptic.createGalaxy(0, own);
       await ecliptic.configureKeys(0, '0x123', '0x456', 1, false);
@@ -141,6 +143,7 @@ module.exports = async function(deployer) {
         await ecliptic.spawn(offset + 256, own);
         await ecliptic.transferPoint(offset + 256, user1, false);
       }
+      break;
 
     default:
       return;

--- a/src/lib/keys.js
+++ b/src/lib/keys.js
@@ -143,12 +143,17 @@ const deriveNetworkSeedFromMnemonic = async (
 };
 
 /**
+ * @param {number} point
  * @param {string} authToken
- * @param {number} number
+ * @param {number} revision
  * @return {Maybe<string>}
  */
-export const deriveNetworkSeedFromAuthToken = (authToken, revision, point) => {
-  const networkSeed = shas(authToken, `revision-${point}-${revision}`)
+export const deriveNetworkSeedFromAuthToken = (point, authToken, revision) => {
+  //NOTE revision is the point's on-chain revision number.
+  //     since deriveNetworkSeedFromMnemonic does this too, we decrement the
+  //     revision number by one before deriving from it.
+  const salt = Buffer.from(`revision-${point}-${revision - 1}`);
+  const networkSeed = shas(authToken, salt)
     .toString('hex')
     .slice(0, 32);
   return Just(networkSeed);
@@ -168,7 +173,7 @@ export const attemptNetworkSeedDerivation = async ({
   }
 
   if (Just.hasInstance(authToken)) {
-    return deriveNetworkSeedFromAuthToken(authToken.value, point, revision);
+    return deriveNetworkSeedFromAuthToken(point, authToken.value, revision);
   }
 
   return Nothing();

--- a/src/lib/keys.js
+++ b/src/lib/keys.js
@@ -160,16 +160,33 @@ export const deriveNetworkSeedFromAuthToken = (point, authToken, revision) => {
 };
 
 /**
+ * Derives from either a full Urbit Wallet, a current management mnemonic,
+ * or an auth token, in that order of preference.
  * @return {Promise<Maybe<string>>}
  */
 export const attemptNetworkSeedDerivation = async ({
   urbitWallet,
+  wallet,
+  authMnemonic,
+  details,
   point,
   authToken,
   revision,
 }) => {
   if (Just.hasInstance(urbitWallet)) {
     return await deriveNetworkSeedFromUrbitWallet(urbitWallet.value, revision);
+  }
+
+  if (Just.hasInstance(wallet) && Just.hasInstance(authMnemonic)) {
+    const managementSeed = await deriveNetworkSeedFromManagementMnemonic(
+      wallet.value,
+      authMnemonic.value,
+      details,
+      revision
+    );
+    if (Just.hasInstance(managementSeed)) {
+      return managementSeed;
+    }
   }
 
   if (Just.hasInstance(authToken)) {

--- a/src/lib/networkCode.js
+++ b/src/lib/networkCode.js
@@ -23,6 +23,11 @@ export function shas(buf, salt) {
 }
 
 function xor(a, b) {
+  if (!Buffer.isBuffer(a) || !Buffer.isBuffer(b)) {
+    console.log('a', a);
+    console.log('b', b);
+    throw new Error('only xor buffers!');
+  }
   const length = Math.max(a.byteLength, b.byteLength);
   const result = new Uint8Array(length);
   for (let i = 0; i < length; i++) {

--- a/src/lib/useInviter.js
+++ b/src/lib/useInviter.js
@@ -204,6 +204,7 @@ const useInviter = () => {
       return { invites: confirmedInvites };
     },
     [
+      authToken,
       contracts,
       gasPrice,
       networkType,

--- a/src/lib/useKeyfileGenerator.js
+++ b/src/lib/useKeyfileGenerator.js
@@ -60,6 +60,9 @@ export default function useKeyfileGenerator(manualNetworkSeed) {
       ? Just(manualNetworkSeed)
       : await attemptNetworkSeedDerivation({
           urbitWallet,
+          wallet,
+          authMnemonic,
+          details: _details,
           authToken,
           point: _point,
           revision: networkRevision,
@@ -94,6 +97,8 @@ export default function useKeyfileGenerator(manualNetworkSeed) {
     hasNetworkingKeys,
     manualNetworkSeed,
     urbitWallet,
+    wallet,
+    authMnemonic,
     setCode,
     details,
     _point,

--- a/src/lib/useKeyfileGenerator.js
+++ b/src/lib/useKeyfileGenerator.js
@@ -20,7 +20,7 @@ import useCurrentPermissions from './useCurrentPermissions';
 import convertToInt from './convertToInt';
 
 export default function useKeyfileGenerator(manualNetworkSeed) {
-  const { urbitWallet, wallet, authMnemonic } = useWallet();
+  const { urbitWallet, wallet, authMnemonic, authToken } = useWallet();
   const { pointCursor } = usePointCursor();
   const { getDetails } = usePointCache();
 
@@ -60,9 +60,8 @@ export default function useKeyfileGenerator(manualNetworkSeed) {
       ? Just(manualNetworkSeed)
       : await attemptNetworkSeedDerivation({
           urbitWallet,
-          wallet,
-          authMnemonic,
-          details: _details,
+          authToken,
+          point: _point,
           revision: networkRevision,
         });
 
@@ -95,11 +94,10 @@ export default function useKeyfileGenerator(manualNetworkSeed) {
     hasNetworkingKeys,
     manualNetworkSeed,
     urbitWallet,
-    wallet,
-    authMnemonic,
     setCode,
     details,
     _point,
+    authToken,
   ]);
 
   const filename = useMemo(() => {

--- a/src/views/Invite/Cohort.js
+++ b/src/views/Invite/Cohort.js
@@ -205,7 +205,7 @@ function CohortMemberExpanded({ point, className, ...rest }) {
       }
     };
     fetchWallet();
-  }, [codeVisible]);
+  }, [authToken, codeVisible, contracts, details, point]);
 
   useEffect(() => {
     setCodeVisible(false);

--- a/src/views/IssueChild.js
+++ b/src/views/IssueChild.js
@@ -117,7 +117,7 @@ export default function IssueChild() {
         },
         validateForm
       ),
-    [validateForm]
+    [_point, validateForm]
   );
 
   const onValues = useCallback(

--- a/src/views/UrbitOS/NetworkingKeys.js
+++ b/src/views/UrbitOS/NetworkingKeys.js
@@ -68,6 +68,9 @@ function useSetKeys(manualNetworkSeed, setManualNetworkSeed) {
 
         const networkSeed = await attemptNetworkSeedDerivation({
           urbitWallet,
+          wallet,
+          authMnemonic,
+          details: _details,
           point: _point,
           authToken,
           revision: newNetworkRevision,
@@ -83,7 +86,16 @@ function useSetKeys(manualNetworkSeed, setManualNetworkSeed) {
         return randomSeed.current;
       }
     },
-    [setManualNetworkSeed, networkRevision, urbitWallet, _point, authToken]
+    [
+      _details,
+      authMnemonic,
+      setManualNetworkSeed,
+      networkRevision,
+      urbitWallet,
+      wallet,
+      _point,
+      authToken,
+    ]
   );
 
   const { completed: _completed, ...rest } = useEthereumTransaction(

--- a/src/views/UrbitOS/NetworkingKeys.js
+++ b/src/views/UrbitOS/NetworkingKeys.js
@@ -38,7 +38,7 @@ import FormError from 'form/FormError';
 import convertToInt from 'lib/convertToInt';
 
 function useSetKeys(manualNetworkSeed, setManualNetworkSeed) {
-  const { urbitWallet, wallet, authMnemonic } = useWallet();
+  const { urbitWallet, wallet, authMnemonic, authToken } = useWallet();
   const { pointCursor } = usePointCursor();
   const { syncDetails, syncRekeyDate, getDetails } = usePointCache();
   const { contracts } = useNetwork();
@@ -68,9 +68,8 @@ function useSetKeys(manualNetworkSeed, setManualNetworkSeed) {
 
         const networkSeed = await attemptNetworkSeedDerivation({
           urbitWallet,
-          wallet,
-          authMnemonic,
-          details: _details,
+          point: _point,
+          authToken,
           revision: newNetworkRevision,
         });
 
@@ -84,14 +83,7 @@ function useSetKeys(manualNetworkSeed, setManualNetworkSeed) {
         return randomSeed.current;
       }
     },
-    [
-      _details,
-      authMnemonic,
-      networkRevision,
-      setManualNetworkSeed,
-      urbitWallet,
-      wallet,
-    ]
+    [setManualNetworkSeed, networkRevision, urbitWallet, _point, authToken]
   );
 
   const { completed: _completed, ...rest } = useEthereumTransaction(


### PR DESCRIPTION
uses the authToken to create a deterministic keyfile that will be valid as long as the (point, revision, authToken) triple remains the same. This allows for redownloading of keyfiles that were set on a non master ticket wallet, and also viewing of the login code for non-master ticket wallets. 

cc: @matildepark might address some of your qualms re: non master ticket wallets being second class citizens in bridge. 