### PR TITLE
proxy: treat L1 points w/ spawn dominion as L2

### DIFF
--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -206,7 +206,7 @@ export default function useRoller() {
           ? await api.getRemainingQuota(pointNum)
           : 0;
 
-        const details = isL2(rawDetails?.dominion)
+        const details = isL2Spawn(rawDetails?.dominion)
           ? toL1Details(rawDetails)
           : await azimuth.azimuth.getPoint(_contracts, point);
 


### PR DESCRIPTION
# Context
Before this change, when loading data from the roller API, points that had a dominion of 'spawn' were being treated like legacy L1 points. As such, Azimuth was queried as the source of truth, instead of the Roller API. Because of this, users were not seeing updated spawn proxy info in the Bridge UI.

Tested on Ropsten, was able to Migrate a star's spawn proxy to L2 and generate invites.

Open question: do we need another Layer indicator? Currently it shows as L1 in the Accounts Dropdown,
but L2 in the ID view

This fixes #874.

# Preview

## Account Dropdown Shows L1
![image](https://user-images.githubusercontent.com/16504501/151583932-ed690ffc-3717-4ad9-a5bd-e24846f64b4c.png)

## ID > Spawn Proxy Shows L2
![image](https://user-images.githubusercontent.com/16504501/151584033-67954d95-0125-4f3d-9209-2f97347e3e68.png)
