### PR TITLE
release: correct numbers for linear star release

### DIFF
--- a/src/lib/starRelease.js
+++ b/src/lib/starRelease.js
@@ -119,11 +119,8 @@ export async function getLinear(contracts, address) {
   const batch = await linearSR.getBatch(contracts, address);
   const { amount, withdrawn } = batch;
 
-  // Contract errors on withdrawing from a user that does not have any
-  const available =
-    amount > 0
-      ? Math.min(await linearSR.getWithdrawLimit(contracts, address), remaining)
-      : 0;
+  const limit = await linearSR.getWithdrawLimit(contracts, address);
+  const available = Math.min(limit - withdrawn, remaining);
 
   const total = Math.min(amount, remaining);
 

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -108,7 +108,7 @@ export const validateMinimumLength = l => v =>
   v.length < l && `Must be ${l} characters or more.`;
 
 export const validateGreaterThan = l => v =>
-  !(v > l) && `Must be at least ${l}.`;
+  !(v > l) && `Must be greater than ${l}.`;
 
 export const validateLessThan = l => v => !(v < l) && `Must be less than ${l}`;
 

--- a/src/views/Release/Locked.js
+++ b/src/views/Release/Locked.js
@@ -95,7 +95,7 @@ export default function Locked({ className, goActive }) {
     () =>
       composeValidator(
         {
-          numStars: buildNumberValidator(0, canWithdraw + 1),
+          numStars: buildNumberValidator(0, canWithdraw.getOrElse(0) + 1),
         },
         (values, errors) => (inputsLocked ? false : errors)
       ),


### PR DESCRIPTION
Also tweaks the validator message to be more correct.

(Kinda messed up how number validator ranges are exclusive on both sides, but eh, outside of scope.)

Fixes #540.