### PR TITLE
details-store: try both L1 and L2 when syncing details

### DIFF
--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -672,7 +672,8 @@ export default function useRoller() {
 
       return api.getPendingTx(txHash);
     },
-    [// eslint-disable-line
+    [
+      // eslint-disable-line
       api,
       authMnemonic,
       authToken,

--- a/src/store/lib/useDetailsStore.ts
+++ b/src/store/lib/useDetailsStore.ts
@@ -48,8 +48,17 @@ export default function useDetailsStore() {
         addToDetails({
           [point]: details,
         });
-      } catch (e) {
+      } catch (error) {
         if (isDevelopment) {
+          console.warn(error);
+        }
+
+        try {
+          const details = await azimuth.azimuth.getPoint(_contracts, point);
+          addToDetails({
+            [point]: details,
+          });
+        } catch (e) {
           console.warn(e);
         }
       }


### PR DESCRIPTION
So I'm not entirely sure this is right, but from what I could glean, it seems like the roller API was failing to find the new L1 point throwing an error from `api.getPoint`, so the L1 point details never get synced?  This just adds a backup call to try getting the point from azimuth similar to what you see in the `useRoller` hook under `initPoint`.