### PR TITLE
invite: send leftover eth back to the gas tank

### DIFF
--- a/src/lib/reticket.js
+++ b/src/lib/reticket.js
@@ -203,10 +203,16 @@ export async function reticketPointBetweenWallets({
 
   progress(TRANSACTION_PROGRESS.TRANSFERRING);
 
-  await sendAndAwaitAllSerial(
+  const receipts = await sendAndAwaitAllSerial(
     web3,
     txPairs.map(p => p.signed),
     usedTank
+  );
+
+  const realCost = gasPriceWeiBN.mul(
+    receipts.reduce((sum, receipt) => {
+      return sum.add(toBN(receipt.gasUsed));
+    }, toBN(0))
   );
 
   //
@@ -215,10 +221,39 @@ export async function reticketPointBetweenWallets({
 
   progress(TRANSACTION_PROGRESS.CLEANING);
 
-  // if non-trivial eth left in invite wallet, transfer to new ownership
   let balance = toBN(await web3.eth.getBalance(fromWallet.address));
   const gasLimit = GAS_LIMITS.SEND_ETH;
   const sendEthCost = gasPriceWeiBN.mul(toBN(gasLimit));
+
+  // if we have funds left over from what the gas tank gave us, send those back
+  if (usedTank && realCost.add(sendEthCost).lt(totalCost)) {
+    try {
+      const remainder = totalCost.sub(realCost).sub(sendEthCost);
+      console.log('returning to gas tank', remainder.toString());
+      const txn = { to: tank.TANK_ADDRESS, value: remainder };
+      const stx = await signTransaction({
+        wallet: fromWallet,
+        walletType: fromWalletType,
+        walletHdPath: fromWalletHdPath,
+        txn,
+        chainId,
+        networkType,
+        gasPrice: gasPriceGwei,
+        gasLimit,
+        nonce: inviteNonce,
+      });
+      sendSignedTransaction(web3, stx);
+
+      // only update these after the above succeeded
+      inviteNonce++;
+      balance = balance.sub(remainder).sub(sendEthCost);
+    } catch (err) {
+      console.log('error returning gas, safely ignored:');
+      console.log(err);
+    }
+  }
+
+  // if non-trivial eth left in invite wallet, transfer to new ownership
   if (transferEth && balance.gt(sendEthCost)) {
     try {
       const value = balance.sub(sendEthCost);

--- a/src/lib/tank.js
+++ b/src/lib/tank.js
@@ -5,6 +5,8 @@ import { toBN } from 'web3-utils';
 import { RETRY_OPTIONS, waitForTransactionConfirm } from './txn';
 import { WALLET_TYPES } from 'lib/wallet';
 
+const TANK_ADDRESS = '0x40f0A6db85f8D7A54fF3eA915b040dE8Cd4A0Eb5';
+
 //NOTE if accessing this in a localhost configuration fails with "CORS request
 //     did not succeed", you might need to visit localhost:3001 or whatever
 //     explicitly and tell your browser that's safe to access.
@@ -142,4 +144,9 @@ function waitForBalance(web3, address, minBalance, askForFunding, gotFunding) {
   }, RETRY_OPTIONS);
 }
 
-export { remainingTransactions, fundTransactions, ensureFundsFor };
+export {
+  TANK_ADDRESS,
+  remainingTransactions,
+  fundTransactions,
+  ensureFundsFor,
+};

--- a/src/lib/txn.js
+++ b/src/lib/txn.js
@@ -164,7 +164,7 @@ const sendAndAwaitAll = (web3, stxs, doubtNonceError) => {
   return Promise.all(
     stxs.map(async tx => {
       const txHash = await sendSignedTransaction(web3, tx, doubtNonceError);
-      await waitForTransactionConfirm(web3, txHash);
+      return await waitForTransactionConfirm(web3, txHash);
     })
   );
 };
@@ -172,9 +172,9 @@ const sendAndAwaitAll = (web3, stxs, doubtNonceError) => {
 const sendAndAwaitAllSerial = (web3, stxs, doubtNonceError) => {
   return stxs.reduce(
     (promise, stx) =>
-      promise.then(async () => {
+      promise.then(async (receipts = []) => {
         const txHash = await sendSignedTransaction(web3, stx, doubtNonceError);
-        await waitForTransactionConfirm(web3, txHash);
+        return [...receipts, await waitForTransactionConfirm(web3, txHash)];
       }),
     Promise.resolve()
   );


### PR DESCRIPTION
At the end of reticketing, if we used the gas tank, and used less gas
than what we got funding for, send the remaining ETH back to the gas
tank for redistribution.

This will help us lower the costs of funding these a bit. We get back the overhead without slowing down the flow for the user. [For example.](https://ropsten.etherscan.io/address/0x68dc899c009a13218de51e258e6d50331b17be91)

There's an argument to be made that this should be built into /lib/tank instead of done ad-hoc, but that change seems much more involved. The bulk of our overhead comes from the invite claiming flow anyway, this change is worth much less for individual transactions.