### PR TITLE
l2transaction: update method signature

### DIFF
--- a/src/lib/types/L2Transaction.ts
+++ b/src/lib/types/L2Transaction.ts
@@ -1,4 +1,16 @@
-import RollerRPCAPI, { EthAddress, Proxy, Ship } from '@urbit/roller-api';
+import RollerRPCAPI, {
+  Adopt,
+  CancelEscape,
+  ConfigureKeys,
+  Detach,
+  Escape,
+  EthAddress,
+  Proxy,
+  Reject,
+  Ship,
+  Spawn,
+  TransferPoint,
+} from '@urbit/roller-api';
 import WalletConnect from '@walletconnect/client';
 import BridgeWallet from './BridgeWallet';
 
@@ -37,7 +49,16 @@ export interface L2TransactionArgs extends SendL2Params {
 
 export interface TransactionData {
   data: any;
-  method: Function;
+  method:
+    | Spawn
+    | TransferPoint
+    | ConfigureKeys
+    | Escape
+    | CancelEscape
+    | Adopt
+    | Detach
+    | Reject
+    | (() => Promise<string>);
 }
 
 export interface ReticketProgressCallback {

--- a/src/lib/utils/roller.ts
+++ b/src/lib/utils/roller.ts
@@ -272,7 +272,7 @@ const getDataAndMethod = (args: L2TransactionArgs) => {
     sponsee,
     ship,
   } = args;
-  const result: TransactionData = { data: { address }, method: () => null };
+  const result: TransactionData = { data: { address }, method: async () => '' };
 
   switch (args.type) {
     case 'transferPoint':
@@ -360,7 +360,7 @@ export const submitL2Transaction = async (args: L2TransactionArgs) => {
     connector
   );
 
-  return method(sig, from, wallet.address, data);
+  return method(sig, false, from, wallet.address, data);
 };
 
 export const reticketL2Point = async () => {};


### PR DESCRIPTION
This updates the typings so they match and also updates the signature of the method call. Wasn't sure if force should be false or true, but it seemed defaulted to false elsewhere.