### PR TITLE
login: improve shard form input handling

### DIFF
--- a/src/form/validators.js
+++ b/src/form/validators.js
@@ -3,6 +3,7 @@ import { some } from 'lodash';
 import {
   validateNotEmpty,
   validatePatq,
+  validateShard,
   validateMnemonic,
   validateHdPath,
   validatePoint,
@@ -62,6 +63,8 @@ export const hasErrors = iter =>
 
 export const buildPatqValidator = (validators = []) =>
   buildValidator([validateNotEmpty, validatePatq, ...validators]);
+export const buildShardValidator = (validators = []) =>
+  buildValidator([validateShard, ...validators]);
 export const buildAnyMnemonicValidator = () =>
   buildValidator([validateNotEmpty]);
 export const buildMnemonicValidator = () =>

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -65,6 +65,16 @@ export const validatePatq = v => {
   }
 };
 
+export const validateShard = v => {
+  try {
+    if (v !== undefined && v !== '' && !ob.isValidPatq(v)) {
+      throw new Error();
+    }
+  } catch {
+    return 'This is not a valid shard.';
+  }
+};
+
 export const validateOneOf = (options = []) => v =>
   !includes(options, v) && 'Is not a valid option.';
 

--- a/src/views/Login/Ticket.js
+++ b/src/views/Login/Ticket.js
@@ -30,6 +30,7 @@ import {
   composeValidator,
   buildCheckboxValidator,
   buildPatqValidator,
+  buildShardValidator,
   buildPassphraseValidator,
   buildPointValidator,
 } from 'form/validators';
@@ -107,6 +108,14 @@ export default function Ticket({ className, goHome }) {
       if (errors.shard1 || errors.shard2 || errors.shard3) {
         return errors;
       }
+      const empty = ['shard1', 'shard2', 'shard3'].filter(s => !values[s]);
+      if (empty.length > 1) {
+        let errors = {};
+        empty.map(s => {
+          errors[s] = 'Please provide at least two out of three shards.';
+        });
+        return errors;
+      }
     } else {
       if (errors.ticket) {
         return errors;
@@ -117,7 +126,11 @@ export default function Ticket({ className, goHome }) {
   const onSubmit = useCallback(
     async values => {
       const ticket = values.useShards
-        ? kg.combine([values.shard1, values.shard2, values.shard3])
+        ? kg.combine(
+            [values.shard1, values.shard2, values.shard3].map(v =>
+              v === '' ? undefined : v
+            )
+          )
         : values.ticket;
 
       try {
@@ -177,9 +190,9 @@ export default function Ticket({ className, goHome }) {
           useShards: buildCheckboxValidator(),
           point: buildPointValidator(4),
           ticket: buildPatqValidator(),
-          shard1: buildPatqValidator(),
-          shard2: buildPatqValidator(),
-          shard3: buildPatqValidator(),
+          shard1: buildShardValidator(),
+          shard2: buildShardValidator(),
+          shard3: buildShardValidator(),
           ticketHidden: buildCheckboxValidator(),
           passphrase: buildPassphraseValidator(),
         },


### PR DESCRIPTION
- Consider empty shard fields as valid.
- If too many shard fields are empty, present an error to the user, asking them to provide at least two shards.
- Coerce shards to be either full strings, or `undefined`. Keygen currently doesn't handle the empty string case well.

Fixes #516.