### PR TITLE
invites: handle error cases slightly better

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1815,6 +1815,16 @@
         "loader-utils": "^1.1.0"
       }
     },
+    "@tlon/sigil-js": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@tlon/sigil-js/-/sigil-js-1.4.1.tgz",
+      "integrity": "sha512-+ajy1lqChGzpFzYE03IhSBmn+IugcgjSVhMurWN6CUb50Wc4z7epPpNk2xFvyfY5BilQlgtxDvMpIcNS54Iw2Q==",
+      "requires": {
+        "invariant": "^2.2.4",
+        "svgson": "^4.0.0",
+        "transformation-matrix": "2.1.1"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.9",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@hot-loader/react-dom": "^16.8.6",
     "@ledgerhq/hw-app-eth": "^5.5.0",
     "@ledgerhq/hw-transport-u2f": "^5.5.0",
+    "@tlon/sigil-js": "^1.4.1",
     "@welldone-software/why-did-you-render": "^3.2.3",
     "async-retry": "^1.2.3",
     "azimuth-js": "^0.19.0",
@@ -54,7 +55,6 @@
     "urbit-key-generation": "^0.17.4",
     "urbit-ob": "^4.1.4",
     "urbit-paper-renderer": "^2.0.9",
-    "urbit-sigil-js": "^1.3.5",
     "web3": "1.0.0-beta.54",
     "web3-utils": "^1.0.0-beta.52"
   },

--- a/src/components/Sigil.js
+++ b/src/components/Sigil.js
@@ -1,4 +1,4 @@
-import { sigil, reactRenderer } from 'urbit-sigil-js';
+import { sigil, reactRenderer } from '@tlon/sigil-js';
 
 export default function Sigil({ patp, size, colors, ...rest }) {
   return sigil({
@@ -6,7 +6,7 @@ export default function Sigil({ patp, size, colors, ...rest }) {
     renderer: reactRenderer,
     style: { width: '100%', height: '100%' }, // NOTE: scale to container
     size,
-    margin: size / 8,
+    margin: true,
     colors,
     ...rest,
   });

--- a/src/lib/useInviter.js
+++ b/src/lib/useInviter.js
@@ -100,7 +100,6 @@ const useInviter = () => {
 
       // NB(shrugs) - must be processed in serial because main thread, etc
       let signedInvites = [];
-      let errorCount = 0;
       for (let i = 0; i < numInvites; i++) {
         setProgress(x => x + 1);
         try {
@@ -195,20 +194,6 @@ const useInviter = () => {
         };
       }
 
-      if (errorCount > 0) {
-        return {
-          errors: {
-            [WARNING]: `There ${pluralize(
-              errorCount,
-              'was',
-              'were'
-            )} ${pluralize(
-              errorCount,
-              'error'
-            )} while generating wallets. You can still send the invites that generated correctly.`,
-          },
-        };
-      }
       return { invites: confirmedInvites };
     },
     [

--- a/src/lib/useInviter.js
+++ b/src/lib/useInviter.js
@@ -159,7 +159,7 @@ const useInviter = () => {
         () => setNeedFunds(undefined)
       );
 
-      let unsentInvites = [];
+      let inviteErrors = [];
       let confirmedInvites = [];
       const txAndMailings = signedInvites.map(async invite => {
         try {
@@ -172,8 +172,12 @@ const useInviter = () => {
           await waitForTransactionConfirm(_web3, txHash);
           confirmedInvites.push(invite);
         } catch (error) {
-          console.error(error);
-          unsentInvites.push(invite);
+          console.error('Error sending invite tx:', error);
+          if (typeof error === 'string') {
+            inviteErrors.push(error);
+          } else if (typeof error === 'object' && error.message) {
+            inviteErrors.push(error.message);
+          }
           return;
         }
       });
@@ -183,8 +187,12 @@ const useInviter = () => {
       setTxStatus(STATUS.SUCCESS);
       setInvites(confirmedInvites);
 
-      if (unsentInvites.length > 0) {
-        return { errors: { [FORM_ERROR]: unsentInvites } };
+      if (inviteErrors.length > 0) {
+        return {
+          errors: {
+            [FORM_ERROR]: ['Error sending invites: ', ...inviteErrors],
+          },
+        };
       }
 
       if (errorCount > 0) {


### PR DESCRIPTION
Also sneaks in a sigil-js upgrade, as partial fix for #496.

This makes invite error handling slightly better, by making it actually render errors, instead of crashing on you. So this fixes #455. But it's still not great...

@liam-fitzgerald consider the following, imagining that only some of the invite transactions succeeded, while some fail:

https://github.com/urbit/bridge/blob/82af1413565f05839b2551cf5451c461cce4c5e5/src/lib/useInviter.js#L186-L197

https://github.com/urbit/bridge/blob/82af1413565f05839b2551cf5451c461cce4c5e5/src/views/Invite/Email.js#L85-L91

We error out without sending emails about the invite transactions that succeeded. This is obviously Not Good (though slightly better now that the user can recover the invite codes).

I tried fixing this, but when trying to communicate intermediate and partial failure states to the user, but found myself stuck in react-final-form hell: I can only communicate successes or failures, nothing in between.

So, RFC: should I just add some additional state for these situations and set those as invite logic proceeds, similar to `setStatus`? Or is there some way to do this that's more friendly to current architecture? ("It's fscked, just do whatever" is a fair answer, too.)