### PR TITLE
Update meta `theme-color`

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="theme-color" content="#000000">
+    <meta name="theme-color" content="#fff">
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <title>Bridge</title>


### PR DESCRIPTION
Updates the meta tag `theme-color` to change the tab bar background and over-scroll area for Safari 15 on macOS and iPadOS, and the status bar in iOS 15+.

Ref: [Safari 15 Release Notes ↗](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#HTML)

| Before        | After |
| ------------- | ----- |
| <img width="1204" alt="Screen Shot 2021-11-19 at 1 08 19 PM" src="https://user-images.githubusercontent.com/4127151/142670868-d423e0d3-7a28-449d-8395-04b03e9412c0.png"> |  <img width="1204" alt="Screen Shot 2021-11-19 at 1 08 21 PM" src="https://user-images.githubusercontent.com/4127151/142670881-391feb35-18fe-44a5-8c6d-cbcb6b6dde65.png"> |

Had some npm issues getting Bridge up and running locally on my fork so please excuse the screenshots (not from `roller`)
 