### PR TITLE
login: link to metamask guide

### DIFF
--- a/src/views/Login/LoginSelector.tsx
+++ b/src/views/Login/LoginSelector.tsx
@@ -192,7 +192,7 @@ export default function LoginSelector({
         </Grid.Item>
         <Modal show={showModal} hide={() => setShowModal(false)}>
           <Box className="info-modal-content">
-            <div className="fw-bold">Other Wallet Types</div>
+            <div className="fw-bold mb5">Other Wallet Types</div>
             <div className="mb5">
               All other wallet types are now supported via Metamask or
               WalletConnect.
@@ -203,6 +203,17 @@ export default function LoginSelector({
                 Hardware Wallet, Ethereum Keystore, or Ethereum Private Key,
               </span>{' '}
               please use Metamask going forward.
+            </div>
+            <div className="mb5">
+              Refer to{' '}
+              <Text
+                as="a"
+                style={{ textDecoration: 'underline' }}
+                href="https://metamask.zendesk.com/hc/en-us/articles/360020394612-How-to-connect-a-Trezor-or-Ledger-Hardware-Wallet"
+                target="_blank">
+                Metamask's guide
+              </Text>{' '}
+              on how to connect these wallets with Metamask.
             </div>
             <div>
               If you are using a <span className="fw-bold">mobile wallet</span>,


### PR DESCRIPTION
Adds supplemental copy and a link to Metamask's guide on how to connect a hardware wallet, since we don't support those any more.

![image](https://user-images.githubusercontent.com/748181/150691379-7288bb3d-00c8-4a32-9f0d-c4dc91ae1af0.png)

fixes urbit/bridge#882