### PR TITLE
store: finish syncOwnedPoint -> syncExtras rename

### DIFF
--- a/src/views/AcceptTransfer.js
+++ b/src/views/AcceptTransfer.js
@@ -25,7 +25,7 @@ import { composeValidator, buildCheckboxValidator } from 'form/validators';
 function useAcceptTransfer() {
   const { contracts } = useNetwork();
   const { pointCursor } = usePointCursor();
-  const { syncOwnedPoint, syncControlledPoints } = usePointCache();
+  const { syncExtras, syncControlledPoints } = usePointCache();
   const { wallet } = useWallet();
 
   const _contracts = need.contracts(contracts);
@@ -39,8 +39,8 @@ function useAcceptTransfer() {
       [_contracts, _point, _address]
     ),
     useCallback(
-      () => Promise.all([syncOwnedPoint(_point), syncControlledPoints()]),
-      [_point, syncControlledPoints, syncOwnedPoint]
+      () => Promise.all([syncExtras(_point), syncControlledPoints()]),
+      [_point, syncControlledPoints, syncExtras]
     ),
     GAS_LIMITS.TRANSFER
   );

--- a/src/views/Party/PartySetPoolSize.js
+++ b/src/views/Party/PartySetPoolSize.js
@@ -33,7 +33,7 @@ import CopiableAddress from 'components/CopiableAddress';
 function useSetPoolSize() {
   const { contracts } = useNetwork();
   const { pointCursor } = usePointCursor();
-  const { syncOwnedPoint } = usePointCache();
+  const { syncExtras } = usePointCache();
 
   const _contracts = need.contracts(contracts);
   const _point = need.point(pointCursor);
@@ -49,7 +49,7 @@ function useSetPoolSize() {
         ),
       [_contracts, _point]
     ),
-    useCallback(() => syncOwnedPoint(_point), [_point, syncOwnedPoint]),
+    useCallback(() => syncExtras(_point), [_point, syncExtras]),
     GAS_LIMITS.DEFAULT // TODO: GAS_LIMITS.SET_POOL_SIZE
   );
 }

--- a/src/views/UrbitOS/ChangeSponsor.js
+++ b/src/views/UrbitOS/ChangeSponsor.js
@@ -26,7 +26,7 @@ import useEthereumTransaction from 'lib/useEthereumTransaction';
 function useChangeSponsor() {
   const { contracts } = useNetwork();
   const { pointCursor } = usePointCursor();
-  const { syncOwnedPoint } = usePointCache();
+  const { syncExtras } = usePointCache();
 
   const _contracts = need.contracts(contracts);
   const point = need.point(pointCursor);
@@ -37,8 +37,8 @@ function useChangeSponsor() {
       _contracts,
     ]),
     useCallback(() => {
-      syncOwnedPoint(point);
-    }, [syncOwnedPoint, point])
+      syncExtras(point);
+    }, [syncExtras, point])
   );
 }
 
@@ -128,7 +128,7 @@ function ChangeSponsor({ onDone }) {
 function useCancelEscape() {
   const { contracts } = useNetwork();
   const { pointCursor } = usePointCursor();
-  const { syncOwnedPoint } = usePointCache();
+  const { syncExtras } = usePointCache();
 
   const _contracts = need.contracts(contracts);
   const point = need.point(pointCursor);
@@ -138,7 +138,7 @@ function useCancelEscape() {
       point,
       _contracts,
     ]),
-    useCallback(() => syncOwnedPoint(point), [point, syncOwnedPoint])
+    useCallback(() => syncExtras(point), [point, syncExtras])
   );
 }
 


### PR DESCRIPTION
In #582 we had renamed some syncing functions, but neglected to replace-all for the `syncOwnedPoint` case. This completes what was started.