### PR TITLE
ui: allow setting gas price >100 gwei

### DIFF
--- a/src/components/InlineEthereumTransaction.js
+++ b/src/components/InlineEthereumTransaction.js
@@ -257,7 +257,7 @@ export default function InlineEthereumTransaction({
                     as="input"
                     type="range"
                     min="1"
-                    max="100"
+                    max="400"
                     value={gasPrice}
                     onChange={e =>
                       setGasPrice(convertToInt(e.target.value, 10))


### PR DESCRIPTION
By bumping the max up to 400.

This is a pretty arbitrary number. I've seen ethgasstation.info mention prices over 300 gwei for fast transactions, but haven't even seen it touch 400. The etherscan.io stats for average gas price per day don't go above 300.

tldr this should be plenty unless things get really wild.