### PR TITLE
Prevent "Cannot read property 'map' of null" jank

### DIFF
--- a/src/Bridge.js
+++ b/src/Bridge.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useEffect } from 'react';
 import { hot } from 'react-hot-loader/root';
 import { Just, Nothing } from 'folktale/maybe';
 import { IndigoApp } from 'indigo-react';
@@ -65,6 +66,14 @@ function useInitialRoutes() {
 
 function Bridge() {
   const initialRoutes = useInitialRoutes();
+
+  //  full reload if the user changes their selected network in Metamask
+  //
+  useEffect(() => {
+    window.ethereum.on('chainChanged', () => {
+      document.location.reload();
+    });
+  }, []);
 
   return (
     <WithErrorBoundary render={error => <GlobalErrorBoundary error={error} />}>

--- a/src/store/lib/useControlledPointsStore.js
+++ b/src/store/lib/useControlledPointsStore.js
@@ -37,17 +37,29 @@ export default function useControlledPointsStore() {
         azimuth.azimuth.getSpawningFor(_contracts, address),
       ]);
 
-      _setControlledPoints(
-        Just(
-          Result.Ok({
-            ownedPoints,
-            incomingPoints,
-            managingPoints,
-            votingPoints,
-            spawningPoints,
-          })
-        )
-      );
+      if (
+        ownedPoints === null &&
+        incomingPoints === null &&
+        managingPoints === null &&
+        votingPoints === null &&
+        spawningPoints === null
+      ) {
+        _setControlledPoints(
+          Just(Result.Error('Failed to read the blockchain.'))
+        );
+      } else {
+        _setControlledPoints(
+          Just(
+            Result.Ok({
+              ownedPoints,
+              incomingPoints,
+              managingPoints,
+              votingPoints,
+              spawningPoints,
+            })
+          )
+        );
+      }
     } catch (error) {
       _setControlledPoints(Just(Result.Error(error)));
     }

--- a/src/views/Points.js
+++ b/src/views/Points.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { Just, Nothing } from 'folktale/maybe';
+import { Just, Nothing, Result } from 'folktale/maybe';
 import { Grid, H5, HelpText, LinkButton, Flex } from 'indigo-react';
 import { get } from 'lodash';
 
@@ -15,6 +15,7 @@ import useIsEclipticOwner from 'lib/useIsEclipticOwner';
 import { useSyncKnownPoints, useSyncOwnedPoints } from 'lib/useSyncPoints';
 import useRejectedIncomingPointTransfers from 'lib/useRejectedIncomingPointTransfers';
 import pluralize from 'lib/pluralize';
+import newGithubIssueUrl from 'new-github-issue-url';
 
 import View from 'components/View';
 import Blinky from 'components/Blinky';
@@ -222,6 +223,36 @@ export default function Points() {
     names.STAR_RELEASE,
     push,
   ]);
+
+  //  if we got an error result, we should display it, instead of showing
+  //  a potentially inaccurately empty point list.
+  //
+  if (
+    Just.hasInstance(controlledPoints) &&
+    controlledPoints.value.matchWith({
+      Error: e => true,
+      Ok: v => false,
+    })
+  ) {
+    const url = newGithubIssueUrl({
+      user: 'urbit',
+      repo: 'bridge',
+      title: controlledPoints.value.value,
+      body: `<!-- Please provide some context. Do you have Metamask installed? What login method did you use? -->`,
+    });
+    return (
+      <View inset>
+        <Grid>
+          <Grid.Item full as={HelpText} className="mt8 t-center">
+            {controlledPoints.value.value}
+            <br />
+            Try reloading the page. If this problem persists, please{' '}
+            <a href={url}>file an issue on GitHub</a>.
+          </Grid.Item>
+        </Grid>
+      </View>
+    );
+  }
 
   if (
     loading ||


### PR DESCRIPTION
As mentioned in https://github.com/urbit/bridge/issues/554#issuecomment-802810525, a confirmed trigger for this crash is Metamask changing the target chain out from under us. So we add a handler for that, and fully reload the Bridge page, to help us get off to a clean start.

Also as previously mentioned, I suspect this isn't the only trigger for the crash, but I'm struggling to come up with further reproduction. To help users out, I added a smol error state/screen.

<img width="520" alt="image" src="https://user-images.githubusercontent.com/3829764/111790750-d2680f00-88c2-11eb-88ac-7c8e42b5d8e4.png">

That links to [this issue template](https://github.com/urbit/bridge/issues/new?body=%3C%21--+Please+provide+some+context.+Do+you+have+Metamask+installed%3F+What+login+method+did+you+use%3F+--%3E&title=Failed+to+read+the+blockchain.). Even if we don't get super useful information out of those reports, still useful to know that they're happening, and whether or not Metamask is always in the picture.