### PR TITLE
constants: (nearly) limitless suggested gas price

### DIFF
--- a/src/components/NeedFundsNotice.js
+++ b/src/components/NeedFundsNotice.js
@@ -17,7 +17,9 @@ export default function NeedFundsNotice({
       <Highlighted warning>
         Your ownership address <CopiableAddress>{address}</CopiableAddress>{' '}
         needs at least {safeFromWei(minBalance)} ETH and currently has{' '}
-        {safeFromWei(balance)} ETH. The transaction will automatically resume
+        {safeFromWei(balance)} ETH. Transaction costs may be high due to{' '}
+        Ethereum network activity. You can come back later to try again, or{' '}
+        transfer the required ETH now. The transaction will automatically resume{' '}
         once enough ETH is available. Waiting... <Blinky />
       </Highlighted>
     </WarningBox>

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -2,7 +2,7 @@ import { isDevelopment } from './flags';
 
 const CHECK_BLOCK_EVERY_MS = isDevelopment ? 1000 : 10000;
 const DEFAULT_GAS_PRICE_GWEI = 40;
-const MAX_GAS_PRICE_GWEI = 80;
+const MAX_GAS_PRICE_GWEI = 400;
 
 const MIN_GALAXY = 0;
 const MAX_GALAXY = 255;


### PR DESCRIPTION
I imagine we still want some value here, as a sanity check, so I'm making it match #520.

Since this now goes way past what the gas tank is willing to fund, we'll probably want to update the copy of the "pls provide your own funds" message, as has been discussed over email, prior to merging this.

Notably, _this impacts the invite flow_, in that it's much more likely to ask users to bring their own funds, in the middle of onboarding. Might make for a rough experience.