### PR TITLE
ledger, metamask: signing fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2255,9 +2255,9 @@
       },
       "dependencies": {
         "@ethersproject/abstract-provider": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.0.tgz",
-          "integrity": "sha512-vPBR7HKUBY0lpdllIn7tLIzNN7DrVnhCLKSzY0l8WAwxz686m/aL7ASDzrVxV93GJtIub6N2t4dfZ29CkPOxgA==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
           "requires": {
             "@ethersproject/bignumber": "^5.4.0",
             "@ethersproject/bytes": "^5.4.0",
@@ -2269,9 +2269,9 @@
           }
         },
         "@ethersproject/abstract-signer": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.0.tgz",
-          "integrity": "sha512-AieQAzt05HJZS2bMofpuxMEp81AHufA5D6M4ScKwtolj041nrfIbIi8ciNW7+F59VYxXq+V4c3d568Q6l2m8ew==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+          "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
           "requires": {
             "@ethersproject/abstract-provider": "^5.4.0",
             "@ethersproject/bignumber": "^5.4.0",
@@ -2301,9 +2301,9 @@
           }
         },
         "@ethersproject/bignumber": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
-          "integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
           "requires": {
             "@ethersproject/bytes": "^5.4.0",
             "@ethersproject/logger": "^5.4.0",
@@ -2356,9 +2356,9 @@
           "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
         },
         "@ethersproject/networks": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.0.tgz",
-          "integrity": "sha512-5fywtKRDcnaVeA5SjxXH3DOQqe/IbeD/plwydi94SdPps1fbDUrnO6SzDExaruBZXxpxJcO9upG9UComsei4bg==",
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+          "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
           "requires": {
             "@ethersproject/logger": "^5.4.0"
           }
@@ -2538,9 +2538,9 @@
       }
     },
     "@ethersproject/contracts": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.4.0.tgz",
-      "integrity": "sha512-hkO3L3IhS1Z3ZtHtaAG/T87nQ7KiPV+/qnvutag35I0IkiQ8G3ZpCQ9NNOpSCzn4pWSW4CfzmtE02FcqnLI+hw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.4.1.tgz",
+      "integrity": "sha512-m+z2ZgPy4pyR15Je//dUaymRUZq5MtDajF6GwFbGAVmKz/RF+DNIPwF0k5qEcL3wPGVqUjFg2/krlCRVTU4T5w==",
       "requires": {
         "@ethersproject/abi": "^5.4.0",
         "@ethersproject/abstract-provider": "^5.4.0",
@@ -2555,9 +2555,9 @@
       },
       "dependencies": {
         "@ethersproject/abstract-provider": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.0.tgz",
-          "integrity": "sha512-vPBR7HKUBY0lpdllIn7tLIzNN7DrVnhCLKSzY0l8WAwxz686m/aL7ASDzrVxV93GJtIub6N2t4dfZ29CkPOxgA==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
           "requires": {
             "@ethersproject/bignumber": "^5.4.0",
             "@ethersproject/bytes": "^5.4.0",
@@ -2569,9 +2569,9 @@
           }
         },
         "@ethersproject/abstract-signer": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.0.tgz",
-          "integrity": "sha512-AieQAzt05HJZS2bMofpuxMEp81AHufA5D6M4ScKwtolj041nrfIbIi8ciNW7+F59VYxXq+V4c3d568Q6l2m8ew==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+          "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
           "requires": {
             "@ethersproject/abstract-provider": "^5.4.0",
             "@ethersproject/bignumber": "^5.4.0",
@@ -2601,9 +2601,9 @@
           }
         },
         "@ethersproject/bignumber": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
-          "integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
           "requires": {
             "@ethersproject/bytes": "^5.4.0",
             "@ethersproject/logger": "^5.4.0",
@@ -2641,9 +2641,9 @@
           "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
         },
         "@ethersproject/networks": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.0.tgz",
