### PR TITLE
transaction: allow transfer without reset

### DIFF
--- a/src/views/AcceptTransfer.js
+++ b/src/views/AcceptTransfer.js
@@ -98,7 +98,7 @@ export default function AcceptTransfer() {
               full
               as={CheckboxInput}
               name="noReset"
-              label="I transferred this to myself"
+              label="Retain proxies and key configuration, in case of transferring to self"
               disabled={inputsLocked}
             />
           )}


### PR DESCRIPTION
By checking an "I transferred this to myself" checkbox.

Currently, accepting a transfer _always_ resets the point, clearing out all proxy addresses, networking keys, and breaching the ship. When you're just transferring from yourself to another address you control though, you generally want to keep all those things the same, and definitely not need to deal with a breach of your ship. This allows you to, well, not reset on-transfer.

<img width="497" alt="image" src="https://user-images.githubusercontent.com/3829764/93402133-2c403b80-f884-11ea-962a-7305e138aa89.png">

We may or may not want to tweak that copy. cc @jyng 