### PR TITLE
transfer: safer star lockup detection

### DIFF
--- a/src/views/UrbitID/Transfer.tsx
+++ b/src/views/UrbitID/Transfer.tsx
@@ -70,7 +70,9 @@ export default function AdminTransfer() {
     const az = azimuth.azimuth;
     return (
       az.getPointSize(point.value) === az.PointSize.Galaxy &&
-      starReleaseDetails.map((a: any) => a.kind).getOrElse('none') !== 'none'
+      starReleaseDetails
+        .map((a: any) => a?.kind || 'none')
+        .getOrElse('none') !== 'none'
     );
   }, [starReleaseDetails, point]);
 


### PR DESCRIPTION
In the event that star release store fails to fetch lockup details, it will
store a `Just(null)` value instead. Here, we need to account for the
possibility that `a` is null and cannot be indexed into.

Arguably it should just put `Nothing()` for the failure case? Though the points overview screen might depend on this being `Just` to determine whether it's done loading yet or not. We've had issues like this in the past though, so perhaps worth cleaning up, but out of scope for now.

(Note that the relevant lookup usually doesn't fail on mainnet, so this was really just a ropsten problem.)

Fixes #908.