-          "integrity": "sha512-5fywtKRDcnaVeA5SjxXH3DOQqe/IbeD/plwydi94SdPps1fbDUrnO6SzDExaruBZXxpxJcO9upG9UComsei4bg==",
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+          "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
           "requires": {
             "@ethersproject/logger": "^5.4.0"
           }
@@ -2753,9 +2753,9 @@
       },
       "dependencies": {
         "@ethersproject/abstract-provider": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.0.tgz",
-          "integrity": "sha512-vPBR7HKUBY0lpdllIn7tLIzNN7DrVnhCLKSzY0l8WAwxz686m/aL7ASDzrVxV93GJtIub6N2t4dfZ29CkPOxgA==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
           "requires": {
             "@ethersproject/bignumber": "^5.4.0",
             "@ethersproject/bytes": "^5.4.0",
@@ -2767,9 +2767,9 @@
           }
         },
         "@ethersproject/abstract-signer": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.0.tgz",
-          "integrity": "sha512-AieQAzt05HJZS2bMofpuxMEp81AHufA5D6M4ScKwtolj041nrfIbIi8ciNW7+F59VYxXq+V4c3d568Q6l2m8ew==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+          "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
           "requires": {
             "@ethersproject/abstract-provider": "^5.4.0",
             "@ethersproject/bignumber": "^5.4.0",
@@ -2799,9 +2799,9 @@
           }
         },
         "@ethersproject/bignumber": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
-          "integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
           "requires": {
             "@ethersproject/bytes": "^5.4.0",
             "@ethersproject/logger": "^5.4.0",
@@ -2839,9 +2839,9 @@
           "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
         },
         "@ethersproject/networks": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.0.tgz",
-          "integrity": "sha512-5fywtKRDcnaVeA5SjxXH3DOQqe/IbeD/plwydi94SdPps1fbDUrnO6SzDExaruBZXxpxJcO9upG9UComsei4bg==",
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+          "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
           "requires": {
             "@ethersproject/logger": "^5.4.0"
           }
@@ -2937,9 +2937,9 @@
       },
       "dependencies": {
         "@ethersproject/abstract-provider": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.0.tgz",
-          "integrity": "sha512-vPBR7HKUBY0lpdllIn7tLIzNN7DrVnhCLKSzY0l8WAwxz686m/aL7ASDzrVxV93GJtIub6N2t4dfZ29CkPOxgA==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
           "requires": {
             "@ethersproject/bignumber": "^5.4.0",
             "@ethersproject/bytes": "^5.4.0",
@@ -2951,9 +2951,9 @@
           }
         },
         "@ethersproject/abstract-signer": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.0.tgz",
-          "integrity": "sha512-AieQAzt05HJZS2bMofpuxMEp81AHufA5D6M4ScKwtolj041nrfIbIi8ciNW7+F59VYxXq+V4c3d568Q6l2m8ew==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+          "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
           "requires": {
             "@ethersproject/abstract-provider": "^5.4.0",
             "@ethersproject/bignumber": "^5.4.0",
@@ -2983,9 +2983,9 @@
           }
         },
         "@ethersproject/bignumber": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
-          "integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
           "requires": {
             "@ethersproject/bytes": "^5.4.0",
             "@ethersproject/logger": "^5.4.0",
@@ -3023,9 +3023,9 @@
           "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
         },
         "@ethersproject/networks": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.0.tgz",
-          "integrity": "sha512-5fywtKRDcnaVeA5SjxXH3DOQqe/IbeD/plwydi94SdPps1fbDUrnO6SzDExaruBZXxpxJcO9upG9UComsei4bg==",
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+          "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
           "requires": {
             "@ethersproject/logger": "^5.4.0"
           }
@@ -3155,9 +3155,9 @@
       }
     },
     "@ethersproject/providers": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.4.0.tgz",
