### PR TITLE
trezor: sign message explicitly with ethereum path

### DIFF
--- a/src/lib/trezor.js
+++ b/src/lib/trezor.js
@@ -37,7 +37,7 @@ const trezorSignTransaction = async (txn, hdpath) => {
 };
 
 export const trezorSignMessage = async (message, hdPath) => {
-  const sig = await TrezorConnect.signMessage({
+  const sig = await TrezorConnect.ethereumSignMessage({
     path: hdPath,
     message,
   });


### PR DESCRIPTION
Calling [this function](https://github.com/trezor/connect/blob/develop/docs/methods/ethereumSignMessage.md) instead of the generic one makes it open up the derivation
paths users are most likely to be hitting. The custom path case is still prone
to getting tripped up by the "forbidden path" security check though.

Fixes #513 as best we can. Any case that's still running into that issue should probably use `trezorctl set safety-checks prompt` to loosen up Trezor's "security" "feature".