### PR TITLE
store: more nuanced syncing

### DIFF
--- a/src/components/Passport.js
+++ b/src/components/Passport.js
@@ -7,7 +7,7 @@ import 'style/anim.css';
 import * as need from 'lib/need';
 import { chunkStr, Matrix, walk, rand } from 'lib/card';
 import usePermissionsForPoint from 'lib/usePermissionsForPoint';
-import { useSyncOwnedPoints } from 'lib/useSyncPoints';
+import { useSyncDetails } from 'lib/useSyncPoints';
 import { buildKeyType } from 'lib/point';
 
 import { useWallet } from 'store/wallet';
@@ -212,7 +212,7 @@ const Cell = props => {
  *
  */
 function MiniPassport({ point, inverted, ...rest }) {
-  useSyncOwnedPoints([point]);
+  useSyncDetails([point]);
   const { wallet } = useWallet();
   const address = need.addressFromWallet(wallet);
 

--- a/src/lib/useSyncPoints.js
+++ b/src/lib/useSyncPoints.js
@@ -21,12 +21,12 @@ export const useSyncKnownPoints = buildSyncHook(function() {
   return syncKnownPoint;
 });
 
-export const useSyncForeignPoints = buildSyncHook(function() {
-  const { syncForeignPoint } = usePointCache();
-  return syncForeignPoint;
+export const useSyncDetails = buildSyncHook(function() {
+  const { syncDetails } = usePointCache();
+  return syncDetails;
 });
 
-export const useSyncOwnedPoints = buildSyncHook(function() {
-  const { syncOwnedPoint } = usePointCache();
-  return syncOwnedPoint;
+export const useSyncExtras = buildSyncHook(function() {
+  const { syncExtras } = usePointCache();
+  return syncExtras;
 });

--- a/src/lib/useSyncPoints.js
+++ b/src/lib/useSyncPoints.js
@@ -16,9 +16,9 @@ const buildSyncHook = getFn =>
     }, [fn, prevPoints, points]);
   };
 
-export const useSyncKnownPoints = buildSyncHook(function() {
-  const { syncKnownPoint } = usePointCache();
-  return syncKnownPoint;
+export const useSyncDates = buildSyncHook(function() {
+  const { syncDates } = usePointCache();
+  return syncDates;
 });
 
 export const useSyncDetails = buildSyncHook(function() {

--- a/src/store/lib/usePointStore.js
+++ b/src/store/lib/usePointStore.js
@@ -20,8 +20,7 @@ export default function usePointStore() {
   const { syncResidents, syncResidentCount, ...residents } = useResidents();
   const ecliptic = useEclipticOwnerStore();
 
-  //TODO  more appropriately named "syncDates" or similar
-  const syncKnownPoint = useCallback(
+  const syncDates = useCallback(
     async point => Promise.all([syncBirthday(point), syncRekeyDate(point)]),
     [syncBirthday, syncRekeyDate]
   );
@@ -29,13 +28,13 @@ export default function usePointStore() {
   const syncExtras = useCallback(
     async point =>
       Promise.all([
-        syncKnownPoint(point),
-        //
-        syncResidentCount(point),
         syncDetails(point),
+        //
+        syncDates(point),
+        syncResidentCount(point),
         syncInvites(point),
       ]),
-    [syncKnownPoint, syncDetails, syncInvites, syncResidentCount]
+    [syncDates, syncDetails, syncInvites, syncResidentCount]
   );
 
   return {
@@ -50,7 +49,7 @@ export default function usePointStore() {
     syncRekeyDate,
     syncInvites,
     syncControlledPoints,
-    syncKnownPoint,
+    syncDates,
     syncResidents,
     syncExtras,
   };

--- a/src/store/lib/usePointStore.js
+++ b/src/store/lib/usePointStore.js
@@ -20,38 +20,22 @@ export default function usePointStore() {
   const { syncResidents, syncResidentCount, ...residents } = useResidents();
   const ecliptic = useEclipticOwnerStore();
 
-  // sync all of the on-chain info required to display a known point
+  //TODO  more appropriately named "syncDates" or similar
   const syncKnownPoint = useCallback(
     async point => Promise.all([syncBirthday(point), syncRekeyDate(point)]),
     [syncBirthday, syncRekeyDate]
   );
 
-  // sync all of the on-chain info required to display a foreign point
-  const syncForeignPoint = useCallback(
-    async point => {
-      syncDetails(point);
-    },
-    [syncDetails]
-  );
-
-  // sync all of the on-chain info required for a point that the user owns
-  const syncOwnedPoint = useCallback(
+  const syncExtras = useCallback(
     async point =>
       Promise.all([
-        syncForeignPoint(point),
         syncKnownPoint(point),
         //
         syncResidentCount(point),
         syncDetails(point),
         syncInvites(point),
       ]),
-    [
-      syncForeignPoint,
-      syncKnownPoint,
-      syncDetails,
-      syncInvites,
-      syncResidentCount,
-    ]
+    [syncKnownPoint, syncDetails, syncInvites, syncResidentCount]
   );
 
   return {
@@ -67,8 +51,7 @@ export default function usePointStore() {
     syncInvites,
     syncControlledPoints,
     syncKnownPoint,
-    syncOwnedPoint,
-    syncForeignPoint,
     syncResidents,
+    syncExtras,
   };
 }

--- a/src/views/Activate.js
+++ b/src/views/Activate.js
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 
 import useRouter from 'lib/useRouter';
 import { LocalRouterProvider } from 'lib/LocalRouter';
-import { useSyncKnownPoints } from 'lib/useSyncPoints';
+import { useSyncDates } from 'lib/useSyncPoints';
 
 import { ActivateFlowProvider } from './Activate/ActivateFlow';
 import useActivateFlowState from './Activate/useActivateFlowState';
@@ -38,9 +38,7 @@ export default function Activate() {
   }, []);
 
   // when we know the derived point, ensure we have the data to display it
-  useSyncKnownPoints(
-    [state.derivedPoint.getOrElse(null)].filter(p => p !== null)
-  );
+  useSyncDates([state.derivedPoint.getOrElse(null)].filter(p => p !== null));
 
   return (
     <LocalRouterProvider value={router}>

--- a/src/views/CreateGalaxy.js
+++ b/src/views/CreateGalaxy.js
@@ -29,7 +29,7 @@ import CopiableAddress from 'components/CopiableAddress';
 
 function useCreateGalaxy() {
   const { contracts } = useNetwork();
-  const { syncKnownPoint } = usePointCache();
+  const { syncDates } = usePointCache();
 
   const _contracts = need.contracts(contracts);
 
@@ -43,7 +43,7 @@ function useCreateGalaxy() {
       },
       [_contracts]
     ),
-    useCallback(() => syncKnownPoint(galaxy), [galaxy, syncKnownPoint]),
+    useCallback(() => syncDates(galaxy), [galaxy, syncDates]),
     GAS_LIMITS.DEFAULT
   );
 }

--- a/src/views/Invite/Cohort.js
+++ b/src/views/Invite/Cohort.js
@@ -26,7 +26,7 @@ import Inviter from 'views/Invite/Inviter';
 
 import { ReactComponent as SearchIcon } from 'assets/search.svg';
 import CopyButton from 'components/CopyButton';
-import { useSyncForeignPoints } from 'lib/useSyncPoints';
+import { useSyncDetails } from 'lib/useSyncPoints';
 import { useNetwork } from 'store/network';
 import NavHeader from 'components/NavHeader';
 
@@ -305,7 +305,7 @@ export default function InviteCohort() {
 
   const [selectedInvite, _setSelectedInvite] = useState();
 
-  useSyncForeignPoints([..._acceptedPoints, ..._pendingPoints]);
+  useSyncDetails([..._acceptedPoints, ..._pendingPoints]);
 
   const setSelectedInvite = useCallback(
     p => _setSelectedInvite(old => (old === p ? null : p)),

--- a/src/views/IssueChild.js
+++ b/src/views/IssueChild.js
@@ -34,7 +34,7 @@ import convertToInt from 'lib/convertToInt';
 
 function useIssueChild() {
   const { contracts } = useNetwork();
-  const { syncKnownPoint } = usePointCache();
+  const { syncDates } = usePointCache();
 
   const _contracts = need.contracts(contracts);
 
@@ -48,10 +48,7 @@ function useIssueChild() {
       },
       [_contracts]
     ),
-    useCallback(() => syncKnownPoint(spawnedPoint), [
-      spawnedPoint,
-      syncKnownPoint,
-    ]),
+    useCallback(() => syncDates(spawnedPoint), [spawnedPoint, syncDates]),
     GAS_LIMITS.DEFAULT
   );
 }

--- a/src/views/Point.js
+++ b/src/views/Point.js
@@ -18,7 +18,7 @@ import { ForwardButton } from 'components/Buttons';
 
 import * as need from 'lib/need';
 import useInvites from 'lib/useInvites';
-import { useSyncOwnedPoints } from 'lib/useSyncPoints';
+import { useSyncExtras } from 'lib/useSyncPoints';
 import useCurrentPermissions from 'lib/useCurrentPermissions';
 import { useLocalRouter } from 'lib/LocalRouter';
 
@@ -216,7 +216,7 @@ export default function Point() {
   })();
 
   // sync the current cursor
-  useSyncOwnedPoints([point]);
+  useSyncExtras([point]);
 
   const address = need.addressFromWallet(wallet);
 

--- a/src/views/Points.js
+++ b/src/views/Points.js
@@ -12,7 +12,6 @@ import { useStarReleaseCache } from 'store/starRelease';
 import * as need from 'lib/need';
 import { isZeroAddress, abbreviateAddress } from 'lib/wallet';
 import useIsEclipticOwner from 'lib/useIsEclipticOwner';
-import { useSyncKnownPoints, useSyncOwnedPoints } from 'lib/useSyncPoints';
 import useRejectedIncomingPointTransfers from 'lib/useRejectedIncomingPointTransfers';
 import pluralize from 'lib/pluralize';
 import newGithubIssueUrl from 'new-github-issue-url';
@@ -203,16 +202,6 @@ export default function Points() {
   useEffect(() => {
     syncStarReleaseDetails();
   }, [syncStarReleaseDetails]);
-  // sync display details for known points
-  useSyncKnownPoints([
-    ...ownedPoints,
-    ...incomingPoints,
-    ...managingPoints,
-    ...votingPoints,
-    ...spawningPoints,
-  ]);
-
-  useSyncOwnedPoints(ownedPoints);
 
   const goCreateGalaxy = useCallback(() => push(names.CREATE_GALAXY), [
     names.CREATE_GALAXY,

--- a/src/views/Release/Active.js
+++ b/src/views/Release/Active.js
@@ -10,13 +10,13 @@ import { useWallet } from 'store/wallet';
 
 import * as need from 'lib/need';
 import usePermissionsForPoint from 'lib/usePermissionsForPoint';
-import { useSyncOwnedPoints } from 'lib/useSyncPoints';
+import { useSyncDetails } from 'lib/useSyncPoints';
 import { buildKeyType } from 'lib/point';
 
 function ActiveViewRow({ point, goPoint }) {
   const { wallet } = useWallet();
   const address = need.addressFromWallet(wallet);
-  useSyncOwnedPoints([point]);
+  useSyncDetails([point]);
   const permissions = usePermissionsForPoint(address, point);
 
   const keyType = buildKeyType(permissions);


### PR DESCRIPTION
This renames some of the syncing functions for clarity, and syncs less aggressively on the points list screen.

Previously, when loading the points list, we would fetch all kinds of details that only come into play once the user actually navigates to a point. This isn't a huge deal for two or three points, but for accounts that control double- or triple-digit points (not uncommon in the "star spawning planets" case), this would result in thousands of requests to the Ethereum node.

(Yes, thousands. This change brings it back to hundreds, but Bridge is still obviously doing way too much work here. Further changes will follow, some day...)

Requesting review from two people here, but review from either would be sufficient as well.