-      "integrity": "sha512-XRmI9syLnkNdLA8ikEeg0duxmwSWTTt9S+xabnTOyI51JPJyhQ0QUNT+wvmod218ebb7rLupHDPQ7UVe2/+Tjg==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.4.3.tgz",
+      "integrity": "sha512-VURwkaWPoUj7jq9NheNDT5Iyy64Qcyf6BOFDwVdHsmLmX/5prNjFrgSX3GHPE4z1BRrVerDxe2yayvXKFm/NNg==",
       "requires": {
         "@ethersproject/abstract-provider": "^5.4.0",
         "@ethersproject/abstract-signer": "^5.4.0",
@@ -3181,9 +3181,9 @@
       },
       "dependencies": {
         "@ethersproject/abstract-provider": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.0.tgz",
-          "integrity": "sha512-vPBR7HKUBY0lpdllIn7tLIzNN7DrVnhCLKSzY0l8WAwxz686m/aL7ASDzrVxV93GJtIub6N2t4dfZ29CkPOxgA==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
           "requires": {
             "@ethersproject/bignumber": "^5.4.0",
             "@ethersproject/bytes": "^5.4.0",
@@ -3195,9 +3195,9 @@
           }
         },
         "@ethersproject/abstract-signer": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.0.tgz",
-          "integrity": "sha512-AieQAzt05HJZS2bMofpuxMEp81AHufA5D6M4ScKwtolj041nrfIbIi8ciNW7+F59VYxXq+V4c3d568Q6l2m8ew==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+          "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
           "requires": {
             "@ethersproject/abstract-provider": "^5.4.0",
             "@ethersproject/bignumber": "^5.4.0",
@@ -3227,9 +3227,9 @@
           }
         },
         "@ethersproject/bignumber": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
-          "integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
           "requires": {
             "@ethersproject/bytes": "^5.4.0",
             "@ethersproject/logger": "^5.4.0",
@@ -3282,9 +3282,9 @@
           "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
         },
         "@ethersproject/networks": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.0.tgz",
-          "integrity": "sha512-5fywtKRDcnaVeA5SjxXH3DOQqe/IbeD/plwydi94SdPps1fbDUrnO6SzDExaruBZXxpxJcO9upG9UComsei4bg==",
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+          "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
           "requires": {
             "@ethersproject/logger": "^5.4.0"
           }
@@ -3443,9 +3443,9 @@
       },
       "dependencies": {
         "@ethersproject/bignumber": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
-          "integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
           "requires": {
             "@ethersproject/bytes": "^5.4.0",
             "@ethersproject/logger": "^5.4.0",
@@ -3531,9 +3531,9 @@
       },
       "dependencies": {
         "@ethersproject/bignumber": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
-          "integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
           "requires": {
             "@ethersproject/bytes": "^5.4.0",
             "@ethersproject/logger": "^5.4.0",
@@ -3586,9 +3586,9 @@
       },
       "dependencies": {
         "@ethersproject/abstract-provider": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.0.tgz",
-          "integrity": "sha512-vPBR7HKUBY0lpdllIn7tLIzNN7DrVnhCLKSzY0l8WAwxz686m/aL7ASDzrVxV93GJtIub6N2t4dfZ29CkPOxgA==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
           "requires": {
             "@ethersproject/bignumber": "^5.4.0",
             "@ethersproject/bytes": "^5.4.0",
@@ -3600,9 +3600,9 @@
           }
         },
         "@ethersproject/abstract-signer": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.0.tgz",
-          "integrity": "sha512-AieQAzt05HJZS2bMofpuxMEp81AHufA5D6M4ScKwtolj041nrfIbIi8ciNW7+F59VYxXq+V4c3d568Q6l2m8ew==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+          "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
           "requires": {
             "@ethersproject/abstract-provider": "^5.4.0",
             "@ethersproject/bignumber": "^5.4.0",
@@ -3632,9 +3632,9 @@
           }
         },
         "@ethersproject/bignumber": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
-          "integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
           "requires": {
             "@ethersproject/bytes": "^5.4.0",
             "@ethersproject/logger": "^5.4.0",
@@ -3687,9 +3687,9 @@
           "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
         },
         "@ethersproject/networks": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.0.tgz",
-          "integrity": "sha512-5fywtKRDcnaVeA5SjxXH3DOQqe/IbeD/plwydi94SdPps1fbDUrnO6SzDExaruBZXxpxJcO9upG9UComsei4bg==",
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+          "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
           "requires": {
             "@ethersproject/logger": "^5.4.0"
           }
@@ -3789,9 +3789,9 @@
       },
       "dependencies": {
         "@ethersproject/abstract-provider": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.0.tgz",
-          "integrity": "sha512-vPBR7HKUBY0lpdllIn7tLIzNN7DrVnhCLKSzY0l8WAwxz686m/aL7ASDzrVxV93GJtIub6N2t4dfZ29CkPOxgA==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
           "requires": {
             "@ethersproject/bignumber": "^5.4.0",
             "@ethersproject/bytes": "^5.4.0",
@@ -3803,9 +3803,9 @@
           }
         },
         "@ethersproject/abstract-signer": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.0.tgz",
