### PR TITLE
points: sync details for owned points

### DIFF
--- a/src/views/Points.js
+++ b/src/views/Points.js
@@ -12,6 +12,7 @@ import { useStarReleaseCache } from 'store/starRelease';
 import * as need from 'lib/need';
 import { isZeroAddress, abbreviateAddress } from 'lib/utils/address';
 import useIsEclipticOwner from 'lib/useIsEclipticOwner';
+import { useSyncDetails } from 'lib/useSyncPoints';
 import useRejectedIncomingPointTransfers from 'lib/useRejectedIncomingPointTransfers';
 import pluralize from 'lib/pluralize';
 import newGithubIssueUrl from 'new-github-issue-url';
@@ -203,6 +204,9 @@ export default function Points() {
   useEffect(() => {
     syncStarReleaseDetails();
   }, [syncStarReleaseDetails]);
+
+  // sync display details for known points
+  useSyncDetails(ownedPoints);
 
   const goCreateGalaxy = useCallback(() => push(names.CREATE_GALAXY), [
     names.CREATE_GALAXY,


### PR DESCRIPTION
These are needed for the outgoing transfers check. If we don't have
them, the points list will just keep displaying the "loading..."
indicator until we get them.

This was removed during the simplification in #582, but turns out to
have been a bit too aggressive.

Should fix the second root cause of #589. Going ahead and self-merging again for the hotfix.