### PR TITLE
sponsorship: L1 can sponsor points on L2

### DIFF
--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -815,8 +815,12 @@ export default function useRoller() {
   );
 
   const changeSponsorship = useCallback(
-    async (sponsee: Ship, type: 'adopt' | 'detach' | 'reject') => {
-      if (quotaReached()) {
+    async (
+      sponsee: Ship,
+      type: 'adopt' | 'detach' | 'reject',
+      skipQuotaCheck = false
+    ) => {
+      if (!skipQuotaCheck && quotaReached()) {
         return;
       }
 

--- a/src/views/Ops/Requests.tsx
+++ b/src/views/Ops/Requests.tsx
@@ -35,21 +35,21 @@ export const Requests = () => {
   const handleAcceptClick = useCallback(
     async (ship: Ship) => {
       setLoading(true);
-      await changeSponsorship(ship, 'adopt');
+      await changeSponsorship(ship, 'adopt', point.isL1);
       await fetchRequests();
       setLoading(false);
     },
-    [changeSponsorship, fetchRequests, setLoading]
+    [changeSponsorship, fetchRequests, point.isL1, setLoading]
   );
 
   const handleRejectClick = useCallback(
     async (ship: Ship) => {
       setLoading(true);
-      await changeSponsorship(ship, 'reject');
+      await changeSponsorship(ship, 'reject', point.isL1);
       await fetchRequests();
       setLoading(false);
     },
-    [changeSponsorship, fetchRequests, setLoading]
+    [changeSponsorship, fetchRequests, point.isL1, setLoading]
   );
 
   useEffect(() => {

--- a/src/views/Ops/Residents.tsx
+++ b/src/views/Ops/Residents.tsx
@@ -34,13 +34,13 @@ export const Residents = () => {
   }, [api, point, setLoading]);
 
   const handleKick = useCallback(
-    async (point: Ship) => {
+    async (ship: Ship) => {
       setLoading(true);
-      await changeSponsorship(point, 'detach');
+      await changeSponsorship(ship, 'detach', point.isL1);
       await fetchResidents();
       setLoading(false);
     },
-    [fetchResidents, changeSponsorship, setLoading]
+    [setLoading, changeSponsorship, point.isL1, fetchResidents]
   );
 
   useEffect(() => {


### PR DESCRIPTION
This closes #898 by allowing L1 points to sponsor points on L2.
It does so by skipping the L2 roller quota check for `adopt`, `reject`, and `detach` actions.