### PR TITLE
point-view: animate Passport based on selected point

### DIFF
--- a/src/components/Passport.js
+++ b/src/components/Passport.js
@@ -48,13 +48,15 @@ function Passport({
 
   const patp = ob.patp(point.value);
 
-  const makeMatrix = addr => {
-    // remove the 0x
-    const onlyTheNumberPart = addr.substring(2);
+  const makeMatrix = azimuthPoint => {
+    // convert point to hex
+    const azimuthPointHex = azimuthPoint.toString(16);
+
     // make bigNum from hex
-    const int = new BN(onlyTheNumberPart, 16);
+    const int = new BN(azimuthPointHex, 16);
+
     // make a bigger number
-    const big = int.pow(new BN(10));
+    const big = int.pow(new BN(100));
     // parse that to a string and pad
     const b10 = big.toString(10).padStart(32, '0');
     // split the big number into parts
@@ -71,7 +73,7 @@ function Passport({
     return matrix;
   };
 
-  const matrix = address.matchWith({
+  const matrix = point.matchWith({
     Just: ({ value }) => makeMatrix(value),
     Nothing: defaultMatrix,
   });


### PR DESCRIPTION
# Change

Previously this used the eth address associated with the point to generate the passport; now it uses the actual azimuth point integer value as the seed. Thus, switching points in the dropdown will update the Passport with a unique, mostly-deterministic animation.

# Preview

https://user-images.githubusercontent.com/16504501/140860093-304656d1-6dc2-4087-a422-fc0d2bcc89cf.mov


