### PR TITLE
Add claims and altid support

### DIFF
--- a/src/components/Passport.js
+++ b/src/components/Passport.js
@@ -21,7 +21,7 @@ function makeSigil(size, patp, colors) {
     full: true,
     patp,
     colors,
-    size
+    size,
   };
 
   return sigil(config);

--- a/src/form/Inputs.js
+++ b/src/form/Inputs.js
@@ -197,3 +197,7 @@ export function EmailInput({ ...rest }) {
     />
   );
 }
+
+export function TextInput({ ...rest }) {
+  return <Input type="text" placeholder="" autoCapitalize="none" {...rest} />;
+}

--- a/src/form/validators.js
+++ b/src/form/validators.js
@@ -92,6 +92,8 @@ export const buildHexValidator = length =>
     validateHexString,
     validateHexLength(length),
   ]);
+export const buildBytesValidator = () =>
+  buildValidator([validateHexPrefix, validateHexString]);
 export const buildPrivateKeyValidator = () =>
   buildValidator([
     validateNotEmpty,

--- a/src/lib/contracts.js
+++ b/src/lib/contracts.js
@@ -23,6 +23,15 @@ const CONTRACT_ADDRESSES = {
     linearSR: '0x86cd9cd0992f04231751e3761de45cecea5d1801',
     conditionalSR: '0x8c241098c3d3498fe1261421633fd57986d74aea',
   },
+  RINKEBY: {
+    ecliptic: '0x396bf44923a23E1b95407932D9F4FE95085e3c83',
+    azimuth: '0x2BAfc1419F41fB850941b8412eC94723489ff41D',
+    polls: '0x33bca2d1bb7af8cc0bf853f252e02e93ea6778fe',
+    claims: '0x4e75404f7cdaacc581389913a22034e9e3114dd4',
+    delegatedSending: '0x95Dc8ca5c3bB32432F720D8F9Ac3DAcB4D835b23',
+    conditionalSR: '0xE2F3CAde6f8b823a0c620eF220D14153C28A5277',
+    linearSR: '0x836311818178300cC3D1E6b82a793Ab95E85f6A4',
+  },
 };
 
 export { CONTRACT_ADDRESSES };

--- a/src/lib/explorer.js
+++ b/src/lib/explorer.js
@@ -5,6 +5,8 @@ function useEtherscanDomain() {
   const { networkType } = useNetwork();
 
   switch (networkType) {
+    case NETWORK_TYPES.RINKEBY:
+      return 'https://rinkeby.etherscan.io';
     case NETWORK_TYPES.ROPSTEN:
       return 'https://ropsten.etherscan.io';
     case NETWORK_TYPES.OFFLINE:

--- a/src/lib/network.js
+++ b/src/lib/network.js
@@ -3,6 +3,7 @@ const NETWORK_TYPES = {
   LOCAL: Symbol('LOCAL'),
   ROPSTEN: Symbol('ROPSTEN'),
   MAINNET: Symbol('MAINNET'),
+  RINKEBY: Symbol('RINKEBY'),
 };
 
 const renderNetworkType = network =>
@@ -13,7 +14,9 @@ const renderNetworkType = network =>
     : network === NETWORK_TYPES.MAINNET
     ? 'Main Network'
     : network === NETWORK_TYPES.LOCAL
-    ? 'Local Node'
+    ? 'Main Network'
+    : network === NETWORK_TYPES.RINKEBY
+    ? 'Rinkeby'
     : 'Offline';
 
 const chainIdToNetworkType = chainId => {
@@ -22,6 +25,8 @@ const chainIdToNetworkType = chainId => {
       return NETWORK_TYPES.MAINNET;
     case '0x3':
       return NETWORK_TYPES.ROPSTEN;
+    case '0x4':
+      return NETWORK_TYPES.RINKEBY;
     default:
       return NETWORK_TYPES.LOCAL;
   }

--- a/src/lib/useMakeClaim.js
+++ b/src/lib/useMakeClaim.js
@@ -1,0 +1,39 @@
+import { useCallback, useState } from 'react';
+import * as azimuth from 'azimuth-js';
+import { useNetwork } from 'store/network';
+import { usePointCache } from 'store/pointCache';
+import { usePointCursor } from 'store/pointCursor';
+
+import * as need from 'lib/need';
+import useEthereumTransaction from 'lib/useEthereumTransaction';
+import { GAS_LIMITS } from 'lib/constants';
+import convertToInt from './convertToInt';
+
+export default function useMakeClaim() {
+  const { contracts } = useNetwork();
+  const { pointCursor } = usePointCursor();
+
+  const _contracts = need.contracts(contracts);
+  const _point = convertToInt(need.point(pointCursor), 10);
+
+  const [claimData, setClaimData] = useState();
+  const { syncClaims } = usePointCache();
+
+  return useEthereumTransaction(
+    useCallback(
+      (protocol, claim, dossier) => {
+        setClaimData({ protocol, claim, dossier });
+        return azimuth.claims.addClaim(
+          _contracts,
+          _point,
+          protocol,
+          claim,
+          dossier
+        );
+      },
+      [_contracts, _point]
+    ),
+    useCallback(() => syncClaims(_point), [syncClaims, _point]),
+    GAS_LIMITS.DEFAULT
+  );
+}

--- a/src/store/lib/useClaimsStore.js
+++ b/src/store/lib/useClaimsStore.js
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+import { Just, Nothing } from 'folktale/maybe';
+import * as azimuth from 'azimuth-js';
+import { useNetwork } from '../network';
+import useSetState from 'lib/useSetState';
+
+const EMPTY_CLAIMS = {
+  claims: Nothing(),
+};
+
+export default function useClaimsStore() {
+  const { contracts } = useNetwork();
+  const [claimsCache, addToClaimsCache] = useSetState({});
+
+  const getClaims = useCallback(point => claimsCache[point] || EMPTY_CLAIMS, [
+    claimsCache,
+  ]);
+
+  const syncClaims = useCallback(
+    async point => {
+      const _contracts = contracts.getOrElse(null);
+      if (!_contracts) {
+        return;
+      }
+
+      const allClaims = await azimuth.claims.getAllClaims(_contracts, point);
+
+      addToClaimsCache({
+        [point]: {
+          claims: Just(allClaims),
+        },
+      });
+    },
+    [contracts, addToClaimsCache]
+  );
+
+  return { getClaims, syncClaims };
+}

--- a/src/store/lib/usePointStore.js
+++ b/src/store/lib/usePointStore.js
@@ -4,6 +4,7 @@ import useDetailsStore from './useDetailsStore';
 import useBirthdaysStore from './useBirthdaysStore';
 import useRekeyDateStore from './useRekeyDateStore';
 import useInvitesStore from './useInvitesStore';
+import useClaimsStore from './useClaimsStore';
 import useControlledPointsStore from './useControlledPointsStore';
 import useEclipticOwnerStore from './useEclipticOwnerStore';
 import useResidents from './useResidentsStore';
@@ -13,6 +14,7 @@ export default function usePointStore() {
   const { syncBirthday, ...birthdays } = useBirthdaysStore();
   const { syncRekeyDate, ...rekeyDates } = useRekeyDateStore();
   const { syncInvites, ...invites } = useInvitesStore();
+  const { syncClaims, ...claims } = useClaimsStore();
   const {
     syncControlledPoints,
     ...controlledPoints
@@ -44,12 +46,14 @@ export default function usePointStore() {
         syncResidentCount(point),
         syncDetails(point),
         syncInvites(point),
+        syncClaims(point),
       ]),
     [
       syncForeignPoint,
       syncKnownPoint,
       syncDetails,
       syncInvites,
+      syncClaims,
       syncResidentCount,
     ]
   );
@@ -59,12 +63,14 @@ export default function usePointStore() {
     ...birthdays,
     ...rekeyDates,
     ...invites,
+    ...claims,
     ...controlledPoints,
     ...ecliptic,
     ...residents,
     syncDetails,
     syncRekeyDate,
     syncInvites,
+    syncClaims,
     syncControlledPoints,
     syncKnownPoint,
     syncOwnedPoint,

--- a/src/store/network.js
+++ b/src/store/network.js
@@ -76,6 +76,13 @@ function _useNetwork(initialNetworkType = null) {
           CONTRACT_ADDRESSES.MAINNET
         );
       }
+      case NETWORK_TYPES.RINKEBY: {
+        const endpoint = `https://rinkeby.infura.io/v3/${process.env.REACT_APP_INFURA_ENDPOINT}`;
+        return initWeb3(
+          new Web3.providers.HttpProvider(endpoint),
+          CONTRACT_ADDRESSES.RINKEBY
+        );
+      }
       case NETWORK_TYPES.OFFLINE:
       default: {
         // NB (jtobin):

--- a/src/views/UrbitID.js
+++ b/src/views/UrbitID.js
@@ -17,6 +17,9 @@ import DownloadKeys from './UrbitID/DownloadKeys';
 import SetProxy from './UrbitID/SetProxy';
 import ResetKeys from './UrbitID/ResetKeys';
 import Transfer from './UrbitID/Transfer';
+import Claims from './UrbitID/Claims';
+import MakeClaim from './UrbitID/Claims/MakeClaim';
+import MakeAltId from './UrbitID/Claims/MakeAltId';
 
 const NAMES = {
   HOME: 'HOME',
@@ -25,6 +28,9 @@ const NAMES = {
   SET_PROXY: 'SET_PROXY',
   RESET_KEYS: 'RESET_KEYS',
   TRANSFER: 'TRANSFER',
+  CLAIMS: 'CLAIMS',
+  MAKE_CLAIM: 'MAKE_CLAIM',
+  MAKE_ALTID: 'MAKE_ALTID',
 };
 
 const VIEWS = {
@@ -34,6 +40,9 @@ const VIEWS = {
   [NAMES.RESET_KEYS]: ResetKeys,
   [NAMES.SET_PROXY]: SetProxy,
   [NAMES.TRANSFER]: Transfer,
+  [NAMES.CLAIMS]: Claims,
+  [NAMES.MAKE_CLAIM]: MakeClaim,
+  [NAMES.MAKE_ALTID]: MakeAltId,
 };
 
 const humanizeName = name => {
@@ -48,6 +57,13 @@ const humanizeName = name => {
       return 'Reset Keys';
     case NAMES.TRANSFER:
       return 'Transfer';
+    case NAMES.CLAIMS:
+      return 'Claims';
+    case NAMES.MAKE_CLAIM:
+      return 'Create Claim';
+    case NAMES.MAKE_ALTID:
+      return 'Create alt id';
+
     default:
       return undefined;
   }
@@ -65,7 +81,10 @@ export default function UrbitID() {
 
   const last = router.peek().key;
   const homeAction = last === NAMES.HOME ? undefined : () => history.pop();
-  const lastCrumb = homeAction ? [{ text: humanizeName(last) }] : [];
+  const tail = router.routes
+    .slice(1)
+    .map(route => ({ text: humanizeName(route.key) }));
+  const lastCrumb = homeAction ? tail : [];
 
   return (
     <View pop={router.pop} inset>

--- a/src/views/UrbitID/Claims.js
+++ b/src/views/UrbitID/Claims.js
@@ -1,0 +1,344 @@
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import cn from 'classnames';
+import { Grid, H4, HelpText } from 'indigo-react';
+import { Just, Nothing } from 'folktale/maybe';
+import { eq } from 'lodash';
+import * as ob from 'urbit-ob';
+import * as azimuth from 'azimuth-js';
+import Tabs from 'components/Tabs';
+import Sigil from 'components/Sigil';
+import Blinky from 'components/Blinky';
+
+import { useLocalRouter } from 'lib/LocalRouter';
+import * as need from 'lib/need';
+
+import { usePointCursor } from 'store/pointCursor';
+import { usePointCache } from 'store/pointCache';
+import Footer from 'components/Footer';
+import { useNetwork } from 'store/network';
+import convertToInt from 'lib/convertToInt';
+import useEthereumTransaction from 'lib/useEthereumTransaction';
+import { GAS_LIMITS } from 'lib/constants';
+import InlineEthereumTransaction from 'components/InlineEthereumTransaction';
+import { ForwardButton } from 'components/Buttons';
+
+const NAMES = {
+  ALTID: 'ALTID',
+  OTHER: 'OTHER',
+};
+
+const OPTIONS = [
+  { text: 'Alt Id', value: NAMES.ALTID },
+
+  { text: 'Other', value: NAMES.OTHER },
+];
+
+const VIEWS = {
+  [NAMES.ALTID]: Tab,
+  [NAMES.OTHER]: Tab,
+};
+
+const CLAIM_AS = {
+  [NAMES.ALTID]: AltId,
+  [NAMES.OTHER]: Claim,
+};
+
+const PAGE_SIZE = 10;
+
+function useRemoveClaim() {
+  const { contracts } = useNetwork();
+  const { pointCursor } = usePointCursor();
+
+  const _contracts = need.contracts(contracts);
+  const _point = convertToInt(need.point(pointCursor), 10);
+
+  const [claimData, setClaimData] = useState();
+  const { syncClaims } = usePointCache();
+
+  return useEthereumTransaction(
+    useCallback(
+      (protocol, claim) => {
+        setClaimData({ protocol, claim });
+        return azimuth.claims.removeClaim(_contracts, _point, protocol, claim);
+      },
+      [_contracts, _point]
+    ),
+    useCallback(() => {
+      syncClaims(_point);
+    }, [syncClaims, _point]),
+    GAS_LIMITS.DEFAULT
+  );
+}
+
+function Tab({
+  className,
+  claimSelected,
+  clickClaim,
+  onReturn,
+  tab,
+  claims,
+  claimAs,
+  page,
+  setPage,
+  bind,
+}) {
+  const start = page * PAGE_SIZE;
+  const end = page * PAGE_SIZE + PAGE_SIZE;
+  const claimsCount = claims.map(cs => cs.length).getOrElse(0);
+  const maxPage = Math.ceil(claimsCount / PAGE_SIZE) - 1;
+  const hasNext = page < maxPage;
+  const hasPrev = page > 0;
+  const _claims = claims
+    .map(cs => {
+      let claims = [];
+      if (tab == NAMES.ALTID) {
+        claims = cs.filter(claim => claim.protocol == 'alt-id');
+      } else {
+        claims = cs.filter(claim => claim.protocol != 'alt-id');
+      }
+      return claims.slice(start, end);
+    })
+    .getOrElse([]);
+  const onNext = useCallback(() => {
+    setPage(p => p + 1);
+  }, [setPage]);
+
+  const onPrev = useCallback(() => {
+    setPage(p => p - 1);
+  }, [setPage]);
+
+  if (Nothing.hasInstance(claims)) {
+    return <Grid className={className}></Grid>;
+  }
+
+  return (
+    <Grid className={cn('mt2', className)}>
+      {_claims.length === 0 && (
+        <Grid.Item full as={HelpText} className="mt8 t-center">
+          {Just.hasInstance(claims) ? (
+            'No claims to display'
+          ) : (
+            <>
+              <Blinky /> Loading...
+            </>
+          )}
+        </Grid.Item>
+      )}
+
+      {_claims.map(claim =>
+        claimAs({
+          key: JSON.stringify(claim),
+          claim: claim,
+          bind: bind,
+          clickClaim: clickClaim,
+          onReturn: onReturn,
+          selected: eq(claim, claimSelected),
+        })
+      )}
+
+      <Grid.Item as={Footer}>
+        <Grid className="pb9">
+          {hasPrev && (
+            <Grid.Item
+              className="pointer underline mt4"
+              fourth={1}
+              onClick={onPrev}>
+              {'<-'}
+            </Grid.Item>
+          )}
+          {maxPage > 0 && (
+            <Grid.Item className="mt4 t-center gray3" cols={[4, 10]}>
+              <span className="black">Page {page + 1}</span> of {maxPage + 1}
+            </Grid.Item>
+          )}
+          {hasNext && (
+            <Grid.Item
+              className="pointer underline t-right mt4"
+              fourth={4}
+              onClick={onNext}>
+              {'->'}
+            </Grid.Item>
+          )}
+        </Grid>
+      </Grid.Item>
+    </Grid>
+  );
+}
+
+function Claim({ claim, selected, clickClaim, bind, onReturn }) {
+  return (
+    <>
+      <Grid.Item onClick={() => clickClaim(claim)}>
+        <Grid.Item className="flex-row align-center mono" cols={[3, 7]}>
+          Protocol: {claim.protocol}
+        </Grid.Item>
+        <Grid.Item
+          className="flex-row-r align-center underline green3 pointer"
+          cols={[7, 10]}>
+          Claim: {claim.claim}
+        </Grid.Item>
+        <Grid.Item
+          className="flex-row-r align-center underline red4 pointer"
+          cols={[10, 13]}>
+          Dossier: 0x
+        </Grid.Item>
+      </Grid.Item>
+      {selected && (
+        <>
+          <Grid.Item
+            full
+            as={InlineEthereumTransaction}
+            label={'Generate transaction to remove claim'}
+            {...bind}
+            onReturn={onReturn}
+          />
+        </>
+      )}
+      <Grid.Divider />
+    </>
+  );
+}
+
+function AltId({ claim, selected, clickClaim, bind, onReturn }) {
+  const patp = ob.patp(claim.claim);
+  const sigilSize = 50;
+  return (
+    <>
+      <Grid.Item className="flex-row justify-center align-center" cols={[1, 3]}>
+        <div
+          style={{
+            display: 'inline-block',
+            height: `${sigilSize}px`,
+            width: `${sigilSize}px`,
+          }}>
+          <Sigil patp={patp} size={25} colors={['#FFFFFF', '#000000']} />
+        </div>
+      </Grid.Item>
+      <Grid.Item className="flex-row align-center mono" cols={[3, 10]}>
+        {patp}{' '}
+      </Grid.Item>
+      <Grid.Item
+        className="flex-row-r align-center underline red4 pointer"
+        cols={[10, 13]}
+        onClick={() => clickClaim(claim)}>
+        Remove
+      </Grid.Item>
+      {selected && (
+        <>
+          <Grid.Item
+            full
+            as={InlineEthereumTransaction}
+            label={'Generate transaction to remove alternative id'}
+            {...bind}
+            onReturn={onReturn}
+          />
+        </>
+      )}
+      <Grid.Divider />
+    </>
+  );
+}
+
+export default function Claims() {
+  const { push, names } = useLocalRouter();
+
+  const { pointCursor } = usePointCursor();
+  const point = need.point(pointCursor);
+  const { getClaims, syncClaims } = usePointCache();
+
+  const {
+    isDefaultState,
+    construct,
+    unconstruct,
+    completed,
+    inputsLocked,
+    bind,
+  } = useRemoveClaim();
+
+  useEffect(() => {
+    syncClaims(point);
+  }, [syncClaims, point]);
+
+  const { claims } = getClaims(point);
+  const [currentTab, _setCurrentTab] = useState(NAMES.ALTID);
+  const [page, setPage] = useState(0);
+  const [claimSelected, setClaimSelected] = useState(null);
+
+  useMemo(() => {
+    if (!claimSelected) {
+      unconstruct();
+    }
+  }, [claimSelected, unconstruct]);
+
+  const setCurrentTab = useCallback(
+    tab => {
+      setPage(0);
+      _setCurrentTab(tab);
+    },
+    [setPage, _setCurrentTab]
+  );
+
+  const goToMakeClaim = useCallback(() => push(names.MAKE_CLAIM, {}), [
+    push,
+    names,
+  ]);
+  const goToMakeAltId = useCallback(() => push(names.MAKE_ALTID, {}), [
+    push,
+    names,
+  ]);
+
+  const clickClaim = useCallback(
+    claim => {
+      if (!inputsLocked) {
+        construct(claim.protocol, claim.claim);
+        setClaimSelected(claim);
+      }
+    },
+    [construct, inputsLocked]
+  );
+
+  const onReturn = () => setClaimSelected(null);
+
+  return (
+    <Grid>
+      <Grid.Item full as={H4} className="mt4">
+        Claims
+      </Grid.Item>
+      <Grid.Item
+        full
+        className="mt1"
+        as={Tabs}
+        views={VIEWS}
+        options={OPTIONS}
+        currentTab={currentTab}
+        tab={currentTab}
+        onTabChange={setCurrentTab}
+        claims={claims}
+        bind={bind}
+        claimSelected={claimSelected}
+        clickClaim={clickClaim}
+        onReturn={onReturn}
+        page={page}
+        setPage={setPage}
+        claimAs={CLAIM_AS[currentTab]}
+      />
+      {currentTab === NAMES.OTHER ? (
+        <Grid.Item
+          onClick={() => goToMakeClaim()}
+          full
+          solid
+          as={ForwardButton}>
+          Create claim
+        </Grid.Item>
+      ) : (
+        <Grid.Item
+          onClick={() => goToMakeAltId()}
+          full
+          solid
+          as={ForwardButton}>
+          Create alt id
+        </Grid.Item>
+      )}
+    </Grid>
+  );
+}

--- a/src/views/UrbitID/Claims/MakeAltId.js
+++ b/src/views/UrbitID/Claims/MakeAltId.js
@@ -1,0 +1,103 @@
+import React, { useCallback } from 'react';
+import cn from 'classnames';
+import { Grid, Text } from 'indigo-react';
+import { useLocalRouter } from 'lib/LocalRouter';
+import useMakeClaim from 'lib/useMakeClaim';
+import ViewHeader from 'components/ViewHeader';
+import InlineEthereumTransaction from 'components/InlineEthereumTransaction';
+import { PointInput } from 'form/Inputs';
+import ob from 'urbit-ob';
+import {
+  composeValidator,
+  hasErrors,
+  buildPointValidator,
+} from 'form/validators';
+import BridgeForm from 'form/BridgeForm';
+import FormError from 'form/FormError';
+
+export default function MakeAltId() {
+  const { pop } = useLocalRouter();
+
+  const {
+    isDefaultState,
+    construct,
+    unconstruct,
+    completed,
+    inputsLocked,
+    bind,
+  } = useMakeClaim();
+
+  const validate = composeValidator(
+    {
+      point: buildPointValidator(),
+    },
+    (values, errors) => {
+      if (hasErrors(errors)) {
+        return errors;
+      }
+    }
+  );
+
+  const onValues = useCallback(
+    ({ valid, values }) => {
+      if (valid) {
+        construct('alt-id', ob.patp2dec(values.point), '0x');
+      } else {
+        unconstruct();
+      }
+    },
+    [construct, unconstruct]
+  );
+
+  return (
+    <Grid>
+      <Grid.Item full as={ViewHeader}>
+        Make alt id
+      </Grid.Item>
+
+      {isDefaultState && (
+        <Grid.Item full as={Text}>
+          Type out your altId
+        </Grid.Item>
+      )}
+
+      <BridgeForm validate={validate} onValues={onValues}>
+        {({ handleSubmit, values }) => (
+          <>
+            {completed && (
+              <Grid.Item
+                full
+                as={Text}
+                className={cn('f5 wrap', {
+                  green3: completed,
+                })}>
+                AltId {values.point} has been made
+              </Grid.Item>
+            )}
+
+            {!completed && (
+              <>
+                <Grid.Item
+                  full
+                  as={PointInput}
+                  name="point"
+                  disabled={inputsLocked}
+                  className="mt4"
+                />
+              </>
+            )}
+
+            <Grid.Item full as={FormError} />
+
+            <Grid.Item
+              full
+              as={InlineEthereumTransaction}
+              {...bind}
+              onReturn={() => pop()}
+            />
+          </>
+        )}
+      </BridgeForm>
+    </Grid>
+  );
+}

--- a/src/views/UrbitID/Claims/MakeClaim.js
+++ b/src/views/UrbitID/Claims/MakeClaim.js
@@ -1,0 +1,129 @@
+import React, { useCallback } from 'react';
+import cn from 'classnames';
+import { Grid, Text } from 'indigo-react';
+import { useLocalRouter } from 'lib/LocalRouter';
+import useMakeClaim from 'lib/useMakeClaim';
+import ViewHeader from 'components/ViewHeader';
+import InlineEthereumTransaction from 'components/InlineEthereumTransaction';
+import { HexInput, TextInput } from 'form/Inputs';
+import {
+  composeValidator,
+  hasErrors,
+  buildBytesValidator,
+} from 'form/validators';
+import BridgeForm from 'form/BridgeForm';
+import FormError from 'form/FormError';
+
+export default function MakeClaim() {
+  const { pop } = useLocalRouter();
+
+  const {
+    isDefaultState,
+    construct,
+    unconstruct,
+    completed,
+    inputsLocked,
+    bind,
+  } = useMakeClaim();
+
+  const validate = composeValidator(
+    {
+      protocol: () => {},
+      claim: () => {},
+      dossier: buildBytesValidator(),
+    },
+    (values, errors) => {
+      if (hasErrors(errors)) {
+        return errors;
+      }
+    }
+  );
+
+  const onValues = useCallback(
+    ({ valid, values }) => {
+      if (valid) {
+        construct(
+          values.protocol || '',
+          values.claim || '',
+          values.dossier || '0x'
+        );
+      } else {
+        unconstruct();
+      }
+    },
+    [construct, unconstruct]
+  );
+
+  return (
+    <Grid>
+      <Grid.Item full as={ViewHeader}>
+        Make claim
+      </Grid.Item>
+
+      {isDefaultState && (
+        <Grid.Item full as={Text}>
+          Type out your claim
+        </Grid.Item>
+      )}
+
+      <BridgeForm validate={validate} onValues={onValues}>
+        {({ handleSubmit, values }) => (
+          <>
+            {completed && (
+              <Grid.Item
+                full
+                as={Text}
+                className={cn('f5 wrap', {
+                  green3: completed,
+                })}>
+                Claim {values.claim} has been made with {values.protocol} and
+                dossier: {values.dossier || '0x'}
+              </Grid.Item>
+            )}
+
+            {!completed && (
+              <>
+                <Grid.Item
+                  full
+                  as={TextInput}
+                  name="protocol"
+                  placeholder="protocol"
+                  disabled={inputsLocked}
+                  label="Protocol"
+                  className="mt4"
+                />
+                <Grid.Item
+                  full
+                  as={TextInput}
+                  className="mb4"
+                  name="claim"
+                  placeholder="claim"
+                  label="Claim"
+                  disabled={inputsLocked}
+                />
+                <Grid.Item
+                  full
+                  as={HexInput}
+                  className="mb4"
+                  name="dossier"
+                  placeholder="0xdossier"
+                  label="Dossier"
+                  disabled={inputsLocked}
+                />
+              </>
+            )}
+
+            <Grid.Item full as={FormError} />
+
+            <Grid.Item
+              full
+              as={InlineEthereumTransaction}
+              {...bind}
+              onReturn={() => pop()}
+            />
+          </>
+        )}
+      </BridgeForm>
+    </Grid>
+  );
+}

--- a/src/views/UrbitID/Home.js
+++ b/src/views/UrbitID/Home.js
@@ -49,6 +49,8 @@ export default function UrbitIDHome() {
 
   const goTransfer = useCallback(() => push(names.TRANSFER), [names, push]);
 
+  const goClaims = useCallback(() => push(names.CLAIMS), [names, push]);
+
   const renderProxyAction = useCallback(
     (proxyType, address) => {
       const disabled =
@@ -158,6 +160,17 @@ export default function UrbitIDHome() {
           <B className="wrap ws-normal"> · Ownership key required</B>
         }>
         Transfer this point
+      </Grid.Item>
+      <Grid.Divider />
+      <Grid.Item
+        full
+        as={ForwardButton}
+        onClick={goClaims}
+        disabled={!isOwner}
+        disabledDetail={
+          <B className="wrap ws-normal"> · Ownership key required</B>
+        }>
+        Claims and alt id
       </Grid.Item>
     </Grid>
   );


### PR DESCRIPTION
This PR adds support for alt-id and arbitrary claims.

This is associated with the broader antechamber initiative, described [here](https://gist.github.com/jalehman/1a3142dc30cc730159ab2daf9bcb726e)

The core functionality is all finished in this PR. The explainer components are not quite there. There is no solution to notifying a point that another point has made an alt-id claim to them without some data availability that comes from EVM event reduction, as the Claims contract does not support such arbitrary querying.