-          "integrity": "sha512-AieQAzt05HJZS2bMofpuxMEp81AHufA5D6M4ScKwtolj041nrfIbIi8ciNW7+F59VYxXq+V4c3d568Q6l2m8ew==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+          "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
           "requires": {
             "@ethersproject/abstract-provider": "^5.4.0",
             "@ethersproject/bignumber": "^5.4.0",
@@ -3835,9 +3835,9 @@
           }
         },
         "@ethersproject/bignumber": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
-          "integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
           "requires": {
             "@ethersproject/bytes": "^5.4.0",
             "@ethersproject/logger": "^5.4.0",
@@ -3890,9 +3890,9 @@
           "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
         },
         "@ethersproject/networks": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.0.tgz",
-          "integrity": "sha512-5fywtKRDcnaVeA5SjxXH3DOQqe/IbeD/plwydi94SdPps1fbDUrnO6SzDExaruBZXxpxJcO9upG9UComsei4bg==",
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+          "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
           "requires": {
             "@ethersproject/logger": "^5.4.0"
           }
@@ -6030,9 +6030,9 @@
       "optional": true
     },
     "@ledgerhq/cryptoassets": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/cryptoassets/-/cryptoassets-6.0.2.tgz",
-      "integrity": "sha512-vBG4GFFhMNTt+Y9GRNCZVAH9SzzzL/GEOXA4dJ/rPwCgz9nxymTCtkJugK4KCzdyFwp6U1X+7s7BOz1F0bnu8g==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/cryptoassets/-/cryptoassets-6.5.0.tgz",
+      "integrity": "sha512-HBmcfb9WTlcsqlzlHfd7nZr49on7ftpWmKXvxZu9DinLS7EZ5ZjgSvmxrx39YCS5yONILBJoA/BSpg1RcCbSjQ==",
       "requires": {
         "invariant": "2"
       }
@@ -6054,48 +6054,57 @@
       "integrity": "sha512-gu6aJ/BHuRlpU7kgVpy2vcYk6atjB4iauP2ymF7Gk0ez0Y/6VSMVSJvubeEQN+IV60+OBK0JgeIZG7OiHaw8ow=="
     },
     "@ledgerhq/hw-app-eth": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-6.0.2.tgz",
