### PR TITLE
network-keys: generated keyfiles use multikey format

### DIFF
--- a/src/components/DownloadKeyfileButton.js
+++ b/src/components/DownloadKeyfileButton.js
@@ -4,7 +4,7 @@ import { B } from 'indigo-react';
 import { DownloadButton } from 'components/Buttons';
 
 export default function DownloadKeyfileButton({
-  // useKeyfileGenerator.bind
+  // useMultikeyFileGenerator.bind
   generating,
   available,
   downloaded,

--- a/src/lib/keys.js
+++ b/src/lib/keys.js
@@ -76,10 +76,34 @@ export const compileNetworkKey = (pair, point, revision) => {
     noun.Atom.fromInt(point),
     noun.Atom.fromInt(revision),
     noun.Atom.fromString(bnsec.toString()),
-    noun.Atom.yes
+    noun.Atom.fromInt(0)
   );
 
   return b64(jam(sed));
+};
+
+/**
+ * @param {number} point
+ * @param {array<{revision: number, pair: object}>} keys
+ * @return {string}
+ */
+export const compileMultiKey = (point, keys) => {
+  const kyz = keys.map(k => {
+    const bnsec = new BN(createRing(k.pair), 'hex');
+    return noun.dwim(
+      noun.Atom.fromInt(k.revision),
+      noun.Atom.fromString(bnsec.toString())
+    );
+  });
+  kyz.push(noun.Atom.fromInt(0));
+
+  const fed = noun.dwim(
+    noun.dwim(noun.Atom.fromInt(1), noun.Atom.fromInt(0)), // version
+    noun.Atom.fromInt(point), // ship
+    noun.dwim(kyz) // keys
+  );
+
+  return b64(jam(fed));
 };
 
 /**

--- a/src/lib/keys.js
+++ b/src/lib/keys.js
@@ -198,8 +198,8 @@ export const attemptNetworkSeedDerivation = async ({
 
 /**
  *
- * @param {object} pair
- * @param {object} details
+ * @param {object} pair - type NetworkKeys
+ * @param {object} details - type L1Point
  * @return {boolean}
  */
 export const keysMatchChain = (pair, details) => {
@@ -221,4 +221,31 @@ export const segmentNetworkKey = hex => {
   const rowFrom = i => `${sl(i)}.${sl(i + 4)}.${sl(i + 8)}.${sl(i + 12)}`;
 
   return [rowFrom(2), rowFrom(18), rowFrom(34), rowFrom(50)];
+};
+
+// ctsy @yosoyubik
+/**
+ * @param {object} pair
+ * @param {number} point
+ * @param {number} revision
+ * @return {string}
+ */
+export const compileMultikey = (point, pair1, pair2, revision1, revision2) => {
+  const bnsec1 = new BN(createRing(pair1), 'hex');
+  const bnsec2 = new BN(createRing(pair2), 'hex');
+
+  const tag = noun.dwim(noun.Atom.fromString('1'), noun.Atom.yes);
+  const ship = noun.Atom.fromInt(point);
+  const key1 = noun.dwim(
+    noun.Atom.fromInt(revision1),
+    noun.Atom.fromString(bnsec1.toString())
+  );
+  const key2 = noun.dwim(
+    noun.Atom.fromInt(revision2),
+    noun.Atom.fromString(bnsec2.toString())
+  );
+
+  const sed = noun.dwim(tag, ship, key1, key2, noun.Atom.yes);
+
+  return b64(jam(sed));
 };

--- a/src/lib/keys.js
+++ b/src/lib/keys.js
@@ -246,30 +246,3 @@ export const segmentNetworkKey = hex => {
 
   return [rowFrom(2), rowFrom(18), rowFrom(34), rowFrom(50)];
 };
-
-// ctsy @yosoyubik
-/**
- * @param {object} pair
- * @param {number} point
- * @param {number} revision
- * @return {string}
- */
-export const compileMultikey = (point, pair1, pair2, revision1, revision2) => {
-  const bnsec1 = new BN(createRing(pair1), 'hex');
-  const bnsec2 = new BN(createRing(pair2), 'hex');
-
-  const tag = noun.dwim(noun.Atom.fromInt(1), noun.Atom.yes);
-  const ship = noun.Atom.fromInt(point);
-  const key1 = noun.dwim(
-    noun.Atom.fromInt(revision1),
-    noun.Atom.fromString(bnsec1.toString())
-  );
-  const key2 = noun.dwim(
-    noun.Atom.fromInt(revision2),
-    noun.Atom.fromString(bnsec2.toString())
-  );
-
-  const sed = noun.dwim(tag, ship, key1, key2, noun.Atom.yes);
-
-  return b64(jam(sed));
-};

--- a/src/lib/keys.js
+++ b/src/lib/keys.js
@@ -234,7 +234,7 @@ export const compileMultikey = (point, pair1, pair2, revision1, revision2) => {
   const bnsec1 = new BN(createRing(pair1), 'hex');
   const bnsec2 = new BN(createRing(pair2), 'hex');
 
-  const tag = noun.dwim(noun.Atom.fromString('1'), noun.Atom.yes);
+  const tag = noun.dwim(noun.Atom.fromInt(1), noun.Atom.yes);
   const ship = noun.Atom.fromInt(point);
   const key1 = noun.dwim(
     noun.Atom.fromInt(revision1),

--- a/src/lib/types/BridgeWallet.ts
+++ b/src/lib/types/BridgeWallet.ts
@@ -2,4 +2,5 @@ import { BIP32Interface } from 'bitcoinjs-lib';
 
 export default interface BridgeWallet extends BIP32Interface {
   address: string;
+  passphrase?: string;
 }

--- a/src/lib/types/Keypair.ts
+++ b/src/lib/types/Keypair.ts
@@ -1,0 +1,7 @@
+// returned from urbit/key-generation#deriveNodes
+export interface Keypair {
+  public: string;
+  private: string;
+  chain: string;
+  address: string;
+}

--- a/src/lib/types/L2Transaction.ts
+++ b/src/lib/types/L2Transaction.ts
@@ -43,6 +43,6 @@ export interface ReticketParams {
   point: Ship;
   to: EthAddress;
   manager: EthAddress;
-  fromWallet: any; // TODO: wallet type
+  fromWallet: UrbitWallet;
   toWallet: any; // TODO: wallet type
 }

--- a/src/lib/types/L2Transaction.ts
+++ b/src/lib/types/L2Transaction.ts
@@ -1,5 +1,6 @@
 import RollerRPCAPI, { EthAddress, Proxy, Ship } from '@urbit/roller-api';
 import WalletConnect from '@walletconnect/client';
+import BridgeWallet from './BridgeWallet';
 
 export type TransactionType =
   | 'transferPoint'
@@ -43,6 +44,6 @@ export interface ReticketParams {
   point: Ship;
   to: EthAddress;
   manager: EthAddress;
-  fromWallet: UrbitWallet;
-  toWallet: any; // TODO: wallet type
+  fromWallet: BridgeWallet;
+  toWallet: UrbitWallet;
 }

--- a/src/lib/types/NetworkKeys.ts
+++ b/src/lib/types/NetworkKeys.ts
@@ -1,0 +1,11 @@
+// returned from urbit/key-generation#deriveNetworkKeys
+export interface NetworkKeys {
+  crypt: {
+    private: string;
+    public: string;
+  };
+  auth: {
+    private: string;
+    public: string;
+  };
+}

--- a/src/lib/useKeyfileGenerator.ts
+++ b/src/lib/useKeyfileGenerator.ts
@@ -28,6 +28,10 @@ interface useKeyfileGeneratorArgs {
   point?: number;
 }
 
+/**
+ * @deprecated
+ * Use `useMultikeyFileGenerator` instead
+ */
 export default function useKeyfileGenerator({
   seed,
   point,

--- a/src/lib/useKeyfileGenerator.ts
+++ b/src/lib/useKeyfileGenerator.ts
@@ -18,20 +18,35 @@ import {
 } from './keys';
 import useCurrentPermissions from './useCurrentPermissions';
 import { convertToInt } from './convertToInt';
+import { stripSigPrefix } from 'form/formatters';
 
-export default function useKeyfileGenerator(manualNetworkSeed) {
-  const { urbitWallet, wallet, authMnemonic, authToken } = useWallet();
-  const { pointCursor } = usePointCursor();
-  const { getDetails } = usePointCache();
+// overrideable defaults:
+// seed - derived from wallet, mnemonic, or token (if posisble)
+// point - the current pointCursor
+interface useKeyfileGeneratorArgs {
+  seed?: string;
+  point?: number;
+}
+
+export default function useKeyfileGenerator({
+  seed,
+  point,
+}: useKeyfileGeneratorArgs) {
+  const { urbitWallet, wallet, authMnemonic, authToken }: any = useWallet();
+  const { pointCursor }: any = usePointCursor();
+  const { syncDetails, getDetails }: any = usePointCache();
 
   const [notice, setNotice] = useState('Deriving networking keys...');
   const [downloaded, setDownloaded] = useState(false);
   const [generating, setGenerating] = useState(true);
-  const [keyfile, setKeyfile] = useState(false);
-
+  const [keyfile, setKeyfile] = useState<boolean | string>(false);
   const [code, setCode] = useState(false);
 
-  const _point = need.point(pointCursor);
+  const _point = point || need.point(pointCursor);
+  useEffect(() => {
+    syncDetails(_point);
+  }, [_point, syncDetails]);
+
   const details = getDetails(_point);
 
   const networkRevision = details.matchWith({
@@ -56,8 +71,8 @@ export default function useKeyfileGenerator(manualNetworkSeed) {
 
     const _details = need.details(details);
 
-    const networkSeed = manualNetworkSeed
-      ? Just(manualNetworkSeed)
+    const networkSeed = seed
+      ? Just(seed)
       : await attemptNetworkSeedDerivation({
           urbitWallet,
           wallet,
@@ -88,14 +103,14 @@ export default function useKeyfileGenerator(manualNetworkSeed) {
       return;
     }
 
-    setNotice();
+    setNotice('');
     setCode(generateCode(pair));
     setKeyfile(compileNetworkKey(pair, _point, networkRevision));
     setGenerating(false);
   }, [
     networkRevision,
     hasNetworkKeys,
-    manualNetworkSeed,
+    seed,
     urbitWallet,
     wallet,
     authMnemonic,
@@ -106,11 +121,14 @@ export default function useKeyfileGenerator(manualNetworkSeed) {
   ]);
 
   const filename = useMemo(() => {
-    return `${ob.patp(_point).slice(1)}-${networkRevision}.key`;
-    // TODO: ^ unifiy "remove tilde" calls
+    return `${stripSigPrefix(ob.patp(_point))}-${networkRevision}.key`;
   }, [_point, networkRevision]);
 
   const download = useCallback(() => {
+    if (typeof keyfile !== 'string') {
+      return;
+    }
+
     saveAs(
       new Blob([keyfile], {
         type: 'text/plain;charset=utf-8',

--- a/src/lib/useMultikeyFileGenerator.ts
+++ b/src/lib/useMultikeyFileGenerator.ts
@@ -80,7 +80,7 @@ export default function useMultikeyFileGenerator({
         ? Just(seed)
         : await attemptNetworkSeedDerivation({
             urbitWallet: seedWallet || urbitWallet,
-            wallet: wallet,
+            wallet,
             authMnemonic,
             details: _details,
             authToken,

--- a/src/lib/useMultikeyFileGenerator.ts
+++ b/src/lib/useMultikeyFileGenerator.ts
@@ -1,0 +1,201 @@
+import * as need from 'lib/need';
+import saveAs from 'file-saver';
+import ob from 'urbit-ob';
+import { Just, Nothing } from 'folktale/maybe';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { usePointCache } from 'store/pointCache';
+import { usePointCursor } from 'store/pointCursor';
+import { useWallet } from 'store/wallet';
+import { deriveNetworkKeys } from 'urbit-key-generation';
+import { convertToInt } from './convertToInt';
+import {
+  attemptNetworkSeedDerivation,
+  compileMultikey,
+  keysMatchChain,
+} from './keys';
+import { generateCode } from './networkCode';
+import { L1Point } from './types/L1Point';
+import useCurrentPermissions from './useCurrentPermissions';
+import { stripSigPrefix } from 'form/formatters';
+
+interface useMultikeyFileGeneratorArgs {
+  seed?: string;
+  point?: number;
+  seedWallet?: any;
+}
+
+/**
+ * defaults:
+ * - seed: derived from wallet, mnemonic, or token (if posisble)
+ * - point: the current pointCursor
+ */
+export default function useMultikeyFileGenerator({
+  seed,
+  point,
+  seedWallet,
+}: useMultikeyFileGeneratorArgs) {
+  const { urbitWallet, wallet, authMnemonic, authToken }: any = useWallet();
+  const { pointCursor }: any = usePointCursor();
+  const { syncDetails, getDetails }: any = usePointCache();
+  const { isOwner, isManagementProxy } = useCurrentPermissions();
+
+  const [notice, setNotice] = useState('Deriving networking keys...');
+  const [downloaded, setDownloaded] = useState(false);
+  const [generating, setGenerating] = useState(true);
+  const [keyfile, setKeyfile] = useState<boolean | string>(false);
+  const [code, setCode] = useState(false);
+
+  const _point = useMemo(() => point || need.point(pointCursor), [
+    point,
+    pointCursor,
+  ]);
+  const details = getDetails(_point);
+  const _details: L1Point | null = useMemo(
+    () =>
+      details.matchWith({
+        Just: d => need.details(d),
+        Nothing: () => null,
+      }),
+    [details]
+  );
+
+  const currentRevision: number = useMemo(
+    () =>
+      details.matchWith({
+        Just: ({ value }) => convertToInt(value.keyRevisionNumber, 10),
+        Nothing: () => 0,
+      }),
+    [details]
+  );
+  const nextRevision = useMemo(() => currentRevision + 1, [currentRevision]);
+
+  const pairFromRevision = useCallback(
+    async (revision: number) => {
+      if (!_details) {
+        return;
+      }
+
+      const networkSeed = seed
+        ? Just(seed)
+        : await attemptNetworkSeedDerivation({
+            urbitWallet: seedWallet || urbitWallet,
+            wallet,
+            authMnemonic,
+            details: _details,
+            authToken,
+            point: _point,
+            revision: revision,
+          });
+
+      if (Nothing.hasInstance(networkSeed)) {
+        setGenerating(false);
+        setNotice(
+          'Custom or nondeterministic networking keys cannot be re-downloaded.'
+        );
+        console.log(`seed is nondeterminable for revision ${revision}`);
+        return;
+      }
+
+      const _networkSeed = networkSeed.value;
+
+      return deriveNetworkKeys(_networkSeed);
+    },
+    [
+      _details,
+      _point,
+      authMnemonic,
+      authToken,
+      seed,
+      urbitWallet,
+      wallet,
+      seedWallet,
+    ]
+  );
+
+  const hasNetworkKeys = currentRevision > 0;
+  const available =
+    (isOwner || isManagementProxy) && hasNetworkKeys && !!keyfile;
+
+  const generate = useCallback(async () => {
+    if (!hasNetworkKeys) {
+      setGenerating(false);
+      setNotice('Network keys not yet set.');
+      console.log(
+        `no networking keys available for revision ${currentRevision}`
+      );
+      return;
+    }
+
+    // TODO: Do we still need this? The legacy implementation in useKeyfileGenerator
+    // performed this guard statement
+
+    // const currentPair = await pairFromRevision(currentRevision);
+
+    // if (!currentPair || !keysMatchChain(currentPair, _details)) {
+    //   setGenerating(false);
+    //   setNotice('Derived networking keys do not match on-chain details.');
+    //   console.log(`keys do not match details for revision ${currentRevision}`);
+    //   return;
+    // }
+
+    // const nextPair = await pairFromRevision(nextRevision);
+
+    const [currentPair, nextPair] = await Promise.all([
+      pairFromRevision(currentRevision),
+      pairFromRevision(nextRevision),
+    ]);
+
+    setNotice('');
+    setCode(generateCode(currentPair));
+    setKeyfile(
+      compileMultikey(
+        _point,
+        currentPair,
+        nextPair,
+        currentRevision,
+        nextRevision
+      )
+    );
+    setGenerating(false);
+  }, [_point, currentRevision, hasNetworkKeys, nextRevision, pairFromRevision]);
+
+  const filename = useMemo(() => {
+    return `${stripSigPrefix(ob.patp(_point))}-${currentRevision}.key`;
+  }, [_point, currentRevision]);
+
+  const download = useCallback(() => {
+    if (typeof keyfile !== 'string') {
+      return;
+    }
+
+    saveAs(
+      new Blob([keyfile], {
+        type: 'text/plain;charset=utf-8',
+      }),
+      filename
+    );
+    setDownloaded(true);
+  }, [filename, keyfile]);
+
+  useEffect(() => {
+    syncDetails(_point);
+  }, [_point, syncDetails]);
+
+  useEffect(() => {
+    generate();
+  }, [generate]);
+
+  const output = {
+    generating,
+    available,
+    downloaded,
+    download,
+    filename,
+    notice,
+    keyfile,
+    code,
+  };
+
+  return { ...output, bind: output };
+}

--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -22,7 +22,7 @@ import { usePointCache } from 'store/pointCache';
 
 import { getUpdatedPointMessage, isPlanet, toL1Details } from './utils/point';
 import { convertToInt } from './convertToInt';
-import { isDevelopment, isRopsten } from './flags';
+import { isDevelopment, isMainnet, isRopsten } from './flags';
 import {
   generateInviteWallet,
   getPendingSpawns,
@@ -113,13 +113,13 @@ export default function useRoller() {
   const [config, setConfig] = useState<Config | null>(null);
 
   const options: Options = useMemo(() => {
-    const type = isRopsten || !isDevelopment ? 'https' : 'http';
-    const host = isRopsten
+    const type = isMainnet || isRopsten ? 'https' : 'http';
+    const host = isMainnet
+      ? ROLLER_HOSTS.MAINNET
+      : isRopsten
       ? ROLLER_HOSTS.ROPSTEN
-      : isDevelopment
-      ? ROLLER_HOSTS.LOCAL
-      : ROLLER_HOSTS.MAINNET;
-    const port = isDevelopment && !isRopsten ? 8080 : 443;
+      : ROLLER_HOSTS.LOCAL;
+    const port = isMainnet || isRopsten ? 443 : 8080;
     const path = '/v1/roller';
 
     return {

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -12,7 +12,11 @@ export function EthereumWallet(privateKey) {
   this.address = publicToAddress(this.publicKey);
 }
 
-export const urbitWalletFromTicket = async (ticket, point, passphrase) => {
+export const urbitWalletFromTicket = async (
+  ticket: string,
+  point: number,
+  passphrase?: string
+) => {
   return await kg.generateWallet({
     ticket: ticket,
     ship: point,

--- a/src/urbit-key-generation.d.ts
+++ b/src/urbit-key-generation.d.ts
@@ -9,6 +9,60 @@ interface NetworkKeys {
   };
 }
 
+interface WalletNodeKeys {
+  public: string;
+  private: string;
+  chain: string;
+  address: string;
+}
+
+interface WalletNode {
+  type: string;
+  seed: string;
+  keys: WalletNodeKeys;
+  derivationPath: string;
+}
+
+interface WalletConfig {
+  ticket: string;
+  ship: number;
+  passphrase?: string;
+  boot?: boolean;
+}
+
+interface UrbitWallet {
+  meta: {
+    generator: {
+      name: string;
+      version: string;
+    };
+    spec: string;
+    ship: string;
+    patp: string;
+    tier: string;
+    passphrase: string;
+  };
+  masterSeed: string;
+  ownership: WalletNode;
+  management: WalletNode;
+  transfer: WalletNode;
+  network:
+    | {
+        type: string;
+        seed: string;
+        keys: string;
+      }
+    | {};
+  voting?: WalletNode;
+  spawn?: WalletNode;
+}
+
 declare module 'urbit-key-generation' {
   function deriveNetworkKeys(hex: string): NetworkKeys;
+  function generateWallet({
+    ticket,
+    ship,
+    passphrase,
+    boot,
+  }: WalletConfig): UrbitWallet;
 }

--- a/src/urbit-key-generation.d.ts
+++ b/src/urbit-key-generation.d.ts
@@ -1,0 +1,14 @@
+interface NetworkKeys {
+  crypt: {
+    private: string;
+    public: string;
+  };
+  auth: {
+    private: string;
+    public: string;
+  };
+}
+
+declare module 'urbit-key-generation' {
+  function deriveNetworkKeys(hex: string): NetworkKeys;
+}

--- a/src/urbit-ob.d.ts
+++ b/src/urbit-ob.d.ts
@@ -1,2 +1,1 @@
-// azimuth-js.d.ts
 declare module 'urbit-ob';

--- a/src/views/Activate/ActivateCodeForm.tsx
+++ b/src/views/Activate/ActivateCodeForm.tsx
@@ -18,10 +18,9 @@ import { useActivateFlow } from './ActivateFlow';
 import WarningBox from 'components/WarningBox';
 import useRoller from 'lib/useRoller';
 import useImpliedTicket from 'lib/useImpliedTicket';
-import { generateOwnershipWallet } from 'lib/walletgen';
-import { generateWallet } from 'lib/invite';
-import { walletFromMnemonic } from 'lib/wallet';
-import { DEFAULT_HD_PATH, POINT_PROXIES } from 'lib/constants';
+import { generateWallet } from 'lib/walletgen';
+import { urbitWalletFromTicket } from 'lib/wallet';
+import { POINT_PROXIES } from 'lib/constants';
 import useBreakpoints from 'lib/useBreakpoints';
 import { Ship } from '@urbit/roller-api';
 import { convertToInt } from 'lib/convertToInt';
@@ -109,11 +108,11 @@ const ActivateCodeForm = ({ afterSubmit }: ActivateCodeFormProps) => {
       const { ticket, point } = getTicketAndPoint(
         impliedTicket || values.ticket
       );
-      const { seed } = await generateOwnershipWallet(point, ticket);
-      const inviteWallet = walletFromMnemonic(seed, DEFAULT_HD_PATH);
+
+      const inviteWallet = Just(await urbitWalletFromTicket(ticket, point));
       setInviteWallet(inviteWallet);
-      const _inviteWallet = need.wallet(inviteWallet);
-      const inviteAddress = _inviteWallet.address;
+      const _inviteWallet: UrbitWallet = need.wallet(inviteWallet);
+      const inviteAddress = _inviteWallet.ownership.keys.address;
 
       let incoming = await loadPoints(inviteAddress);
 
@@ -136,7 +135,7 @@ const ActivateCodeForm = ({ afterSubmit }: ActivateCodeFormProps) => {
         setDerivedPatp(Just(ob.patp(point)));
         setDerivedPoint(Just(point));
         setDerivedPointDominion(Just(rollerPoint.dominion));
-        setDerivedWallet(Just(await generateWallet(point, true)));
+        setDerivedWallet(Just(await generateWallet(point, ticket, true)));
         setIsIn(false);
         await timeout(100);
       } else {

--- a/src/views/Activate/ActivateCodeForm.tsx
+++ b/src/views/Activate/ActivateCodeForm.tsx
@@ -19,8 +19,8 @@ import WarningBox from 'components/WarningBox';
 import useRoller from 'lib/useRoller';
 import useImpliedTicket from 'lib/useImpliedTicket';
 import { generateWallet } from 'lib/walletgen';
-import { urbitWalletFromTicket } from 'lib/wallet';
-import { POINT_PROXIES } from 'lib/constants';
+import { urbitWalletFromTicket, walletFromMnemonic } from 'lib/wallet';
+import { DEFAULT_HD_PATH, POINT_PROXIES } from 'lib/constants';
 import useBreakpoints from 'lib/useBreakpoints';
 import { Ship } from '@urbit/roller-api';
 import { convertToInt } from 'lib/convertToInt';
@@ -45,6 +45,7 @@ const ActivateCodeForm = ({ afterSubmit }: ActivateCodeFormProps) => {
     setDerivedWallet,
     setInviteWallet,
     setIsIn,
+    setSendWallet,
   } = useActivateFlow();
 
   // this is a pretty naive way to detect if we're on a mobile device
@@ -113,6 +114,12 @@ const ActivateCodeForm = ({ afterSubmit }: ActivateCodeFormProps) => {
       setInviteWallet(inviteWallet);
       const _inviteWallet: UrbitWallet = need.wallet(inviteWallet);
       const inviteAddress = _inviteWallet.ownership.keys.address;
+
+      const sendWallet = await walletFromMnemonic(
+        _inviteWallet.ownership.seed,
+        DEFAULT_HD_PATH
+      );
+      setSendWallet(sendWallet);
 
       let incoming = await loadPoints(inviteAddress);
 

--- a/src/views/Activate/MasterKeyDownload.tsx
+++ b/src/views/Activate/MasterKeyDownload.tsx
@@ -18,6 +18,7 @@ import { DEFAULT_FADE_TIMEOUT, MASTER_KEY_DURATION } from 'lib/constants';
 import { timeout } from 'lib/timeout';
 import View from 'components/View';
 import useMultikeyFileGenerator from 'lib/useMultikeyFileGenerator';
+import { downloadWallet } from 'lib/invite';
 
 const MasterKeyDownload = () => {
   const {
@@ -45,7 +46,7 @@ const MasterKeyDownload = () => {
     Just: p => p.value.toFixed(),
   });
 
-  const { download } = useMultikeyFileGenerator({
+  const { keyfile, filename } = useMultikeyFileGenerator({
     point,
     seedWallet: inviteWallet,
   });
@@ -61,6 +62,10 @@ const MasterKeyDownload = () => {
       ),
     [paper, setGenerated]
   );
+
+  const download = useCallback(async () => {
+    await downloadWallet(paper.getOrElse([]), keyfile, filename);
+  }, [paper, keyfile, filename]);
 
   const onDownloadClick = useCallback(async () => {
     await download();

--- a/src/views/Activate/MasterKeyDownload.tsx
+++ b/src/views/Activate/MasterKeyDownload.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Just, Nothing } from 'folktale/maybe';
 import * as need from 'lib/need';
-import * as ob from 'urbit-ob';
 
 import { ActivateSteps } from './ActivateSteps';
 import { Box } from '@tlon/indigo-react';
@@ -24,6 +23,7 @@ const MasterKeyDownload = () => {
   const {
     derivedPoint,
     derivedWallet,
+    inviteWallet,
     isIn,
     setGenerated,
     setIsIn,
@@ -47,7 +47,7 @@ const MasterKeyDownload = () => {
 
   const { download } = useMultikeyFileGenerator({
     point,
-    seedWallet: derivedWallet,
+    seedWallet: inviteWallet,
   });
 
   // sync paper value to activation state

--- a/src/views/Activate/MasterKeyDownload.tsx
+++ b/src/views/Activate/MasterKeyDownload.tsx
@@ -18,7 +18,7 @@ import PaperBuilder from 'components/PaperBuilder';
 import { DEFAULT_FADE_TIMEOUT, MASTER_KEY_DURATION } from 'lib/constants';
 import { timeout } from 'lib/timeout';
 import View from 'components/View';
-import useKeyfileGenerator from 'lib/useKeyfileGenerator';
+import useMultikeyFileGenerator from 'lib/useMultikeyFileGenerator';
 
 const MasterKeyDownload = () => {
   const {
@@ -45,7 +45,10 @@ const MasterKeyDownload = () => {
     Just: p => p.value.toFixed(),
   });
 
-  const { download } = useKeyfileGenerator({ point });
+  const { download } = useMultikeyFileGenerator({
+    point,
+    seedWallet: derivedWallet,
+  });
 
   // sync paper value to activation state
   useEffect(

--- a/src/views/Activate/MasterKeyDownload.tsx
+++ b/src/views/Activate/MasterKeyDownload.tsx
@@ -14,12 +14,11 @@ import { FadeableMasterKeyPresenter as MasterKeyPresenter } from './MasterKeyPre
 import { useActivateFlow } from './ActivateFlow';
 import ActivateView from './ActivateView';
 import { useLocalRouter } from 'lib/LocalRouter';
-import { compileNetworkKey } from 'lib/keys';
-import { downloadWallet } from 'lib/invite';
 import PaperBuilder from 'components/PaperBuilder';
 import { DEFAULT_FADE_TIMEOUT, MASTER_KEY_DURATION } from 'lib/constants';
 import { timeout } from 'lib/timeout';
 import View from 'components/View';
+import useKeyfileGenerator from 'lib/useKeyfileGenerator';
 
 const MasterKeyDownload = () => {
   const {
@@ -46,12 +45,7 @@ const MasterKeyDownload = () => {
     Just: p => p.value.toFixed(),
   });
 
-  const download = useCallback(async () => {
-    const netkey = compileNetworkKey(wallet.network.keys, point, 1);
-    //TODO  could be deduplicated with useKeyfileGenerator's logic
-    const filename = ob.patp(point).slice(1) + '-1.key';
-    await downloadWallet(paper.getOrElse([]), netkey, filename);
-  }, [paper, wallet, point]);
+  const { download } = useKeyfileGenerator({ point });
 
   // sync paper value to activation state
   useEffect(

--- a/src/views/Activate/MasterKeyTransfer.tsx
+++ b/src/views/Activate/MasterKeyTransfer.tsx
@@ -20,7 +20,7 @@ const MasterKeyTransfer = () => {
     derivedPatp,
     derivedPoint,
     derivedWallet,
-    inviteWallet,
+    sendWallet,
   } = useActivateFlow();
   const [error, setError] = useState();
 
@@ -33,18 +33,13 @@ const MasterKeyTransfer = () => {
         to: derivedWallet.value.ownership.keys.address,
         manager: derivedWallet.value.management.keys.address,
         toWallet: derivedWallet.value,
-        fromWallet: inviteWallet.value,
+        fromWallet: sendWallet.value,
       });
     } catch (e) {
       console.error(e);
       setError(e);
     }
-  }, [
-    derivedWallet,
-    performL2Reticket,
-    derivedPoint.value,
-    inviteWallet.value,
-  ]);
+  }, [derivedWallet, performL2Reticket, derivedPoint.value, sendWallet.value]);
 
   useFadeIn();
 

--- a/src/views/Activate/useActivateFlowState.js
+++ b/src/views/Activate/useActivateFlowState.js
@@ -4,12 +4,29 @@ import { Nothing } from 'folktale/maybe';
 export default function useActivateFlowState() {
   const [derivedPatp, setDerivedPatp] = useState(Nothing());
   const [derivedPoint, setDerivedPoint] = useState(Nothing());
-  const [derivedPointDominion, setDerivedPointDominion] = useState(Nothing());
-  const [derivedWallet, setDerivedWallet] = useState(Nothing());
   const [generated, setGenerated] = useState(false);
   const [incomingPoints, setIncomingPoints] = useState(Nothing());
-  const [inviteWallet, setInviteWallet] = useState(Nothing());
+  const [derivedPointDominion, setDerivedPointDominion] = useState(Nothing());
   const [isIn, setIsIn] = useState(false);
+
+  // A new wallet generated after confirming that the invite ticket is valid
+  // and the point is available for activation.
+  // At the end of the Activate flow, the point will be transferred
+  // from the invite wallet to the derived wallet. When the user confirms
+  // the Master Key (ticket) and downloads the passport / mnemonic,
+  // it is for the derived wallet
+  // type UrbitWallet
+  const [derivedWallet, setDerivedWallet] = useState(Nothing());
+  // The wallet generated deterministically during the invite flow;
+  // it is re-generated when the user starts the Activate flow. It is used
+  // to derive and confirm a shareable ticket that a user can activate a point with.
+  // type UrbitWallet
+  const [inviteWallet, setInviteWallet] = useState(Nothing());
+  // This wallet is generated from the invite wallet's seed phrase.
+  // It is used during the transfer phase of the invite flow to send transactions.
+  // useMultiKeyFileGenerator.
+  // type bip32.BIP32Interface
+  const [sendWallet, setSendWallet] = useState(Nothing());
 
   const reset = useCallback(() => {
     setDerivedPatp(Nothing());
@@ -19,13 +36,16 @@ export default function useActivateFlowState() {
     setGenerated(false);
     setIncomingPoints(Nothing());
     setInviteWallet(Nothing());
+    setSendWallet(Nothing());
   }, [
+    setDerivedPatp,
     setDerivedPoint,
     setDerivedPointDominion,
     setDerivedWallet,
     setGenerated,
     setIncomingPoints,
     setInviteWallet,
+    setSendWallet,
   ]);
 
   return {
@@ -38,6 +58,7 @@ export default function useActivateFlowState() {
     inviteWallet,
     isIn,
     reset,
+    sendWallet,
     setDerivedPatp,
     setDerivedPoint,
     setDerivedPointDominion,
@@ -46,5 +67,6 @@ export default function useActivateFlowState() {
     setIncomingPoints,
     setInviteWallet,
     setIsIn,
+    setSendWallet,
   };
 }

--- a/src/views/UrbitID/DownloadKeys.js
+++ b/src/views/UrbitID/DownloadKeys.js
@@ -9,7 +9,7 @@ import { DownloadButton, RestartButton } from 'components/Buttons';
 import PaperBuilder from 'components/PaperBuilder';
 
 import { downloadWallet } from 'lib/invite';
-import useKeyfileGenerator from 'lib/useKeyfileGenerator';
+import useMultikeyFileGenerator from 'lib/useMultikeyFileGenerator';
 
 import { useWallet } from 'store/wallet';
 import { Grid, P } from 'indigo-react';
@@ -26,7 +26,7 @@ export default function AdminRedownload() {
   const _urbitWallet = need.wallet(urbitWallet);
   const point = need.point(pointCursor);
 
-  const { keyfile, filename } = useKeyfileGenerator({});
+  const { keyfile, filename } = useMultikeyFileGenerator({});
 
   const [paper, setPaper] = useState(Nothing());
   const [downloaded, setDownloaded] = useState(false);

--- a/src/views/UrbitID/DownloadKeys.js
+++ b/src/views/UrbitID/DownloadKeys.js
@@ -26,7 +26,7 @@ export default function AdminRedownload() {
   const _urbitWallet = need.wallet(urbitWallet);
   const point = need.point(pointCursor);
 
-  const { keyfile, filename } = useKeyfileGenerator();
+  const { keyfile, filename } = useKeyfileGenerator({});
 
   const [paper, setPaper] = useState(Nothing());
   const [downloaded, setDownloaded] = useState(false);

--- a/src/views/UrbitID/Home.tsx
+++ b/src/views/UrbitID/Home.tsx
@@ -13,7 +13,7 @@ import {
 } from 'lib/constants';
 import { abbreviateAddress } from 'lib/utils/address';
 import { downloadWallet } from 'lib/invite';
-import useKeyfileGenerator from 'lib/useKeyfileGenerator';
+import useMultikeyFileGenerator from 'lib/useMultikeyFileGenerator';
 
 import { useWallet } from 'store/wallet';
 import { useRollerStore } from 'store/rollerStore';
@@ -43,7 +43,7 @@ export default function UrbitIDHome() {
       return null;
     }
   }, [urbitWallet]);
-  const { keyfile, filename } = useKeyfileGenerator({});
+  const { keyfile, filename } = useMultikeyFileGenerator({});
   const [paper, setPaper] = useState(Nothing());
 
   const downloadKeys = useCallback(() => {

--- a/src/views/UrbitID/Home.tsx
+++ b/src/views/UrbitID/Home.tsx
@@ -43,7 +43,7 @@ export default function UrbitIDHome() {
       return null;
     }
   }, [urbitWallet]);
-  const { keyfile, filename } = useKeyfileGenerator();
+  const { keyfile, filename } = useKeyfileGenerator({});
   const [paper, setPaper] = useState(Nothing());
 
   const downloadKeys = useCallback(() => {

--- a/src/views/UrbitOS/AccessCode.test.tsx
+++ b/src/views/UrbitOS/AccessCode.test.tsx
@@ -4,7 +4,7 @@ import AccessCode from './AccessCode';
 
 describe('AccessCode', () => {
   describe('when code is not available', () => {
-    // Value is initialized as `false` in `useKeyfileGenerator`
+    // Value is initialized as `false` in `useMultikeyFileGenerator`
     const testCode = false;
 
     it('does not render the component', () => {
@@ -15,7 +15,7 @@ describe('AccessCode', () => {
   });
 
   describe('when code is available', () => {
-    // Value has been loaded from `useKeyfileGenerator`
+    // Value has been loaded from `useMultikeyFileGenerator`
     const testCode = 'foo-bar';
 
     it('renders the component', () => {

--- a/src/views/UrbitOS/Home.tsx
+++ b/src/views/UrbitOS/Home.tsx
@@ -42,7 +42,7 @@ export default function UrbitOSHome() {
     names,
   ]);
 
-  const { bind: keyBind, code } = useKeyfileGenerator();
+  const { bind: keyBind, code } = useKeyfileGenerator({});
 
   return (
     <Window className="os-home">

--- a/src/views/UrbitOS/Home.tsx
+++ b/src/views/UrbitOS/Home.tsx
@@ -9,7 +9,7 @@ import BodyPane from 'components/L2/Window/BodyPane';
 import { ReactComponent as KeyfileIcon } from 'assets/keyfile.svg';
 
 import { useLocalRouter } from 'lib/LocalRouter';
-import useKeyfileGenerator from 'lib/useKeyfileGenerator';
+import useMultikeyFileGenerator from 'lib/useMultikeyFileGenerator';
 import { Box, Button, Row } from '@tlon/indigo-react';
 import CopiableWithTooltip from 'components/copiable/CopiableWithTooltip';
 
@@ -42,7 +42,7 @@ export default function UrbitOSHome() {
     names,
   ]);
 
-  const { bind: keyBind, code } = useKeyfileGenerator({});
+  const { code, download } = useMultikeyFileGenerator({});
 
   return (
     <Window className="os-home">
@@ -53,7 +53,7 @@ export default function UrbitOSHome() {
             <Button
               className="header-button keyfile"
               disabled={!hasSetNetworkKeys}
-              onClick={keyBind.download}>
+              onClick={download}>
               <KeyfileIcon />
               Download Keyfile
             </Button>

--- a/src/views/UrbitOS/NetworkKeys.tsx
+++ b/src/views/UrbitOS/NetworkKeys.tsx
@@ -28,7 +28,7 @@ import {
 import useEthereumTransaction from 'lib/useEthereumTransaction';
 import { GAS_LIMITS } from 'lib/constants';
 import { addHexPrefix } from 'lib/utils/address';
-import useKeyfileGenerator from 'lib/useKeyfileGenerator';
+import useMultikeyFileGenerator from 'lib/useMultikeyFileGenerator';
 
 import DownloadKeyfileButton from 'components/DownloadKeyfileButton';
 import InlineEthereumTransaction from 'components/InlineEthereumTransaction';
@@ -72,7 +72,7 @@ function useSetKeys(
     generating: keyfileGenerating,
     filename,
     bind: keyfileBind,
-  } = useKeyfileGenerator({ seed: manualNetworkSeed });
+  } = useMultikeyFileGenerator({ seed: manualNetworkSeed });
 
   const buildNetworkSeed = useCallback(
     async manualSeed => {

--- a/src/views/UrbitOS/NetworkKeys.tsx
+++ b/src/views/UrbitOS/NetworkKeys.tsx
@@ -72,7 +72,7 @@ function useSetKeys(
     generating: keyfileGenerating,
     filename,
     bind: keyfileBind,
-  } = useKeyfileGenerator(manualNetworkSeed);
+  } = useKeyfileGenerator({ seed: manualNetworkSeed });
 
   const buildNetworkSeed = useCallback(
     async manualSeed => {

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -1,6 +1,6 @@
 import kg from 'urbit-key-generation';
 
-export async function generateWallet(data: string): Promise<string> {
+export async function generateWallet(data: string): Promise<UrbitWallet> {
   // Process the data without stalling the UI
   const config = JSON.parse(data);
   const wallet = await kg.generateWallet(config);


### PR DESCRIPTION
# Changes
- [x] refactor Activate flow to unify keyfile generation and download behavior
- [x] refactor `lib/keys` to support multikey format

# Example Key
## Before
```
0w54.XImwa.fDTLw.gBfjF.zVHuz.PUp3g.dXxtu.7Ycw2.iJYNb.NepHA.0NJ6L.B9AQQ.pY45l.X61fS.5ygpk.RQfAG.m3TjJ.~zQWg.wf00U.NGu41
```

## After
```
0wa5FlF.MRsOU.x46cu.1N~9q.5XQjk.LH7ye.cbD81.B9lYo.rzDLb.kgne7.5TFZd.dJCSY.Hfore.9WpoQ.HgDfE.zmqmC.MKi5r.y41o0.92NeX.5E2zV.ZXU49.jQWo-.qTEY-.6gQ3u.Unnx~.380AH.vciYj.CqV0c.rhHVi.pdd6v.11luN.wjZxo.A6ldt.3VaBw.ZQXvU.ZeA83.M0oIq.Dx0r5
```

# Testing
This was tested using `npm run pilot-ropsten`, the following flows "work on my machine":

- downloaded keyfile from Home view
- downloaded keyfile in Activate flow

