### PR TITLE
migrate: add notice to Points view

### DIFF
--- a/src/views/Points.scss
+++ b/src/views/Points.scss
@@ -15,3 +15,14 @@
     font-family: 'Inter';
   }
 }
+
+div.migrated-info-box {
+  margin-top: 30px;
+  font-size: 14px;
+  display: flex;
+  flex-flow: row nowrap;
+
+  span.message {
+    padding-left: 5px;
+  }
+}

--- a/src/views/Points.tsx
+++ b/src/views/Points.tsx
@@ -28,11 +28,12 @@ import L2PointHeader from 'components/L2/Headers/L2PointHeader';
 import IncomingPoint from 'components/L2/Points/IncomingPoint';
 import LoadingOverlay from 'components/L2/LoadingOverlay';
 import PointList from 'components/L2/PointList';
-import { Box, Text } from '@tlon/indigo-react';
+import { Box, Icon, Text } from '@tlon/indigo-react';
 
 import './Points.scss';
 import { StarReleaseButton } from './Points/StarReleaseButton';
 import { maybeGetResult } from 'lib/maybeGetResult';
+import { isGalaxy, isStar } from 'lib/utils/point';
 
 export const isLocked = (details: any, contracts: any) =>
   details.owner === contracts.linearSR ||
@@ -171,6 +172,11 @@ export default function Points() {
 
   const displayEmptyState =
     !loading && incomingPoints.length === 0 && allPoints.length === 0;
+
+  // If the user has any stars or galaxies, give a polite heads up that
+  // it can take some time for the roller be aware of L1 TXs
+  const showMigrateNotice = !displayEmptyState &&
+    allPoints.some(p => isStar(p.value) || isGalaxy(p.value));
 
   const starReleasing = starReleaseDetails
     .map((s: any) => (s ? s.total > 0 : false))
@@ -324,19 +330,17 @@ export default function Points() {
           </Grid.Item>
         )}
 
-        {/* {processingPoints.length > 0 && (
-          <Grid.Item full as={Grid} gap={1} className="mv6">
-            <Grid.Item full as={H5}>
-              Awaiting L2 Rollup
-            </Grid.Item>
-            <Grid.Item
-              full
-              as={PointList}
-              points={processingPoints}
-              processing
-            />
+        {showMigrateNotice && (
+          <Grid.Item full as={Box} className={'migrated-info-box'}>
+            <span className={'icon'}>
+              <Icon icon="Info" />
+            </span>
+            <span className={'message'}>
+              Not seeing a recently-migrated Layer 2 point? It may take a few
+              minutes for the public roller to be aware of the transaction.
+            </span>
           </Grid.Item>
-        )} */}
+        )}
 
         <Footer>
           <Grid>


### PR DESCRIPTION
# Changes

Based on early user feedback, the Migration UX can be unsettling when a star seemingly disappears from the Family view after migration.

This change adds a brief notice that will hopefully assuage this feeling until we can come up with a better experience.

Also, some dead code is removed.

# Preview

![image](https://user-images.githubusercontent.com/16504501/153779210-73c8980a-009f-4b01-9492-629e7eb30aa2.png)