-      "integrity": "sha512-vAkn/cod5qucPI2D59uRpOXq/cmbXf96GCuaXQWCOEjMhENe+k/be6RuHh8TVah9fAWunBmcPHyLVeHj1oVSCA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-6.5.0.tgz",
+      "integrity": "sha512-2M43aXxVX3xPwmluG/7zXRljSWSMdifi19V2JR5ezjBhpNg+fgrg6cYOkl7nhyrelsCCaRhWmn3+KCNrkFYLOQ==",
       "requires": {
-        "@ledgerhq/cryptoassets": "^6.0.2",
-        "@ledgerhq/errors": "^6.0.2",
-        "@ledgerhq/hw-transport": "^6.0.2",
-        "@ledgerhq/logs": "^6.0.2",
+        "@ledgerhq/cryptoassets": "^6.5.0",
+        "@ledgerhq/errors": "^6.2.0",
+        "@ledgerhq/hw-transport": "^6.3.0",
+        "@ledgerhq/logs": "^6.2.0",
+        "axios": "^0.21.1",
         "bignumber.js": "^9.0.1",
-        "ethers": "^5.2.0"
+        "ethers": "^5.4.4"
       },
       "dependencies": {
         "@ledgerhq/devices": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-6.0.2.tgz",
-          "integrity": "sha512-xR4RYXltXISH4Vf7bLgiaIRy4W3F+kvDXYhXY7Q72goR4NA+vAosuRLGFQZIQiuZZMdPCIbXHuysj07z/NsEpA==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-6.3.0.tgz",
+          "integrity": "sha512-DmVxqMAf3FhkpKjkbBCFVJ5DmesfplujeCLzFwO/zF5VGuwY7xxPqeSxlpusXJkqhEq+DbFzIDRWJYDf7rtXqg==",
           "requires": {
-            "@ledgerhq/errors": "^6.0.2",
-            "@ledgerhq/logs": "^6.0.2",
+            "@ledgerhq/errors": "^6.2.0",
+            "@ledgerhq/logs": "^6.2.0",
             "rxjs": "6",
             "semver": "^7.3.5"
           }
         },
         "@ledgerhq/errors": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.0.2.tgz",
-          "integrity": "sha512-m42ZMzR/EKpOrZfPR3DzusE98DoF3d03cbBkQG6ddm6diwVXFSa7MabaKzgD+41EYQ+hrCGOEZK1K0kosX1itg=="
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.2.0.tgz",
+          "integrity": "sha512-eO03x8HJmG60WtlrMuahigW/rwywFdcGzCnihta/MjkM8BD9A660cKVkyIuheCcpaB7UV/r+QsRl9abHbjjaag=="
         },
         "@ledgerhq/hw-transport": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.0.2.tgz",
-          "integrity": "sha512-JI8bhs0vQW1pjDeZ8/Cv/OT4iejH2F3j0i5z5mGNkSgs179GiGeM81EhStLB0XuXqxWpFZMnZ97/Cdo0XmffrA==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.3.0.tgz",
+          "integrity": "sha512-kdnVrgmxrFtKaRdkoaQBEa02RXgLzEBiooYbxA65BGSJig3PGWDS9LrqNpzLTZM1RQlivd9NLBmfwU2ze4chWA==",
           "requires": {
-            "@ledgerhq/devices": "^6.0.2",
-            "@ledgerhq/errors": "^6.0.2",
+            "@ledgerhq/devices": "^6.3.0",
+            "@ledgerhq/errors": "^6.2.0",
             "events": "^3.3.0"
           }
         },
         "@ledgerhq/logs": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.0.2.tgz",
-          "integrity": "sha512-4lU3WBwugG+I/dv/qE8HQ2f7MNsKfU58FEzSE1PAELvW96umrlO4ogwuO1tRCPmrtOo9ssam1QVYotwELY8zvw=="
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.2.0.tgz",
+          "integrity": "sha512-SLyFyD7ElMhgKWPYedFGCT/ilcbGPgL5hXXYHxOM79Fs5fWi0zaUpt5oGqGMsOAAFaMa9/rbun0pokzPhEFz8A=="
+        },
+        "axios": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
         }
       }
     },
@@ -15348,29 +15357,29 @@
       }
     },
     "ethers": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.0.tgz",
