### PR TITLE
passport: include keyfile when available

### DIFF
--- a/src/lib/invite.js
+++ b/src/lib/invite.js
@@ -3,14 +3,14 @@ import * as wg from './walletgen';
 import JSZip from 'jszip';
 import saveAs from 'file-saver';
 
-export async function generateWallet(point) {
+export async function generateWallet(point, boot) {
   const ticket = await wg.makeTicket(point);
-  const wallet = await wg.generateWallet(point, ticket);
+  const wallet = await wg.generateWallet(point, ticket, boot);
   return wallet;
 }
 
 //TODO should be moved to lib/walletgen
-export async function downloadWallet(paperWallets) {
+export async function downloadWallet(paperWallets, keyfile, keyfilename) {
   if (paperWallets.length === 1) {
     const zip = new JSZip();
 
@@ -23,6 +23,10 @@ export async function downloadWallet(paperWallets) {
       const filename = `${ship}-${frame.givenName}.png`;
       folder.file(filename, frame.image);
     });
+
+    if (keyfile && keyfilename) {
+      folder.file(keyfilename, keyfile);
+    }
 
     await zip.generateAsync({ type: 'blob' }).then(content => {
       saveAs(content, `${zipName}.zip`);

--- a/src/views/Activate/ActivateCode.js
+++ b/src/views/Activate/ActivateCode.js
@@ -126,7 +126,7 @@ export default function ActivateCode() {
 
         setDerivedPoint(Just(point));
         setInviteWallet(inviteWallet);
-        setDerivedWallet(Just(await generateWallet(point)));
+        setDerivedWallet(Just(await generateWallet(point, true)));
       } else {
         return {
           [FORM_ERROR]:

--- a/src/views/Activate/PassportDownload.js
+++ b/src/views/Activate/PassportDownload.js
@@ -1,10 +1,12 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Just, Nothing } from 'folktale/maybe';
 import { Grid, P } from 'indigo-react';
+import ob from 'urbit-ob';
 
 import * as need from 'lib/need';
 import { downloadWallet } from 'lib/invite';
 import { useLocalRouter } from 'lib/LocalRouter';
+import { compileNetworkingKey } from 'lib/keys';
 
 import { DownloadButton, ForwardButton } from 'components/Buttons';
 import PaperBuilder from 'components/PaperBuilder';
@@ -20,7 +22,7 @@ export default function PassportDownload({ className }) {
     setGenerated,
   } = useActivateFlow();
   const { push, names } = useLocalRouter();
-  // const point = need.point(derivedPoint);
+  const point = need.point(derivedPoint);
   const wallet = need.wallet(derivedWallet);
 
   const [paper, setPaper] = useState(Nothing());
@@ -32,9 +34,12 @@ export default function PassportDownload({ className }) {
   });
 
   const download = useCallback(() => {
-    downloadWallet(paper.getOrElse([]));
+    const netkey = compileNetworkingKey(wallet.network.keys, point, 1);
+    //TODO  could be deduplicated with useKeyfileGenerator's logic
+    const filename = ob.patp(point).slice(1) + '-1.key';
+    downloadWallet(paper.getOrElse([]), netkey, filename);
     setDownloaded(true);
-  }, [paper, setDownloaded]);
+  }, [paper, wallet, point, setDownloaded]);
 
   // sync paper value to activation state
   useEffect(

--- a/src/views/UrbitID/DownloadKeys.js
+++ b/src/views/UrbitID/DownloadKeys.js
@@ -8,6 +8,7 @@ import { DownloadButton, RestartButton } from 'components/Buttons';
 import PaperBuilder from 'components/PaperBuilder';
 
 import { downloadWallet } from 'lib/invite';
+import useKeyfileGenerator from 'lib/useKeyfileGenerator';
 
 import { useWallet } from 'store/wallet';
 import { Grid, P } from 'indigo-react';
@@ -22,13 +23,15 @@ export default function AdminRedownload() {
   const _urbitWallet = need.wallet(urbitWallet);
   const point = need.point(pointCursor);
 
+  const { keyfile, filename } = useKeyfileGenerator();
+
   const [paper, setPaper] = useState(Nothing());
   const [downloaded, setDownloaded] = useState(false);
 
   const doDownload = useCallback(() => {
-    downloadWallet(paper.value);
+    downloadWallet(paper.value, keyfile, filename);
     setDownloaded(true);
-  }, [paper, setDownloaded]);
+  }, [paper, keyfile, filename, setDownloaded]);
 
   const goBack = useCallback(() => pop(), [pop]);
 


### PR DESCRIPTION
We include it during the invite flow, because we always end up
configuring the keys. And we include it when redownloading our passport,
if the auto-derived keys are available.