### PR TITLE
release: make "available" count consistent

### DIFF
--- a/src/lib/starRelease.js
+++ b/src/lib/starRelease.js
@@ -108,8 +108,7 @@ export async function getConditional(contracts, address) {
   }
 
   const withdrawnTotal = withdrawn.reduce((acc, val) => acc + val, 0);
-  const available =
-    batchLimits.reduce((acc, val) => acc + val, 0) + withdrawnTotal;
+  const available = batchLimits.reduce((acc, val) => acc + val, 0);
 
   return { total, available, withdrawn: withdrawnTotal, batchLimits };
 }

--- a/src/views/Release/Locked.js
+++ b/src/views/Release/Locked.js
@@ -88,7 +88,7 @@ export default function Locked({ className, goActive }) {
     [construct, unconstruct]
   );
 
-  const canWithdraw = starReleaseDetails.map(b => b.available - b.withdrawn);
+  const canWithdraw = starReleaseDetails.map(b => b.available);
   const total = starReleaseDetails.map(b => b.total);
 
   const validate = useMemo(


### PR DESCRIPTION
Linear Release was treating it as "amount we can still withdraw",
Conditional Release was treating it as "total we could have withdrawn".
The former seems simpler to reason about, and is what the UI layer
actually cares about, so we go with that.

Fixes #532. (Sorry for the wait on this, @eglaysher!)