### PR TITLE
bridge: more copyfixes

### DIFF
--- a/src/views/Activate/ActivateView.tsx
+++ b/src/views/Activate/ActivateView.tsx
@@ -32,16 +32,7 @@ export default function ActivateView({
 
   return (
     <Grid>
-      <Grid.Item
-        full
-        as={Text}
-        className="flex justify-center mt9 mb7 w-max-mobile">
-        <Grid.Item as={Text}>Bridge /&nbsp;</Grid.Item>
-        <Grid.Item className="fw-bold" as={Text}>
-          Activate
-        </Grid.Item>
-      </Grid.Item>
-      <Grid.Item>
+      <Grid.Item className="mt10">
         {!hideBack && (
           <HeaderButton
             className="mb4"

--- a/src/views/Activate/MasterKeyTransfer.tsx
+++ b/src/views/Activate/MasterKeyTransfer.tsx
@@ -113,9 +113,9 @@ const MasterKeyTransfer = () => {
         <p
           className="mb2 sans gray5"
           style={{ fontSize: 14, textAlign: 'center' }}>
-          You need your bootkey to boot your Urbit ID. You can find your bootkey
-          inside the Passport you downloaded. A computer running on the Urbit
-          network is called a ship.
+          You need your Network Key to boot your Urbit ID. You can find your
+          Network Key file inside the Passport you downloaded. A computer
+          running on the Urbit network is called a ship.
         </p>
       </Box>
     );

--- a/src/views/UrbitOS/NetworkKeys.scss
+++ b/src/views/UrbitOS/NetworkKeys.scss
@@ -6,6 +6,12 @@
   .body-pane {
     height: 360px;
 
+    .download {
+      height: 24px;
+      width: 24px;
+      margin: 0 auto 22px;
+    }
+
     .download-message {
       align-items: center;
       width: 350px;
@@ -15,12 +21,6 @@
       letter-spacing: 0em;
       text-align: center;
       margin: 90px auto 40px;
-
-      .download {
-        height: 24px;
-        width: 24px;
-        margin-bottom: 22px;
-      }
     }
 
     .contents {
@@ -29,24 +29,24 @@
       display: flex;
       flex-direction: column;
       justify-content: space-between;
-      
+
       .check-row {
         margin-top: 8px;
         font-weight: 500;
-    
+
         .checkbox {
           border-radius: $medium-border-radius;
           height: 16px;
           width: 16px;
           margin-right: 14px;
-    
+
           svg {
             height: 18px;
             width: 18px;
           }
         }
       }
-    
+
       .info-text {
         color: $dark-gray;
         margin: 8px 0px 24px 32px;

--- a/src/views/UrbitOS/NetworkKeys.tsx
+++ b/src/views/UrbitOS/NetworkKeys.tsx
@@ -9,7 +9,7 @@ import { Just } from 'folktale/maybe';
 import { Grid, Button } from 'indigo-react';
 import * as azimuth from 'azimuth-js';
 import { randomHex } from 'web3-utils';
-import { Box, Checkbox, Icon, Row } from '@tlon/indigo-react';
+import { Box, Checkbox, Icon, Row, Text } from '@tlon/indigo-react';
 
 import { usePointCache } from 'store/pointCache';
 import { useNetwork } from 'store/network';
@@ -280,8 +280,44 @@ export default function UrbitOSNetworkKeys({
     ? 'Set Network Keys'
     : 'Initiate Network Keys';
 
-  const usageMessage =
-    'With your new network keys, you also have a new keyfile. Download your new keyfile to boot your OS.';
+  const bootMessage = () => (
+    <Text as="p" textAlign={'center'}>
+      With your new network keys, you also have a new bootkey. Download your new
+      bootkey to boot your ship. Be sure to delete your old pier before booting
+      with this new bootkey.
+    </Text>
+  );
+
+  const resetMessage = () => (
+    <>
+      <Text as="p" textAlign={'center'}>
+        With your new network keys, you also have a new bootkey.
+        <br />
+        Copy the contents of your new bootkey and run
+      </Text>
+      <Text
+        as="code"
+        mono
+        bg={'washedGray'}
+        padding={2}
+        borderRadius={2}
+        textAlign={'center'}>
+        |rekey 'bootkey_contents'
+      </Text>
+      <Text as="p" textAlign={'center'}>
+        using the dojo on your running ship.
+      </Text>
+    </>
+  );
+
+  const waitMessage = () => (
+    <Text as="p" textAlign={'center'}>
+      <strong>Important:</strong> you will need to wait until the next L2 batch
+      is submitted to the roller to boot your ship. If you do not wait, then you
+      will run into a key mismatch error and will not be able to communicate
+      with other ships on the network.
+    </Text>
+  );
 
   const buttonText = `${hasKeys ? 'Reset' : 'Set'} Network Keys`;
 
@@ -295,9 +331,10 @@ export default function UrbitOSNetworkKeys({
       <BodyPane>
         {isComplete && (
           <Box className="flex-col col justify-between h-full">
-            <Box className="flex-col download-message">
+            <Box className="flex-col h-full justify-center">
               <Icon icon="Download" className="download" />
-              <Box>{usageMessage}</Box>
+              {breach ? bootMessage() : resetMessage()}
+              {breach && point.isL2 ? waitMessage() : null}
             </Box>
             {point.isL2 ? (
               <Grid.Item
@@ -306,7 +343,7 @@ export default function UrbitOSNetworkKeys({
                 solid
                 center
                 onClick={keyfileBind.download}>
-                Download Keyfile
+                Download Bootkey
               </Grid.Item>
             ) : (
               <Grid.Item

--- a/src/views/UrbitOS/NetworkKeys.tsx
+++ b/src/views/UrbitOS/NetworkKeys.tsx
@@ -282,18 +282,15 @@ export default function UrbitOSNetworkKeys({
 
   const bootMessage = () => (
     <Text as="p" textAlign={'center'}>
-      With your new network keys, you also have a new bootkey. Download your new
-      bootkey to boot your ship. Be sure to delete your old pier before booting
-      with this new bootkey.
+      Download your new Network Key to boot your ship. Be sure to delete your
+      old pier before booting with this new key.
     </Text>
   );
 
   const resetMessage = () => (
     <>
       <Text as="p" textAlign={'center'}>
-        With your new network keys, you also have a new bootkey.
-        <br />
-        Copy the contents of your new bootkey and run
+        Copy the contents of the Network Key file and run
       </Text>
       <Text
         as="code"
@@ -302,7 +299,7 @@ export default function UrbitOSNetworkKeys({
         padding={2}
         borderRadius={2}
         textAlign={'center'}>
-        |rekey 'bootkey_contents'
+        |rekey 'keyfile_contents'
       </Text>
       <Text as="p" textAlign={'center'}>
         using the dojo on your running ship.
@@ -343,7 +340,7 @@ export default function UrbitOSNetworkKeys({
                 solid
                 center
                 onClick={keyfileBind.download}>
-                Download Bootkey
+                Download Network Key
               </Grid.Item>
             ) : (
               <Grid.Item

--- a/src/views/UrbitOS/NetworkKeys.tsx
+++ b/src/views/UrbitOS/NetworkKeys.tsx
@@ -311,8 +311,7 @@ export default function UrbitOSNetworkKeys({
     <Text as="p" textAlign={'center'}>
       <strong>Important:</strong> you will need to wait until the next L2 batch
       is submitted to the roller to boot your ship. If you do not wait, then you
-      will run into a key mismatch error and will not be able to communicate
-      with other ships on the network.
+      will not be able to boot your ship.
     </Text>
   );
 


### PR DESCRIPTION
- New copy for Factory Reset confirmation screen
- New `|rekey` instructions for normal rekey confirmation screen
- Eliminates 'Bridge / Activate' header in activation flow

Fixes urbit/bridge#868, fixes urbit/bridge#888, fixes urbit/bridge#881