### PR TITLE
store: distinguish SR failure state from loading

### DIFF
--- a/src/store/lib/useStarReleaseStore.js
+++ b/src/store/lib/useStarReleaseStore.js
@@ -49,8 +49,8 @@ export default function useStarRelease() {
 
       _setDetails(Just(result));
     } catch (e) {
-      _setDetails(Nothing());
-      console.error(e);
+      _setDetails(Just(null));
+      console.error('error fetching star release details', e);
     }
   }, [contracts, wallet]);
 

--- a/src/views/Points.js
+++ b/src/views/Points.js
@@ -151,7 +151,8 @@ export default function Points() {
               all.length === 1 &&
               incoming.length === 0 &&
               maybeOutgoingPoints.value.length === 0 &&
-              starReleaseDetails.value.total === 0
+              (starReleaseDetails.value === null ||
+                starReleaseDetails.value.total === 0)
             ) {
               setPointCursor(Just(all[0]));
               popAndPush(names.POINT);
@@ -196,7 +197,7 @@ export default function Points() {
     !loading && incomingPoints.length === 0 && allPoints.length === 0;
 
   const starReleasing = starReleaseDetails
-    .map(s => s.total > 0)
+    .map(s => (s ? s.total > 0 : false))
     .getOrElse(false);
 
   useEffect(() => {


### PR DESCRIPTION
As it turns out, trying to fetch star release details for an account may
unexpectedly throw "invalid opcode" errors, if the account in question
does not have any stars in lockup(?). This in turn would result in the
points list screen staying stuck on "loading...".

We were already handling such exceptions, but were handling them
incorrectly*. We were setting the star release state to `Nothing()`,
which the points list was interpreting as "still loading".

Now, when we encounter any exception, we set the star release state to
`Just(null)`. This means the points list needs to do a little bit more
work to interpret the state, but lets it distinguish between "loading"
and "failed to load".

(* One can argue that "failure to load" does indeed imply we still do not
know what the actual state is, and so we should not set it yet. Even if
that's correct, it's not as practical/convenient as the changes herein.
At least for the time being, we choose "better" over "perfect".)

Should fix #589 and fix #536. See the latter for prior thinking on this issue. The most curious part here is that we had previously only seen this on Ropsten, where fetching these details was _expected_ to fail, but it's now rearing its head on mainnet as well.

Tagging @tomholford for review, but going ahead and self-merging right away to push this out as a hotfix. Please do still take a look when you get a chance.