### PR TITLE
bitcoin: add flow for viewing bitcoin extended key

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@welldone-software/why-did-you-render": "^3.2.3",
     "async-retry": "^1.2.3",
     "azimuth-js": "^0.22.1",
-    "azimuth-solidity": "^1.2.2",
+    "azimuth-solidity": "^1.2.3",
     "bip32": "^1.0.2",
     "bip39": "^2.5.0",
     "bitcoinjs-lib": "^5.2.0",

--- a/src/lib/flowCommand.js
+++ b/src/lib/flowCommand.js
@@ -12,10 +12,13 @@ import { isValidAddress } from './wallet';
 // ? kind = btc
 // & utx  = somebase64string
 //
+// ? kind = xpub
+//
 
 const COMMANDS = {
   TAKE_LOCKUP: 'takeLockup',
   BITCOIN: 'btc',
+  XPUB: 'xpub',
 };
 
 const useFlowCommand = () => {
@@ -49,6 +52,9 @@ const useFlowCommand = () => {
           } catch (e) {
             flow = null;
           }
+          break;
+        //
+        case COMMANDS.XPUB:
           break;
         //
         default:

--- a/src/views/Login.js
+++ b/src/views/Login.js
@@ -1,51 +1,21 @@
 import React, { useCallback, useState } from 'react';
-import { P, H4, H5, Grid, Text, Button, Flex, LinkButton } from 'indigo-react';
+import { Grid, Text, Button, Flex, LinkButton } from 'indigo-react';
 
 import { version } from '../../package.json';
 
 import { useHistory } from 'store/history';
-import { useWallet } from 'store/wallet';
-import { usePointCursor } from 'store/pointCursor';
 
-import { WALLET_TYPES } from 'lib/wallet';
 import { COMMANDS, useFlowCommand } from 'lib/flowCommand';
 
 import View from 'components/View';
-import Tabs from 'components/Tabs';
-import Crumbs from 'components/Crumbs';
 import Footer from 'components/Footer';
-import { ForwardButton, OfflineButton } from 'components/Buttons';
 
 import Ticket from './Login/Ticket';
 import Other from './Login/Other';
 
-const NAMES = {
-  TICKET: 'TICKET',
-  OTHER: 'OTHER',
-};
-
-const VIEWS = {
-  [NAMES.TICKET]: Ticket,
-  [NAMES.OTHER]: Other,
-};
-
-const OPTIONS = [
-  { text: 'Master Ticket', value: NAMES.TICKET },
-  { text: 'Other', value: NAMES.OTHER },
-];
-
-const walletTypeToViewName = walletType => {
-  if (walletType === WALLET_TYPES.TICKET || !walletType) {
-    return NAMES.TICKET;
-  }
-  return NAMES.OTHER;
-};
-
 export default function Login() {
   // globals
-  const { pop, push, names } = useHistory();
-  const { walletType } = useWallet();
-  const { setPointCursor } = usePointCursor();
+  const { push, names } = useHistory();
   const flow = useFlowCommand();
 
   // inputs

--- a/src/views/Login.js
+++ b/src/views/Login.js
@@ -63,9 +63,14 @@ export default function Login() {
       switch (flow.kind) {
         case COMMANDS.TAKE_LOCKUP:
           push(names.ACCEPT_LOCKUP);
+          break;
         //
         case COMMANDS.BITCOIN:
           push(names.BITCOIN_SIGN_TRANSACTION);
+          break;
+        //
+        case COMMANDS.XPUB:
+          push(names.BITCOIN_XPUB);
           break;
         //
         default:
@@ -82,6 +87,9 @@ export default function Login() {
       //
       case COMMANDS.BITCOIN:
         return <>To sign a Bitcoin transaction, please sign in.</>;
+      //
+      case COMMANDS.XPUB:
+        return <>To view your Bitcoin extended public key, please sign in</>;
       //
       default:
         return <>Flow: {command.kind}</>;


### PR DESCRIPTION
We want to encourage people to do the key-sensitive BTC stuff with Bridge instead of wildly throwing around their master ticket in the BTC wallet app, so we need a flow for the xpub as well.

Also cleaned up whatever the linter complained about in `Login.js` and more importantly bumped `azimuth-solidity` to `1.2.3`, the development environment wouldn't compile otherwise.