### PR TITLE
txs: consider transaction broadcasted instantly

### DIFF
--- a/src/lib/useEthereumTransaction.js
+++ b/src/lib/useEthereumTransaction.js
@@ -145,6 +145,7 @@ export default function useEthereumTransaction(
     try {
       setConfirmationProgress(0.0);
       setError(undefined);
+      setState(STATE.BROADCASTED);
 
       const rawTxs = signedTransactions.map(stx => hexify(stx.serialize()));
 
@@ -182,7 +183,6 @@ export default function useEthereumTransaction(
       );
 
       setTxHashes(txHashes);
-      setState(STATE.BROADCASTED);
 
       await timeout(PROGRESS_ANIMATION_DELAY_MS);
 


### PR DESCRIPTION
This removes the annoying 5-30 second wait before the state change on the
"send transaction" button, now instead making the button unclickable right away.

cc @vvisigoth 