### PR TITLE
metamask: strange personal_sign ritual

### DIFF
--- a/src/lib/authToken.ts
+++ b/src/lib/authToken.ts
@@ -57,7 +57,19 @@ type GetAuthTokenArgs =
   | DefaultAuthTokenArgs;
 
 const getMetamaskAuthToken = ({ address, web3 }: MetamaskAuthTokenArgs) => {
-  return web3.eth.personal.sign(MESSAGE, address, '');
+  if (window.ethereum) {
+    //NOTE  this doesn't _seem_ to be affected by #596,
+    //      but web3.eth.personal.sign hits it semi-reliably?
+    //      no idea what's going on, we should figure it out,
+    //      but we apply this bandaid to hopefully stop the bleeding.
+    return window.ethereum.request({
+      method: 'personal_sign',
+      params: [MESSAGE, address],
+      from: address,
+    });
+  } else {
+    return web3.eth.personal.sign(MESSAGE, address, '');
+  }
 };
 
 const getLedgerAuthToken = ({ walletHdPath }: LedgerAuthTokenArgs) => {


### PR DESCRIPTION
This is an attempt to do something about #596.

I can reproduce that issue fairly consistently by just pressing "cancel" when Metamask pops up for the signing request and reloading the page. Eventually it gets into the bad state where pressing the Metamask login button doesn't actually prompt you for signing the message, instead it just stays grey and gives the "personal_sign does not exist" in the browser console.

For some reason, calling `personal_sign` through `window.ethereum` this way is highly reliable, and doesn't let me reproduce using the above steps. Is it because of `window.ethereum`? Is it because we manually construct the request? We just don't know..[.](http://img.photobucket.com/albums/v695/carnilia/randomgifs/tumblr_m7swmtmv7n1rn95k2o1_250_zps880b4a1e.gif)

Notably, in `Login/Metamask.js`, we already use `window.ethereum` directly (with `.send`, which is deprecated and should be replaced by `.request`) for requesting the accounts.

The `if (window.ethereum)` is kind of superfluous in this case, because we _should_ only call this when we _do_ have it, but I want to get this live quickly so I'm opting for the extra safety.

(For the record, we should do something about Mm login's error handling in general, but I just want this out into the hands of people quickly.)