### PR TITLE
trezor: update transaction signing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33876,9 +33876,9 @@
       "integrity": "sha512-74MoNHhwLVuzwaPDcAecFjSkOA9vwWqyOdkeB0Be8Jc/IWSS5SNZKapFllqzkTliqZptkvqX5CZnVeDvfhN8cw=="
     },
     "trezor-connect": {
-      "version": "8.1.27",
-      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-8.1.27.tgz",
-      "integrity": "sha512-U6vP8kehQ5enCTY0k01R6jR3EORC+GIzTl4pM80lu9gJB5e988sM5YwK1hED6KZx7LJvFjWuOxB2J3W0pwv7lw==",
+      "version": "8.1.29",
+      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-8.1.29.tgz",
+      "integrity": "sha512-SYIT2C3mqNxTsDTglqgz6FyhgXbBFBo0q5WH9ABkyLUarjPNNt2PrmmgF5nT78RE5GwX5QvHoGl9Efis6+4e5Q==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "events": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "secp256k1": "^4.0.2",
     "styled-components": "^5.3.0",
     "styled-system": "^5.1.5",
-    "trezor-connect": "^8.1.27",
+    "trezor-connect": "^8.1.29",
     "typescript": "^4.3.2",
     "urbit-key-generation": "^0.19.0",
     "urbit-ob": "^4.1.4",

--- a/src/lib/trezor.ts
+++ b/src/lib/trezor.ts
@@ -1,5 +1,6 @@
 import TrezorConnect from 'trezor-connect';
 import { convertToInt } from './convertToInt';
+import BN from 'bn.js';
 
 const TREZOR_PATH = "m/44'/60'/0'/0/x";
 
@@ -15,7 +16,7 @@ const trezorSignTransaction = async (txn, hdpath) => {
     gasLimit: txn.gasLimit.toString('hex'),
     gasPrice: txn.gasPrice.toString('hex'),
     nonce: txn.nonce.length === 0 ? '00' : txn.nonce.toString('hex'),
-    chainId: formatChainId(txn.getChainId()),
+    chainId: formatChainId(txn.common.chainId()),
   };
 
   const sig = await TrezorConnect.ethereumSignTransaction({
@@ -29,9 +30,9 @@ const trezorSignTransaction = async (txn, hdpath) => {
 
   const payload = sig.payload;
 
-  txn.v = Buffer.from(payload.v.slice(2), 'hex');
-  txn.r = Buffer.from(payload.r.slice(2), 'hex');
-  txn.s = Buffer.from(payload.s.slice(2), 'hex');
+  txn.v = new BN(payload.v.slice(2), 'hex');
+  txn.r = new BN(payload.r.slice(2), 'hex');
+  txn.s = new BN(payload.s.slice(2), 'hex');
 
   return txn;
 };


### PR DESCRIPTION
To match latest ethereumjs-tx version. The chainId is accessed
differently, and it expects BNs, not Buffers in its fields.

Also went ahead and updated the trezor-connect library to latest for good measure, though that isn't strictly necessary to fix the issue here.

Going ahead and self-merging so I can make a release for this, but @tomholford please still take a look when you get a chance.