### PR TITLE
eth: update Ethereum Provider integration

### DIFF
--- a/src/views/Login/LoginSelector.tsx
+++ b/src/views/Login/LoginSelector.tsx
@@ -79,14 +79,19 @@ export default function LoginSelector({
 
   const selectMetamask = useCallback(async () => {
     try {
+      if (!window.ethereum) {
+        throw new Error(
+          'Device does not have an Ethereum provider available (is Metamask or Brave Wallet installed?)'
+        );
+      }
       setMetamask(true);
       setMetamaskSelected(true);
-      const accounts = await (window as any).ethereum.send(
-        'eth_requestAccounts'
-      );
-      const wallet = new MetamaskWallet(accounts.result[0]);
+      const accounts = await window.ethereum.request({
+        method: 'eth_requestAccounts',
+      });
+      const wallet = new MetamaskWallet(accounts[0]);
 
-      const web3 = new Web3((window as any).ethereum);
+      const web3 = new Web3(window.ethereum);
       const authToken = await getAuthToken({
         address: wallet.address,
         walletType: WALLET_TYPES.METAMASK,

--- a/src/views/Login/Metamask.js
+++ b/src/views/Login/Metamask.js
@@ -33,7 +33,9 @@ export default function Metamask({ className, goHome }) {
   const onSubmit = useCallback(async () => {
     try {
       setMetamask(true);
-      const accounts = await window.ethereum.send('eth_requestAccounts');
+      const accounts = await window.ethereum.request({
+        method: 'eth_requestAccounts',
+      });
       const wallet = new MetamaskWallet(accounts.result[0]);
 
       const web3 = new Web3(window.ethereum);


### PR DESCRIPTION
The Ethereum Provider API was recently updated:
- [announcement](https://medium.com/metamask/breaking-changes-to-the-metamask-provider-are-here-7b11c9388be9)
- [migration guide](https://docs.metamask.io/guide/provider-migration.html#table-of-contents)

This change fixes Brave Wallet integration by using the updated method to request connected accounts