### PR TITLE
txn: generalize fake signed transactions

### DIFF
--- a/src/components/InlineEthereumTransaction.js
+++ b/src/components/InlineEthereumTransaction.js
@@ -26,6 +26,7 @@ import CopyButton from './CopyButton';
 import ProgressButton from './ProgressButton';
 import { convertToInt } from 'lib/convertToInt';
 import NeedFundsNotice from './NeedFundsNotice';
+import NoticeBox from './NoticeBox';
 
 export default function InlineEthereumTransaction({
   // from useEthereumTransaction.bind
@@ -33,6 +34,7 @@ export default function InlineEthereumTransaction({
   canSign,
   generateAndSign,
   signed,
+  fakeSigned,
   broadcast,
   broadcasted,
   confirmed,
@@ -277,7 +279,15 @@ export default function InlineEthereumTransaction({
               </>
             )}
 
-            {showSignedTx && (
+            {showSignedTx && fakeSigned && (
+              <>
+                <Grid.Item full as={NoticeBox} className="mt2">
+                  Your wallet will sign the transaction upon sending it.
+                </Grid.Item>
+              </>
+            )}
+
+            {showSignedTx && !fakeSigned && (
               <>
                 <Grid.Item
                   full

--- a/src/lib/WalletConnect.ts
+++ b/src/lib/WalletConnect.ts
@@ -1,27 +1,47 @@
 import { ITxData } from '@walletconnect/types';
 import { Transaction } from '@ethereumjs/tx';
 import { stripHexPrefix } from './utils/address';
+import { FakeSignResult } from './txn';
 
 type SignWalletConnectTransactionArgs = {
   from: string;
   txn: Transaction;
   txnSigner: (args: ITxData) => Promise<string>;
+  txnSender: (args: ITxData) => Promise<string>;
 };
 
 const walletConnectSignTransaction = async ({
   from,
   txn,
   txnSigner,
+  txnSender,
 }: SignWalletConnectTransactionArgs) => {
   let wcFormattedTx = txn.toJSON();
   wcFormattedTx.from = from;
   wcFormattedTx.gas = wcFormattedTx.gasLimit;
 
-  const signature = await txnSigner(wcFormattedTx);
+  let signature;
+  try {
+    signature = await txnSigner(wcFormattedTx);
+  } catch (e) {
+    if (e.message === 'METHOD_NOT_SUPPORTED') {
+      console.log('connected wc wallet does not support tx signing.');
+      return new FakeSignResult(
+        wcFormattedTx,
+        walletConnectSendTransaction(txnSender)
+      );
+    } else {
+      throw e;
+    }
+  }
   const serializedTx = Buffer.from(stripHexPrefix(signature), 'hex');
   const signedTx = Transaction.fromSerializedTx(serializedTx);
 
   return signedTx;
 };
+
+const walletConnectSendTransaction = (
+  txnSender: (tx: any) => Promise<string>
+) => (_web3, txn): Promise<string> => txnSender(txn);
 
 export { walletConnectSignTransaction };

--- a/src/lib/metamask.js
+++ b/src/lib/metamask.js
@@ -1,28 +1,32 @@
 import { toHex } from 'web3-utils';
+import { FakeSignResult } from './txn';
 
 export function MetamaskWallet(address) {
   this.address = address;
 }
 
-export function FakeMetamaskTransaction(txnData) {
-  this.txnData = txnData;
-
-  this.serialize = function() {
-    return '0';
-  };
-}
-
 // Cheat a bit and pretend to sign transaction
 // Sign it actually when sending
 export const metamaskSignTransaction = async (txn, from) => {
+  txn.from = from;
+  return new FakeSignResult(txn, metamaskSendTransaction);
+};
+
+const metamaskSendTransaction = async (web3, txn) => {
   const metamaskFormattedTxn = {
     data: txn.data,
     gasLimit: txn.gasLimit,
     gasPrice: txn.gasPrice,
     nonce: txn.nonce,
     to: toHex(txn.to),
-    from: toHex(from),
+    from: toHex(txn.from),
   };
 
-  return new FakeMetamaskTransaction(metamaskFormattedTxn);
-};
+  //NOTE  since this gives us a receipt instead of just the hash of the signed
+  //      tx, it makes us wait for confirmation outside of our own
+  //      waitForTransactionConfirm. because of this the progress bar loses
+  //      its progressiveness for metamask users.
+  //TODO  can we do better?
+  const receipt = await web3.eth.sendTransaction(metamaskFormattedTxn);
+  return receipt.transactionHash;
+}

--- a/src/lib/tank.js
+++ b/src/lib/tank.js
@@ -64,6 +64,12 @@ const ensureFundsFor = async (
     throw new Error('tank: no transactions provided!');
   }
 
+  //TODO  this depends on FakeSignResult serialization in a somewhat ugly way
+  if (signedTxs.some(tx => tx === '0x???')) {
+    console.log('tank: disabling for unsigned sender wallet');
+    return false;
+  }
+
   const balance = toBN(await web3.eth.getBalance(address));
   cost = toBN(cost);
 
@@ -76,11 +82,6 @@ const ensureFundsFor = async (
     return false;
   }
 
-  if (walletType === WALLET_TYPES.METAMASK) {
-    console.log('tank: disabling for metamask login');
-
-    return false;
-  }
   try {
     // TODO: if we can't always (easily) provide a point, and the
     // fundTransactions call is gonna fail anyway, should we maybe

--- a/src/lib/useWalletConnect.ts
+++ b/src/lib/useWalletConnect.ts
@@ -3,7 +3,7 @@ import QRCodeModal from '@walletconnect/qrcode-modal';
 import { ITxData } from '@walletconnect/types';
 
 import { useEffect, useMemo, useState } from 'react';
-import { Just } from 'folktale/maybe';
+import { Just, Nothing } from 'folktale/maybe';
 
 import { useWallet } from 'store/wallet';
 import { getAuthToken } from './authToken';
@@ -81,17 +81,30 @@ export const useWalletConnect = () => {
       return;
     }
 
-    const authToken = await getAuthToken({
-      address,
-      connector,
-      walletType: WALLET_TYPES.WALLET_CONNECT,
-    });
+    let authToken = Nothing();
+    try {
+      const token = await getAuthToken({
+        address,
+        connector,
+        walletType: WALLET_TYPES.WALLET_CONNECT,
+      });
+      authToken = Just(token);
+    } catch (e) {
+      if (e.message === 'METHOD_NOT_SUPPORTED') {
+        console.warn(
+          'wallet does not support message signing. proceeding without auth token.'
+        );
+      } else {
+        throw e;
+        //TODO  should errors with this *really* prevent login?
+      }
+    }
 
     const wallet: WalletConnectWallet = {
       address,
     };
 
-    setAuthToken(Just(authToken));
+    setAuthToken(authToken);
     setWallet(Just(wallet));
   };
 

--- a/src/lib/useWalletConnect.ts
+++ b/src/lib/useWalletConnect.ts
@@ -152,6 +152,37 @@ export const useWalletConnect = () => {
           data,
           nonce,
         })
+        .then((signature: string) => resolve(signature))
+        .catch((error: Error) => reject(error));
+    });
+  };
+
+  const sendTransaction = async ({
+    from,
+    to,
+    gas,
+    gasPrice,
+    value,
+    data,
+    nonce,
+  }: ITxData): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      if (!connector || !isConnected()) {
+        reject(new Error('No connected wallet available for signing'));
+        return;
+      }
+
+      //REVIEW  .then path untested
+      return connector
+        .sendTransaction({
+          from,
+          to,
+          gas,
+          gasPrice,
+          value,
+          data,
+          nonce,
+        })
         .then((txHash: string) => resolve(txHash))
         .catch((error: Error) => reject(error));
     });
@@ -247,5 +278,6 @@ export const useWalletConnect = () => {
     peerMeta,
     resetConnector,
     signTransaction,
+    sendTransaction,
   };
 };