-      "integrity": "sha512-hqN1x0CV8VMpQ25WnNEjaMqtB3nA4DRAb2FSmmNaUbD1dF6kWbHs8YaXbVvD37FCg3GTEyc4rV9Pxafk1ByHKw==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.4.tgz",
+      "integrity": "sha512-zaTs8yaDjfb0Zyj8tT6a+/hEkC+kWAA350MWRp6yP5W7NdGcURRPMOpOU+6GtkfxV9wyJEShWesqhE/TjdqpMA==",
       "requires": {
         "@ethersproject/abi": "5.4.0",
-        "@ethersproject/abstract-provider": "5.4.0",
-        "@ethersproject/abstract-signer": "5.4.0",
+        "@ethersproject/abstract-provider": "5.4.1",
+        "@ethersproject/abstract-signer": "5.4.1",
         "@ethersproject/address": "5.4.0",
         "@ethersproject/base64": "5.4.0",
         "@ethersproject/basex": "5.4.0",
-        "@ethersproject/bignumber": "5.4.0",
+        "@ethersproject/bignumber": "5.4.1",
         "@ethersproject/bytes": "5.4.0",
         "@ethersproject/constants": "5.4.0",
-        "@ethersproject/contracts": "5.4.0",
+        "@ethersproject/contracts": "5.4.1",
         "@ethersproject/hash": "5.4.0",
         "@ethersproject/hdnode": "5.4.0",
         "@ethersproject/json-wallets": "5.4.0",
         "@ethersproject/keccak256": "5.4.0",
         "@ethersproject/logger": "5.4.0",
-        "@ethersproject/networks": "5.4.0",
+        "@ethersproject/networks": "5.4.2",
         "@ethersproject/pbkdf2": "5.4.0",
         "@ethersproject/properties": "5.4.0",
-        "@ethersproject/providers": "5.4.0",
+        "@ethersproject/providers": "5.4.3",
         "@ethersproject/random": "5.4.0",
         "@ethersproject/rlp": "5.4.0",
         "@ethersproject/sha2": "5.4.0",
@@ -15385,9 +15394,9 @@
       },
       "dependencies": {
         "@ethersproject/abstract-provider": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.0.tgz",
-          "integrity": "sha512-vPBR7HKUBY0lpdllIn7tLIzNN7DrVnhCLKSzY0l8WAwxz686m/aL7ASDzrVxV93GJtIub6N2t4dfZ29CkPOxgA==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
           "requires": {
             "@ethersproject/bignumber": "^5.4.0",
             "@ethersproject/bytes": "^5.4.0",
@@ -15399,9 +15408,9 @@
           }
         },
         "@ethersproject/abstract-signer": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.0.tgz",
-          "integrity": "sha512-AieQAzt05HJZS2bMofpuxMEp81AHufA5D6M4ScKwtolj041nrfIbIi8ciNW7+F59VYxXq+V4c3d568Q6l2m8ew==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+          "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
           "requires": {
             "@ethersproject/abstract-provider": "^5.4.0",
             "@ethersproject/bignumber": "^5.4.0",
@@ -15431,9 +15440,9 @@
           }
         },
         "@ethersproject/bignumber": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
-          "integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
           "requires": {
             "@ethersproject/bytes": "^5.4.0",
             "@ethersproject/logger": "^5.4.0",
@@ -15486,9 +15495,9 @@
           "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
         },
         "@ethersproject/networks": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.0.tgz",
