### PR TITLE
ui: hide login code, make copy on-click work

### DIFF
--- a/src/views/UrbitOS/Home.js
+++ b/src/views/UrbitOS/Home.js
@@ -260,12 +260,7 @@ function Hosting({ manualNetworkSeed }) {
         />
         <Grid.Divider />
         {code && (
-          <Grid.Item
-            full
-            className="mt2"
-            as={CopyButtonWide}
-            detail={code}
-            detailClassName="mono">
+          <Grid.Item full className="mt2" as={CopyButtonWide} text={code}>
             Login Code
           </Grid.Item>
         )}


### PR DESCRIPTION
Fixes #472 by making the copy button copy the code on-click.

Additionally stops displaying the login code directly to the screen without a
way to hide it, because it's sensitive information.