### PR TITLE
roller: move polling, less ddos

### DIFF
--- a/src/Bridge.js
+++ b/src/Bridge.js
@@ -25,6 +25,7 @@ import Modal from 'components/L2/Modal';
 import { useRollerStore } from 'store/rollerStore';
 import { Box } from '@tlon/indigo-react';
 import LoadingOverlay from 'components/L2/LoadingOverlay';
+import { useRollerPoller } from 'lib/useRollerPoller';
 
 const INITIAL_NETWORK_TYPE = isRopsten
   ? NETWORK_TYPES.ROPSTEN
@@ -72,6 +73,12 @@ function useInitialRoutes() {
   return [{ key: ROUTE_NAMES.LOGIN }];
 }
 
+function Poller() {
+  useRollerPoller();
+
+  return null;
+}
+
 function Bridge() {
   const initialRoutes = useInitialRoutes();
   const { loading, modalText, setModalText } = useRollerStore();
@@ -105,6 +112,7 @@ function Bridge() {
           <Box width="280px">{modalText}</Box>
         </Modal>
         <LoadingOverlay loading={loading} />
+        <Poller />
       </Provider>
     </WithErrorBoundary>
   );

--- a/src/lib/useRollerPoller.ts
+++ b/src/lib/useRollerPoller.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { useRollerStore } from 'store/rollerStore';
+import { useTimerStore } from 'store/timerStore';
+import { ONE_SECOND, TEN_SECONDS } from './constants';
+import useRoller from './useRoller';
+import { getTimeToNextBatch } from './utils/roller';
+
+export function useRollerPoller() {
+  const { nextBatchTime, setNextBatchTime, setNextRoll } = useTimerStore();
+  const { point } = useRollerStore();
+  const { api, getInvites, getPendingTransactions } = useRoller();
+  const [time, setTime] = useState(ONE_SECOND);
+
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      const nextRoll = getTimeToNextBatch(nextBatchTime, new Date().getTime());
+      setNextRoll(nextRoll);
+
+      if (nextBatchTime - ONE_SECOND <= new Date().getTime()) {
+        const response = await api.getRollerConfig();
+
+        if (response.nextBatch === nextBatchTime) {
+          // exponentially back off or cap at polling every minute
+          setTime(Math.min(60 * ONE_SECOND, time + time));
+          return;
+        }
+
+        setTime(ONE_SECOND); // reset the timer
+        setNextBatchTime(response.nextBatch);
+        getPendingTransactions();
+
+        setTimeout(() => {
+          if (!point.isDefault) {
+            getInvites(); // This will also get pending txns
+          }
+        }, TEN_SECONDS); // Should this be more like a minute?
+      }
+    }, time);
+
+    return () => clearInterval(interval);
+  }, [time, point, nextBatchTime, getPendingTransactions, getInvites]); // eslint-disable-line react-hooks/exhaustive-deps
+}


### PR DESCRIPTION
This PR adjusts the polling behavior for next batch time so that it doesn't have the capability of sending off lots of requests as soon as the roller falls behind. It also refactors the polling behavior to live in it's own file so that we're not adding to the giant useRoller file. 