### PR TITLE
invites-ui: Show only unclaimed L2 invites in Invites view

### DIFF
--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import * as azimuth from 'azimuth-js';
 import * as need from 'lib/need';
+import * as ob from 'urbit-ob';
 import SecureLS from 'secure-ls';
 
 import { Invite } from 'lib/types/Invite';
@@ -405,6 +406,26 @@ export default function useRoller() {
           // TODO: check if the invite point's owner still matches the deterministic wallet address
           const planetInfo = await api.getPoint(planet);
           setStoredInvite(ls, invite);
+
+          if (isDevelopment) {
+            console.log(
+              `planet: ${planet} dominion: ${planetInfo.dominion} (${ob.patp(
+                planet
+              )})`
+            );
+            console.log(`invite owner: ${invite.owner.toLowerCase()}`);
+            console.log(
+              `planetInfo owner: ${planetInfo.ownership?.owner?.address}`
+            );
+            console.log(
+              `planetInfo transfer: ${planetInfo.ownership?.transferProxy?.address}`
+            );
+            console.log(
+              `invite unclaimed: ${invite.owner.toLowerCase() ===
+                planetInfo.ownership?.owner?.address ||
+                planetInfo.ownership?.transferProxy?.address !== ETH_ZERO_ADDR}`
+            );
+          }
 
           if (
             invite.owner.toLowerCase() ===
@@ -1064,6 +1085,7 @@ export default function useRoller() {
     getPoints,
     getPointsDetails,
     getPendingTransactions,
+    initPoint,
     ls,
     performL2Reticket,
     setProxyAddress,

--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -426,15 +426,13 @@ export default function useRoller() {
             );
             console.log(
               `invite unclaimed: ${invite.owner.toLowerCase() ===
-                planetInfo.ownership?.owner?.address ||
-                planetInfo.ownership?.transferProxy?.address !== ETH_ZERO_ADDR}`
+                planetInfo.ownership?.owner?.address}`
             );
           }
 
           if (
-            (invite.owner.toLowerCase() ===
-              planetInfo.ownership?.owner?.address ||
-              planetInfo.ownership?.transferProxy?.address !== ETH_ZERO_ADDR) &&
+            invite.owner.toLowerCase() ===
+              planetInfo.ownership?.owner?.address &&
             planetInfo.dominion === POINT_DOMINIONS.L2
           ) {
             newInvites.push(invite);

--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -31,9 +31,13 @@ import {
   getTimeToNextBatch,
   registerProxyAddress,
   isL2Spawn,
-  isL2,
 } from './utils/roller';
-import { ETH_ZERO_ADDR, ROLLER_HOSTS, TEN_SECONDS } from './constants';
+import {
+  ETH_ZERO_ADDR,
+  POINT_DOMINIONS,
+  ROLLER_HOSTS,
+  TEN_SECONDS,
+} from './constants';
 
 import {
   Config,
@@ -428,9 +432,10 @@ export default function useRoller() {
           }
 
           if (
-            invite.owner.toLowerCase() ===
+            (invite.owner.toLowerCase() ===
               planetInfo.ownership?.owner?.address ||
-            planetInfo.ownership?.transferProxy?.address !== ETH_ZERO_ADDR
+              planetInfo.ownership?.transferProxy?.address !== ETH_ZERO_ADDR) &&
+            planetInfo.dominion === POINT_DOMINIONS.L2
           ) {
             newInvites.push(invite);
             updateInvite(curPoint, invite);

--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import * as azimuth from 'azimuth-js';
 import * as need from 'lib/need';
-import * as ob from 'urbit-ob';
 import SecureLS from 'secure-ls';
 
 import { Invite } from 'lib/types/Invite';
@@ -410,25 +409,6 @@ export default function useRoller() {
           // TODO: check if the invite point's owner still matches the deterministic wallet address
           const planetInfo = await api.getPoint(planet);
           setStoredInvite(ls, invite);
-
-          if (isDevelopment) {
-            console.log(
-              `planet: ${planet} dominion: ${planetInfo.dominion} (${ob.patp(
-                planet
-              )})`
-            );
-            console.log(`invite owner: ${invite.owner.toLowerCase()}`);
-            console.log(
-              `planetInfo owner: ${planetInfo.ownership?.owner?.address}`
-            );
-            console.log(
-              `planetInfo transfer: ${planetInfo.ownership?.transferProxy?.address}`
-            );
-            console.log(
-              `invite unclaimed: ${invite.owner.toLowerCase() ===
-                planetInfo.ownership?.owner?.address}`
-            );
-          }
 
           if (
             invite.owner.toLowerCase() ===


### PR DESCRIPTION
# Context

On load, Bridge queries for spawning points from both Azimuth and the Roller, and the results are concatenated into a single de-duplicated array. This data is stored in the `controlledPointsStore`, and eventually `rollerStore`.

The Invites view consumes `invites` data from the `rollerStore` to render the list of invite links, and the count of invites in the badge.

For L1 stars that had previously issued L1 invites, and then subsequently migrated spawn proxy to L2, users would see legacy L1 invites in the Invites view, along with their L2 invites:

![image](https://user-images.githubusercontent.com/16504501/152269940-46461061-6896-4f3a-9f8b-058bf7454aef.png)

# Changes

This resolves #903 by removing the legacy filter based on transferProxy, and adding one based on the spawning point's `dominion`.

# Testing

Thanks to @yapishu for reporting the original issue, and for helping QA this branch with his star as the test case.

Also verified on Ropsten locally
