### PR TITLE
keys: during Activation, use new wallet's seed

### DIFF
--- a/src/views/Activate/ActivateCodeForm.tsx
+++ b/src/views/Activate/ActivateCodeForm.tsx
@@ -44,7 +44,7 @@ const ActivateCodeForm = ({ afterSubmit }: ActivateCodeFormProps) => {
     setDerivedPatp,
     setDerivedPoint,
     setDerivedPointDominion,
-    setDerivedWallet,
+    setInviteMasterTicketWallet,
     setInviteWallet,
     setIsIn,
     setSendWallet,
@@ -153,7 +153,7 @@ const ActivateCodeForm = ({ afterSubmit }: ActivateCodeFormProps) => {
         setDerivedPatp(Just(ob.patp(point)));
         setDerivedPoint(Just(point));
         setDerivedPointDominion(Just(rollerPoint.dominion));
-        setDerivedWallet(Just(await generateWallet(point, ticket, true)));
+        setInviteMasterTicketWallet(Just(await generateWallet(point, ticket, true)));
         setIsIn(false);
         await timeout(100);
       } else {
@@ -174,7 +174,7 @@ const ActivateCodeForm = ({ afterSubmit }: ActivateCodeFormProps) => {
       setDerivedPatp,
       setDerivedPoint,
       setDerivedPointDominion,
-      setDerivedWallet,
+      setInviteMasterTicketWallet,
       setIsIn,
       setSendWallet,
     ]

--- a/src/views/Activate/MasterKeyConfirm.tsx
+++ b/src/views/Activate/MasterKeyConfirm.tsx
@@ -25,8 +25,8 @@ import View from 'components/View';
 import './MasterKeyConfirm.scss';
 
 const MasterKeyConfirm = () => {
-  const { derivedWallet, setIsIn }: any = useActivateFlow();
-  const { ticket } = need.wallet(derivedWallet);
+  const { inviteMasterTicketWallet, setIsIn }: any = useActivateFlow();
+  const { ticket } = need.wallet(inviteMasterTicketWallet);
   const { push, names }: any = useLocalRouter();
   const STUB_VERIFY_TICKET = isDevelopment;
   const ticketSegments = useMemo(() => ticketToSegments(ticket), [ticket]);

--- a/src/views/Activate/MasterKeyDownload.tsx
+++ b/src/views/Activate/MasterKeyDownload.tsx
@@ -23,7 +23,7 @@ import View from 'components/View';
 const MasterKeyDownload = () => {
   const {
     derivedPoint,
-    derivedWallet,
+    inviteMasterTicketWallet,
     inviteWallet,
     isIn,
     setGenerated,
@@ -31,7 +31,7 @@ const MasterKeyDownload = () => {
   }: any = useActivateFlow();
   const { data, push, names }: any = useLocalRouter();
   const point = need.point(derivedPoint);
-  const wallet = need.wallet(derivedWallet);
+  const wallet = need.wallet(inviteMasterTicketWallet);
   const ticket = wallet.ticket.replace('~', '');
 
   const [paper, setPaper] = useState(Nothing());
@@ -49,6 +49,7 @@ const MasterKeyDownload = () => {
   const { keyfile, filename } = useMultikeyFileGenerator({
     point,
     seedWallet: inviteWallet,
+    inviteMasterTicketWallet,
   });
 
   // sync paper value to activation state

--- a/src/views/Activate/MasterKeyTransfer.tsx
+++ b/src/views/Activate/MasterKeyTransfer.tsx
@@ -19,7 +19,7 @@ const MasterKeyTransfer = () => {
   const {
     derivedPatp,
     derivedPoint,
-    derivedWallet,
+    inviteMasterTicketWallet,
     sendWallet,
   }: any = useActivateFlow();
   const [error, setError] = useState<any>();
@@ -30,16 +30,16 @@ const MasterKeyTransfer = () => {
     try {
       await performL2Reticket({
         point: derivedPoint.value,
-        to: derivedWallet.value.ownership.keys.address,
-        manager: derivedWallet.value.management.keys.address,
-        toWallet: derivedWallet.value,
+        to: inviteMasterTicketWallet.value.ownership.keys.address,
+        manager: inviteMasterTicketWallet.value.management.keys.address,
+        toWallet: inviteMasterTicketWallet.value,
         fromWallet: sendWallet.value,
       });
     } catch (e) {
       console.error(e);
       setError(e);
     }
-  }, [derivedWallet, performL2Reticket, derivedPoint.value, sendWallet.value]);
+  }, [inviteMasterTicketWallet, performL2Reticket, derivedPoint.value, sendWallet.value]);
 
   useFadeIn();
 

--- a/src/views/Activate/useActivateFlowState.js
+++ b/src/views/Activate/useActivateFlowState.js
@@ -12,11 +12,11 @@ export default function useActivateFlowState() {
   // A new wallet generated after confirming that the invite ticket is valid
   // and the point is available for activation.
   // At the end of the Activate flow, the point will be transferred
-  // from the invite wallet to the derived wallet. When the user confirms
+  // from the invite wallet to this wallet. When the user confirms
   // the Master Key (ticket) and downloads the passport / mnemonic,
-  // it is for the derived wallet
+  // it is for this wallet
   // type UrbitWallet
-  const [derivedWallet, setDerivedWallet] = useState(Nothing());
+  const [inviteMasterTicketWallet, setInviteMasterTicketWallet] = useState(Nothing());
   // The wallet generated deterministically during the invite flow;
   // it is re-generated when the user starts the Activate flow. It is used
   // to derive and confirm a shareable ticket that a user can activate a point with.
@@ -32,7 +32,7 @@ export default function useActivateFlowState() {
     setDerivedPatp(Nothing());
     setDerivedPoint(Nothing());
     setDerivedPointDominion(Nothing());
-    setDerivedWallet(Nothing());
+    setInviteMasterTicketWallet(Nothing());
     setGenerated(false);
     setIncomingPoints(Nothing());
     setInviteWallet(Nothing());
@@ -41,7 +41,7 @@ export default function useActivateFlowState() {
     setDerivedPatp,
     setDerivedPoint,
     setDerivedPointDominion,
-    setDerivedWallet,
+    setInviteMasterTicketWallet,
     setGenerated,
     setIncomingPoints,
     setInviteWallet,
@@ -52,7 +52,7 @@ export default function useActivateFlowState() {
     derivedPatp,
     derivedPoint,
     derivedPointDominion,
-    derivedWallet,
+    inviteMasterTicketWallet,
     generated,
     incomingPoints,
     inviteWallet,
@@ -62,7 +62,7 @@ export default function useActivateFlowState() {
     setDerivedPatp,
     setDerivedPoint,
     setDerivedPointDominion,
-    setDerivedWallet,
+    setInviteMasterTicketWallet,
     setGenerated,
     setIncomingPoints,
     setInviteWallet,


### PR DESCRIPTION
This fix adds conditional behavior to the MultiKeyFileGenerator.
By default, the keygen uses the logged-in wallet to generate both halves of the pair.

During the Activation flow, the generator now accepts an optional wallet arg which is used to pass in the receiving master ticket wallet. Then, the MT wallet is used to generate the 2nd half of the keypair.

This change also renames some variables for improved readability.