### PR DESCRIPTION
Not all wallets support transaction signing as separate from sending.
Metamask was one such case, we handled it through special logic.
With WalletConnect, we might connect to a wallet that doesn't support
transaction signing either. As such, we generalize Metamask's special
logic.

When the wallet doesn't support transaction signing, we pretend to
succeed, but produce a "fake signed transaction" instead. This has
stubbed out serialization logic, and contains the original transaction
data plus a callback for sending that transaction.

In these cases, the user is informed that their transaction will be
signed by their wallet when sending. The signed transaction fold-out
is not shown.

<img width="556" alt="image" src="https://user-images.githubusercontent.com/3829764/129980003-965164b3-8955-4c73-ab2c-118b8d9be2d8.png">

Worth noting that, for the WalletConnect case, we cannot tell whether
the connected wallet supports transaction signing or not. So we simply
try to do it, and if it fails with METHOD_NOT_SUPPORTED, we know what's
up and proceed with the "fake signed" logic accordingly.

Additionally, this PR patches the auth token logic for the WalletConnect case to simply proceed if we cannot sign a message for reasons similar to the above.

This makes it so that Gnosis Safe can be used through WalletConnect, though it should be noted that the Bridge-side UX for sending a transaction using that is "sending progress bar forever". I don't think there's anything we can do about that.

@tomholford I tried adding in types as I went, but I couldn't get everything quite right. There's some TODOs strewn about relating to this, please advise.

Need to do another full testing pass over this once changes have settled, but so far seems to work alright. Only thing I haven't touched yet is reticketing, which is a bit special in that it does many sequential transactions. Might just work as-is, but worth verifying.

@tomholford If you could please test with some of the other WalletConnect wallets that you had success with in the past, that would be much appreciated.