### PR TITLE
activate: form entry should override implied ticket

### DIFF
--- a/src/views/Activate/ActivateCodeForm.tsx
+++ b/src/views/Activate/ActivateCodeForm.tsx
@@ -122,7 +122,7 @@ const ActivateCodeForm = ({ afterSubmit }: ActivateCodeFormProps) => {
 
       // Derive wallet
       const { ticket, point } = getTicketAndPoint(
-        impliedTicket || values.ticket
+        values.ticket || impliedTicket
       );
 
       const inviteWallet = Just(await urbitWalletFromTicket(ticket, point));


### PR DESCRIPTION
If you happen to get into the activate flow without a valid ticket, we kick you to a screen for manual entry. However, if you put junk in the URL to get there we were actually using that over what was entered into the form.