### PR TITLE
Fix grab-bag

### DIFF
--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -1008,7 +1008,6 @@ export default function useRoller() {
       spawningPoints: number[]
     ) => {
       try {
-        debugger;
         const allPoints = [
           await Promise.all(ownedPoints.map(initPoint)),
           await Promise.all(incomingPoints.map(initPoint)),
@@ -1017,7 +1016,6 @@ export default function useRoller() {
           await Promise.all(spawningPoints.map(initPoint)),
         ];
 
-        debugger;
         setPoints(
           allPoints.reduce((acc: Points, cur: (Point | undefined)[]) => {
             cur.forEach(p => {

--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -97,6 +97,7 @@ export default function useRoller() {
   const { setNextRoll } = useTimerStore();
 
   const {
+    invitesLoading,
     nextBatchTime,
     point,
     points,
@@ -357,6 +358,10 @@ export default function useRoller() {
   };
 
   const getInvites = useCallback(async () => {
+    if (invitesLoading) {
+      return;
+    }
+
     try {
       setInvitesLoading(true);
       const curPoint: number = Number(need.point(pointCursor));
@@ -672,7 +677,8 @@ export default function useRoller() {
 
       return api.getPendingTx(txHash);
     },
-    [// eslint-disable-line
+    [
+      // eslint-disable-line
       api,
       authMnemonic,
       authToken,

--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -268,7 +268,8 @@ export default function useRoller() {
     }: UpdateParams) => {
       if (l1Txn) storePendingL1Txn(l1Txn);
 
-      const interval = setInterval(async () => {
+      let interval: any;
+      const check = async () => {
         const updatedPoint = await initPoint(point);
         const changedField = !points[point]
           ? 'newPoint'
@@ -280,7 +281,10 @@ export default function useRoller() {
 
         if (!updatedPoint.isPlaceholder && changedField) {
           updatePoint(updatedPoint);
-          clearInterval(interval);
+          if (interval) {
+            clearInterval(interval);
+          }
+
           if (l1Txn) deletePendingL1Txn(l1Txn);
           if (notify) {
             showNotification(
@@ -288,7 +292,10 @@ export default function useRoller() {
             );
           }
         }
-      }, intervalTime);
+      };
+
+      interval = setInterval(check, intervalTime);
+      check();
     },
     [points, initPoint, updatePoint, storePendingL1Txn, deletePendingL1Txn]
   );
@@ -1001,6 +1008,7 @@ export default function useRoller() {
       spawningPoints: number[]
     ) => {
       try {
+        debugger;
         const allPoints = [
           await Promise.all(ownedPoints.map(initPoint)),
           await Promise.all(incomingPoints.map(initPoint)),
@@ -1009,6 +1017,7 @@ export default function useRoller() {
           await Promise.all(spawningPoints.map(initPoint)),
         ];
 
+        debugger;
         setPoints(
           allPoints.reduce((acc: Points, cur: (Point | undefined)[]) => {
             cur.forEach(p => {

--- a/src/views/AcceptTransfer.tsx
+++ b/src/views/AcceptTransfer.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import cn from 'classnames';
 import { Nothing } from 'folktale/maybe';
 import { Grid, Text, CheckboxInput, Button } from 'indigo-react';
@@ -68,6 +74,7 @@ export default function AcceptTransfer() {
 
   const name = useCurrentPointName();
 
+  const transferring = useRef(false);
   const [reset, setReset] = useState(true);
 
   const {
@@ -115,6 +122,11 @@ export default function AcceptTransfer() {
   }, [pop, setPointCursor]);
 
   const acceptTransfer = useCallback(async () => {
+    if (transferring.current) {
+      return;
+    }
+
+    transferring.current = true;
     await transferPoint(_address, reset);
     await checkForUpdates({
       point: point.value,

--- a/src/views/Points.tsx
+++ b/src/views/Points.tsx
@@ -121,7 +121,6 @@ export default function Points() {
     [getDetails, controlledPoints, _contracts]
   );
 
-  debugger;
   const allPoints = useMemo(
     () =>
       pointList.filter(

--- a/src/views/Points.tsx
+++ b/src/views/Points.tsx
@@ -121,11 +121,14 @@ export default function Points() {
     [getDetails, controlledPoints, _contracts]
   );
 
+  debugger;
   const allPoints = useMemo(
     () =>
       pointList.filter(
-        ({ isTransferProxy, shouldDisplay, value }) =>
-          shouldDisplay && !isTransferProxy && !rejectedPoints.includes(value)
+        ({ isTransferProxy, isTransferProxySet, shouldDisplay, value }) =>
+          shouldDisplay &&
+          !(isTransferProxy || isTransferProxySet) &&
+          !rejectedPoints.includes(value)
       ),
     [pointList, rejectedPoints]
   );

--- a/src/views/Points.tsx
+++ b/src/views/Points.tsx
@@ -121,7 +121,14 @@ export default function Points() {
     [getDetails, controlledPoints, _contracts]
   );
 
-  const allPoints = pointList.filter(({ shouldDisplay }) => shouldDisplay);
+  const allPoints = useMemo(
+    () =>
+      pointList.filter(
+        ({ isTransferProxy, shouldDisplay, value }) =>
+          shouldDisplay && !isTransferProxy && !rejectedPoints.includes(value)
+      ),
+    [pointList, rejectedPoints]
+  );
 
   // if we can only interact with a single point, jump to the point page.
   // if there are any pending transfers, incoming or outgoing, stay on this


### PR DESCRIPTION
This PR implements a few fixes associated with issues and a few things to just clean up:

- Fixes issue where clicking "Accept Transfer" made multiple transactions
- Fixes issue where "Incoming Point" box still shows upon going back to home screen after accepting transfer, #938 
- Hides rejected points, incoming, and outgoing points from the main list of points so they aren't duplicated, #939 
- Prevents multiple calls for `getInvites` from overlapping and generating the same wallets over and over