### PR TITLE
deterministic keyfiles: fixes and improvements

### DIFF
--- a/src/lib/keys.js
+++ b/src/lib/keys.js
@@ -148,7 +148,10 @@ const deriveNetworkSeedFromMnemonic = async (
  * @return {Maybe<string>}
  */
 export const deriveNetworkSeedFromAuthToken = (authToken, revision, point) => {
-  const salt = Buffer.from(`revision-${point}-${revision}`);
+  //NOTE revision is the point's on-chain revision number.
+  //     since deriveNetworkSeedFromMnemonic does this too, we decrement the
+  //     revision number by one before deriving from it.
+  const salt = Buffer.from(`revision-${point}-${revision - 1}`);
   const networkSeed = shas(authToken, salt)
     .toString('hex')
     .slice(0, 32);

--- a/src/lib/keys.js
+++ b/src/lib/keys.js
@@ -143,11 +143,12 @@ const deriveNetworkSeedFromMnemonic = async (
 };
 
 /**
+ * @param {number} point
  * @param {string} authToken
- * @param {number} number
+ * @param {number} revision
  * @return {Maybe<string>}
  */
-export const deriveNetworkSeedFromAuthToken = (authToken, revision, point) => {
+export const deriveNetworkSeedFromAuthToken = (point, authToken, revision) => {
   //NOTE revision is the point's on-chain revision number.
   //     since deriveNetworkSeedFromMnemonic does this too, we decrement the
   //     revision number by one before deriving from it.
@@ -172,7 +173,7 @@ export const attemptNetworkSeedDerivation = async ({
   }
 
   if (Just.hasInstance(authToken)) {
-    return deriveNetworkSeedFromAuthToken(authToken.value, point, revision);
+    return deriveNetworkSeedFromAuthToken(point, authToken.value, revision);
   }
 
   return Nothing();

--- a/src/lib/keys.js
+++ b/src/lib/keys.js
@@ -148,7 +148,8 @@ const deriveNetworkSeedFromMnemonic = async (
  * @return {Maybe<string>}
  */
 export const deriveNetworkSeedFromAuthToken = (authToken, revision, point) => {
-  const networkSeed = shas(authToken, `revision-${point}-${revision}`)
+  const salt = Buffer.from(`revision-${point}-${revision}`);
+  const networkSeed = shas(authToken, salt)
     .toString('hex')
     .slice(0, 32);
   return Just(networkSeed);

--- a/src/lib/networkCode.js
+++ b/src/lib/networkCode.js
@@ -23,6 +23,11 @@ export function shas(buf, salt) {
 }
 
 function xor(a, b) {
+  if (!Buffer.isBuffer(a) || !Buffer.isBuffer(b)) {
+    console.log('a', a);
+    console.log('b', b);
+    throw new Error('only xor buffers!');
+  }
   const length = Math.max(a.byteLength, b.byteLength);
   const result = new Uint8Array(length);
   for (let i = 0; i < length; i++) {


### PR DESCRIPTION
Turns out my ramblings on #505 were only partially grounded in reality. The _real_ problem was that we weren't passing `Buffer` objects when we should, and it was silently accepting them, always giving empty seed as a result, leading to identical keys being set every time.

This fixes that (101a2a2), the broken function call I pointed out in #505 (eae5e1c), and changes the derivation here to be more consistent with the way derivation is done for urbit wallets (a0efefc).  
Happy to debate on that last one, but I think diverging from the uhdw logic as little as possible, even if that logic is a bit wack, can potentially make our lives slightly less hard in the future.