### PR TITLE
wallet: make publicToAddress more robust

### DIFF
--- a/src/lib/utils/address.ts
+++ b/src/lib/utils/address.ts
@@ -35,5 +35,5 @@ export const eqAddr = (addr0, addr1) =>
   toChecksumAddress(addr0) === toChecksumAddress(addr1);
 
 export const publicToAddress = (publicKey: Buffer): string => {
-  return toHex(pubToAddress(publicKey, true).toString('hex'));
+  return '0x' + pubToAddress(Buffer.from(publicKey), true).toString('hex');
 };


### PR DESCRIPTION
Apparently Uint8Arrays aren't quite enough like Buffers as far as
ethereumjs-util is concerned. Here we make sure we always pass in a
Buffer by creating one from whatever argument was passed in.

Arguably this needs fixing as the callsites instead, happy to discuss.

Fixes #604.