### PR TITLE
network: get ecliptic & polls addresses from chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@tlon/sigil-js": "^1.4.1",
     "@welldone-software/why-did-you-render": "^3.2.3",
     "async-retry": "^1.2.3",
-    "azimuth-js": "^0.19.0",
+    "azimuth-js": "^0.22.1",
     "azimuth-solidity": "^1.2.2",
     "bip32": "^1.0.2",
     "bip39": "^2.5.0",

--- a/src/lib/contracts.js
+++ b/src/lib/contracts.js
@@ -1,24 +1,18 @@
 const CONTRACT_ADDRESSES = {
   DEV: {
-    ecliptic: '0x56db68f29203ff44a803faa2404a44ecbb7a7480',
     azimuth: '0x863d9c2e5c4c133596cfac29d55255f0d0f86381',
-    polls: '0x935452c45eda2958976a429c9733c40302995efd',
     delegatedSending: '0xb71c0b6cee1bcae56dfe95cd9d3e41ddd7eafc43',
     linearSR: '0x03C3dC12BE658158D1d7F9e66E08ec4099c568e4',
     conditionalSR: '0x35EB3B102d9C1B69Ac1469C1B1FE1799850CD3EB',
   },
   ROPSTEN: {
-    ecliptic: '0x8b9f86a28921d9c705b3113a755fb979e1bd1bce',
     azimuth: '0x308ab6a6024cf198b57e008d0ac9ad0219886579',
-    polls: '0xf5DA85f0d285A0F88af2388DD177A221872C8971',
     delegatedSending: '0x3e8ca510354bc2fdbbd6150252d93105c9c27bbe',
     linearSR: '0x1f8edd031ee414740aedb39b84fb8f2f66ca422f',
     conditionalSR: '0x1f8edd031ee414740aedb39b84fb8f2f66ca422f',
   },
   MAINNET: {
-    ecliptic: '0x6ac07b7c4601b5ce11de8dfe6335b871c7c4dd4d',
     azimuth: '0x223c067f8cf28ae173ee5cafea60ca44c335fecb',
-    polls: '0x7fecab617c868bb5996d99d95200d2fa708218e4',
     delegatedSending: '0xF7908Ab1F1e352F83c5ebc75051c0565AEaea5FB',
     linearSR: '0x86cd9cd0992f04231751e3761de45cecea5d1801',
     conditionalSR: '0x8c241098c3d3498fe1261421633fd57986d74aea',

--- a/src/store/network.js
+++ b/src/store/network.js
@@ -54,15 +54,18 @@ function _useNetwork(initialNetworkType = null) {
           web3,
           contractAddresses.azimuth
         );
-        contracts.linearSR = azimuth.contracts.newLinearStarRelease(
+        contracts = azimuth.contracts.newLinearStarRelease(
+          contracts,
           web3,
           contractAddresses.linearSR
         );
-        contracts.conditionalSR = azimuth.contracts.newConditionalStarRelease(
+        contracts = azimuth.contracts.newConditionalStarRelease(
+          contracts,
           web3,
           contractAddresses.conditionalSR
         );
-        contracts.delegatedSending = azimuth.contracts.newDelegatedSending(
+        contracts = azimuth.contracts.newDelegatedSending(
+          contracts,
           web3,
           contractAddresses.delegatedSending
         );

--- a/src/store/network.js
+++ b/src/store/network.js
@@ -16,10 +16,16 @@ import { NETWORK_TYPES, chainIdToNetworkType } from '../lib/network';
 import { isDevelopment } from '../lib/flags';
 import { BRIDGE_ERROR } from '../lib/error';
 
+import { Grid } from 'indigo-react';
+import View from 'components/View';
+import Blinky from 'components/Blinky';
+
 function _useNetwork(initialNetworkType = null) {
   const [networkType, setNetworkType] = useState(initialNetworkType);
 
   const [metamask, setMetamask] = useState(false);
+  const [web3, setWeb3] = useState(Nothing());
+  const [contracts, setContracts] = useState(Nothing());
 
   useEffect(() => {
     (async () => {
@@ -35,71 +41,90 @@ function _useNetwork(initialNetworkType = null) {
     })();
   }, []);
 
-  const { web3, contracts } = useMemo(() => {
-    // given a web3 provider and contract addresses,
-    // build the web3 and contracts objects
-    const initWeb3 = (provider, contractAddresses) => {
-      // use an in-window eth provider if possible
-      const _provider = metamask ? window.ethereum : provider;
-      const web3 = new Web3(_provider);
-      const contracts = azimuth.initContracts(web3, contractAddresses);
+  useEffect(() => {
+    (async () => {
+      // given a web3 provider and contract addresses,
+      // build the web3 and contracts objects
+      const initWeb3 = async (provider, contractAddresses) => {
+        // use an in-window eth provider if possible
+        const _provider = metamask ? window.ethereum : provider;
+        const web3 = new Web3(_provider);
 
-      return {
-        web3: Just(web3),
-        contracts: Just(contracts),
+        let contracts = await azimuth.initContractsPartial(
+          web3,
+          contractAddresses.azimuth
+        );
+        contracts.linearSR = azimuth.newLinearStarRelease(
+          web3,
+          contractAddresses.linearSR
+        );
+        contracts.conditionalSR = azimuth.newConditionalStarRelease(
+          web3,
+          contractAddresses.conditionalSR
+        );
+        contracts.delegatedSending = azimuth.newDelegatedSending(
+          web3,
+          contractAddresses.delegatedSending
+        );
+
+        setWeb3(Just(web3));
+        setContracts(Just(contracts));
+        return;
       };
-    };
 
-    switch (networkType) {
-      case NETWORK_TYPES.LOCAL: {
-        const protocol = isDevelopment ? 'ws' : 'wss';
-        const endpoint = `${protocol}://${document.location.hostname}:8545`;
+      switch (networkType) {
+        case NETWORK_TYPES.LOCAL: {
+          const protocol = isDevelopment ? 'ws' : 'wss';
+          const endpoint = `${protocol}://${document.location.hostname}:8545`;
 
-        return initWeb3(
-          new Web3.providers.WebsocketProvider(endpoint),
-          CONTRACT_ADDRESSES.DEV
-        );
-      }
-      case NETWORK_TYPES.ROPSTEN: {
-        const endpoint = `https://ropsten.infura.io/v3/${process.env.REACT_APP_INFURA_ENDPOINT}`;
+          initWeb3(
+            new Web3.providers.WebsocketProvider(endpoint),
+            CONTRACT_ADDRESSES.DEV
+          );
+          return;
+        }
+        case NETWORK_TYPES.ROPSTEN: {
+          const endpoint = `https://ropsten.infura.io/v3/${process.env.REACT_APP_INFURA_ENDPOINT}`;
 
-        return initWeb3(
-          new Web3.providers.HttpProvider(endpoint),
-          CONTRACT_ADDRESSES.ROPSTEN
-        );
-      }
-      case NETWORK_TYPES.MAINNET: {
-        const endpoint = `https://mainnet.infura.io/v3/${process.env.REACT_APP_INFURA_ENDPOINT}`;
+          initWeb3(
+            new Web3.providers.HttpProvider(endpoint),
+            CONTRACT_ADDRESSES.ROPSTEN
+          );
+          return;
+        }
+        case NETWORK_TYPES.MAINNET: {
+          const endpoint = `https://mainnet.infura.io/v3/${process.env.REACT_APP_INFURA_ENDPOINT}`;
 
-        return initWeb3(
-          new Web3.providers.HttpProvider(endpoint),
-          CONTRACT_ADDRESSES.MAINNET
-        );
-      }
-      case NETWORK_TYPES.OFFLINE:
-      default: {
-        // NB (jtobin):
-        //
-        // The 'offline' network type targets the mainnet contracts, but does not
-        // actually use a provider to connect.  We use a web3 instance to
-        // initalise the contracts, but the network itself is set to Nothing.
-        //
-        // We may want to offer the ability to select a target network for
-        // transactions when offline.
+          initWeb3(
+            new Web3.providers.HttpProvider(endpoint),
+            CONTRACT_ADDRESSES.MAINNET
+          );
+          return;
+        }
+        case NETWORK_TYPES.OFFLINE:
+        default: {
+          // NB (jtobin):
+          //
+          // The 'offline' network type targets the mainnet contracts, but does
+          // not actually use a provider to connect.  We use a web3 instance to
+          // initalise the contracts, but the network itself is set to Nothing.
+          //
+          // We may want to offer the ability to select a target network for
+          // transactions when offline.
 
-        // Note: example.com:3456 doesn't actually point to anything, we just need
-        // a provider to initialize the Web3 object
-        return {
-          ...initWeb3(
+          // Note: example.com:3456 doesn't actually point to anything, we just
+          // need a provider to initialize the Web3 object
+          initWeb3(
             new Web3.providers.HttpProvider('http://example.com:3456'),
             isDevelopment ? CONTRACT_ADDRESSES.DEV : CONTRACT_ADDRESSES.MAINNET
-          ),
-          web3: Nothing(),
+          );
+          setWeb3(Nothing());
           // ^ overwrite the web3 object from initWeb3 with a Nothing
           // to indicate that there is no valid web3 connection
-        };
+          return;
+        }
       }
-    }
+    })();
   }, [networkType, metamask]);
 
   return { networkType, setNetworkType, web3, contracts };
@@ -110,9 +135,24 @@ const NetworkContext = createContext(null);
 // provider
 export function NetworkProvider({ initialNetworkType, children }) {
   const value = _useNetwork(initialNetworkType);
-  return (
-    <NetworkContext.Provider value={value}>{children}</NetworkContext.Provider>
-  );
+
+  if (Just.hasInstance(value.contracts)) {
+    return (
+      <NetworkContext.Provider value={value}>
+        {children}
+      </NetworkContext.Provider>
+    );
+  } else {
+    return (
+      <View inset>
+        <Grid>
+          <Grid.Item full className="mt8 t-center">
+            <Blinky /> Connecting...
+          </Grid.Item>
+        </Grid>
+      </View>
+    );
+  }
 }
 
 // hook consumer

--- a/src/store/network.js
+++ b/src/store/network.js
@@ -54,15 +54,15 @@ function _useNetwork(initialNetworkType = null) {
           web3,
           contractAddresses.azimuth
         );
-        contracts.linearSR = azimuth.newLinearStarRelease(
+        contracts.linearSR = azimuth.contracts.newLinearStarRelease(
           web3,
           contractAddresses.linearSR
         );
-        contracts.conditionalSR = azimuth.newConditionalStarRelease(
+        contracts.conditionalSR = azimuth.contracts.newConditionalStarRelease(
           web3,
           contractAddresses.conditionalSR
         );
-        contracts.delegatedSending = azimuth.newDelegatedSending(
+        contracts.delegatedSending = azimuth.contracts.newDelegatedSending(
           web3,
           contractAddresses.delegatedSending
         );


### PR DESCRIPTION
Instead of hardcoding their contract addresses, use azimuth-js's
initContractsPartial to retrieve the Ecliptic and Polls contracts
dynamically.

Depends on as-of-yet unreleased azimuth-js changes (specifically,
exposing its newContract functions), but going ahead and putting this
up for review.