### PR TITLE
qol: fix github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bridge-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bridge-bug-report.md
@@ -2,7 +2,7 @@
 name: Bridge Bug report
 about: 'Use this template to file a bug for Bridge'
 title: ''
-labels: landscape
+labels: bridge
 assignees: ''
 
 ---


### PR DESCRIPTION
There is already a template, but it's not getting used for new issues.
The docs are not very clear, but it seems that it needs to be markdown

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/manually-creating-a-single-issue-template-for-your-repository