-          "integrity": "sha512-5fywtKRDcnaVeA5SjxXH3DOQqe/IbeD/plwydi94SdPps1fbDUrnO6SzDExaruBZXxpxJcO9upG9UComsei4bg==",
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+          "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
           "requires": {
             "@ethersproject/logger": "^5.4.0"
           }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "proxy": "http://localhost:4000",
   "dependencies": {
     "@ethereumjs/tx": "^3.3.0",
-    "@ledgerhq/hw-app-eth": "^6.0.2",
+    "@ledgerhq/hw-app-eth": "^6.5.0",
     "@ledgerhq/hw-transport-u2f": "^5.36.0-deprecated",
     "@reach/disclosure": "^0.15.0",
     "@reach/menu-button": "^0.15.1",

--- a/src/lib/ledger.js
+++ b/src/lib/ledger.js
@@ -1,5 +1,6 @@
 import Transport from '@ledgerhq/hw-transport-u2f';
 import Eth from '@ledgerhq/hw-app-eth';
+import BN from 'bn.js';
 
 export const LEDGER_LEGACY_PATH = "m/44'/60'/0'/x";
 export const LEDGER_LIVE_PATH = "m/44'/60'/x'/0/0";
@@ -16,9 +17,9 @@ export const ledgerSignTransaction = async (txn, hdPath) => {
   const serializedTx = txn.serialize().toString('hex');
   const sig = await eth.signTransaction(path, serializedTx);
 
-  txn.v = Buffer.from(sig.v, 'hex');
-  txn.r = Buffer.from(sig.r, 'hex');
-  txn.s = Buffer.from(sig.s, 'hex');
+  txn.v = new BN(sig.v, 'hex');
+  txn.r = new BN(sig.r, 'hex');
+  txn.s = new BN(sig.s, 'hex');
 
   return txn;
 };

--- a/src/lib/txn.ts
+++ b/src/lib/txn.ts
@@ -86,13 +86,20 @@ const signTransaction = async ({
 
   const utx = Object.assign(txn, signingParams);
 
-  const chain =
-    networkType === NETWORK_TYPES.ROPSTEN ? Chain.Ropsten : Chain.Mainnet;
-  const common = new Common({
-    chain: chain,
-    hardfork: Hardfork.MuirGlacier,
-  });
-  let stx = Transaction.fromTxData(utx, { common, freeze: false });
+  const txConfig: any = { freeze: false };
+  //  we must specify the chain *either* in the Common object,
+  //  *or* eip155 style, but never both!
+  //
+  if (!needEip155Params) {
+    const chain =
+      networkType === NETWORK_TYPES.ROPSTEN ? Chain.Ropsten : Chain.Mainnet;
+    txConfig.common = new Common({
+      chain: chain,
+      hardfork: Hardfork.MuirGlacier,
+    });
+  }
+
+  let stx = Transaction.fromTxData(utx, txConfig);
 
   //TODO should try-catch and display error message to user,
   //     ie ledger's "pls enable contract data"

--- a/src/store/network.js
+++ b/src/store/network.js
@@ -28,7 +28,6 @@ function _useNetwork(initialNetworkType = null) {
     (async () => {
       if (window.ethereum) {
         try {
-          await window.ethereum.enable();
           setMetamask(true);
           setNetworkType(chainIdToNetworkType(window.ethereum.chainId));
         } catch (e) {

--- a/src/views/Login/Metamask.js
+++ b/src/views/Login/Metamask.js
@@ -25,11 +25,11 @@ export default function Metamask({ className, goHome }) {
 
   const onSubmit = useCallback(async () => {
     try {
-      const accounts = await window.ethereum.enable();
-      const wallet = new MetamaskWallet(accounts[0]);
+      const accounts = await window.ethereum.send('eth_requestAccounts');
+      const wallet = new MetamaskWallet(accounts.result[0]);
 
       const authToken = await getAuthToken({
-        wallet,
+        address: wallet.address,
         walletType: WALLET_TYPES.METAMASK,
         web3: _web3,
       });


### PR DESCRIPTION
In the Metamask case, it seems we simply weren't calling the getAuthToken function correctly. Took the opportunity to also heed some of the deprecation warnings it was printing.

In the Ledger case, in addition to needing BNs instead of Buffers, latest ethereumjs-tx requires some care when doing EIP-155 style chain specification. Specifically, we can't do _both_ that and pass a `Common` object, they'll clash if we do.

Also updates the Ledger hw-app-eth to its latest version for good measure.

Fixes the thing @ngzax mentioned in https://github.com/urbit/bridge/issues/581#issuecomment-900305467.

Apologies for all the little issues here, I should've tested these things (especially the hw wallet ones) more thoroughly before approving recent changes.