### PR TITLE
metamask: send TX nonces as a string

### DIFF
--- a/src/lib/metamask.ts
+++ b/src/lib/metamask.ts
@@ -27,7 +27,7 @@ const metamaskSendTransaction = async (txn: FakeSignableTx, web3: Web3) => {
     data: data.toString(),
     gasLimit,
     gasPrice,
-    nonce: Number(nonce),
+    nonce: Number(nonce).toString(),
     to: to.toString(),
     from: toHex(from),
   };
@@ -48,6 +48,12 @@ const metamaskSendTransaction = async (txn: FakeSignableTx, web3: Web3) => {
     //      signed tx, it makes us wait for confirmation outside of our own
     //      waitForTransactionConfirm. because of this the progress bar loses
     //      its progressiveness for metamask users.
+
+    // Per the web3 lib's Typescript declarations, sendTransaction
+    // expects a Transaction nonce of type number to be passed in.
+    // However, at runtime, Metamask throws an error indicating that 
+    // nonce should be a string.
+    //@ts-ignore
     let receipt = await web3.eth.sendTransaction(metamaskFormattedTxn);
     txHash = receipt.transactionHash;
   }


### PR DESCRIPTION
Despite the Typescript compiler thinking that `web3.eth.sendTransaction`
 expects the `nonce` param as a type `number`,
 a `string` is actually required.

 Resolves this runtime error
 ```
 inpage.js:1 MetaMask - RPC Error: Invalid transaction params: nonce is not a string. got: (471) {code: -32602, message: 'Invalid transaction params: nonce is not a string. got: (471)'}
 ```