### PR TITLE
api: configurable Roller endpoint via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,19 @@ A proper "offline mode" for the latest iteration of Bridge is still being worked
 ## Development
 
 See [development.md](DEVELOPMENT.md).
+
+
+## Configurable Roller Endpoint
+
+By default, Bridge uses Tlon's L2 Roller, but can also be configured to use your own.
+
+For example:
+
+```sh
+REACT_APP_ROLLER_HOST=my-personal-roller.net npm run pilot-mainnet
+```
+
+The following are configurable, and will otherwise fallback to the defaults in `constants`:
+- `REACT_APP_ROLLER_HOST` - host
+- `REACT_APP_ROLLER_PORT` - port
+- `REACT_APP_ROLLER_TRANSPORT_TYPE` - transport type (e.g., `http` or `https`)

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -106,6 +106,8 @@ const ROLLER_HOSTS = {
   MAINNET: 'roller.urbit.org',
 };
 
+const ROLLER_PATH = '/v1/roller';
+
 const POINT_DOMINIONS = {
   L1: 'l1',
   L2: 'l2',
@@ -250,6 +252,7 @@ export {
   ZOD,
   PROGRESS_ANIMATION_DELAY_MS,
   ROLLER_HOSTS,
+  ROLLER_PATH,
   POINT_DOMINIONS,
   POINT_PROXIES,
   DEFAULT_FADE_TIMEOUT,

--- a/src/lib/flags.js
+++ b/src/lib/flags.js
@@ -6,3 +6,8 @@ export const isRopsten = process.env.REACT_APP_ROPSTEN === 'true';
 export const isMainnet = process.env.REACT_APP_MAINNET === 'true';
 export const versionLabel =
   process.env.REACT_APP_BRIDGE_VERSION || `${version}${isRopsten ? 'r' : ''}`;
+export const providedRollerOptions = {
+  host: process.env.REACT_APP_ROLLER_HOST,
+  port: process.env.REACT_APP_ROLLER_PORT,
+  type: process.env.REACT_APP_ROLLER_TRANSPORT_TYPE,
+};

--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -22,7 +22,7 @@ import { usePointCache } from 'store/pointCache';
 
 import { getUpdatedPointMessage, isPlanet, toL1Details } from './utils/point';
 import { convertToInt } from './convertToInt';
-import { isDevelopment, isMainnet, isRopsten } from './flags';
+import { isDevelopment } from './flags';
 import {
   generateInviteWallet,
   getPendingSpawns,
@@ -30,14 +30,13 @@ import {
   registerProxyAddress,
   isL2Spawn,
 } from './utils/roller';
-import { POINT_DOMINIONS, ROLLER_HOSTS, TEN_SECONDS } from './constants';
+import { POINT_DOMINIONS, TEN_SECONDS } from './constants';
 
 import {
   Config,
   Ship,
   Proxy,
   RollerRPCAPI,
-  Options,
   EthAddress,
   UnspawnedPoints,
 } from '@urbit/roller-api';
@@ -50,6 +49,7 @@ import { showNotification } from './utils/notifications';
 import { useWalletConnect } from './useWalletConnect';
 import { PendingL1Txn } from './types/PendingL1Transaction';
 import { TRANSACTION_PROGRESS } from './reticket';
+import { useRollerOptions } from './useRollerOptions';
 
 interface UpdateParams {
   point: number;
@@ -108,25 +108,7 @@ export default function useRoller() {
   } = useRollerStore();
   const [config, setConfig] = useState<Config | null>(null);
 
-  const options: Options = useMemo(() => {
-    const type = isMainnet || isRopsten ? 'https' : 'http';
-    const host = isMainnet
-      ? ROLLER_HOSTS.MAINNET
-      : isRopsten
-      ? ROLLER_HOSTS.ROPSTEN
-      : ROLLER_HOSTS.LOCAL;
-    const port = isMainnet || isRopsten ? 443 : 8080;
-    const path = '/v1/roller';
-
-    return {
-      transport: {
-        type,
-        host,
-        port,
-        path,
-      },
-    };
-  }, []);
+  const { options } = useRollerOptions();
 
   const api = useMemo(() => {
     return new RollerRPCAPI(options);

--- a/src/lib/useRollerOptions.ts
+++ b/src/lib/useRollerOptions.ts
@@ -1,0 +1,59 @@
+import { Options } from '@urbit/roller-api';
+import { useMemo } from 'react';
+import { ROLLER_HOSTS, ROLLER_PATH } from './constants';
+import { convertToInt } from './convertToInt';
+import { isMainnet, isRopsten, providedRollerOptions } from './flags';
+
+type TransportType =
+  | 'websocket'
+  | 'http'
+  | 'https'
+  | 'postmessagewindow'
+  | 'postmessageiframe';
+
+/**
+ * This hook produces a Roller API options config based on the runtime env.
+ *
+ * By default, it uses the hardcoded values from constants.ts, but optionally
+ * a consumer of Bridge can provide a custom host, port, and transport type to
+ * override these settings.
+ *
+ * @returns options (type Options from @urbit/roller-api)
+ */
+export const useRollerOptions = () => {
+  const {
+    host: providedHost,
+    port: providedPort,
+    type: providedType,
+  } = providedRollerOptions;
+
+  const options: Options = useMemo(() => {
+    const type =
+      (providedType as TransportType | undefined) ||
+      (isMainnet || isRopsten ? 'https' : 'http');
+    const host =
+      providedHost ||
+      (isMainnet
+        ? ROLLER_HOSTS.MAINNET
+        : isRopsten
+        ? ROLLER_HOSTS.ROPSTEN
+        : ROLLER_HOSTS.LOCAL);
+    const port =
+      (providedPort && convertToInt(providedPort, 10)) ||
+      (isMainnet || isRopsten ? 443 : 8080);
+    const path = ROLLER_PATH;
+
+    return {
+      transport: {
+        type,
+        host,
+        port,
+        path,
+      },
+    };
+  }, [providedHost, providedPort, providedType]);
+
+  return {
+    options,
+  };
+};


### PR DESCRIPTION
Before this change, Bridge was configured to only use the L2 roller provided by Tlon.

This change allows a Bridge user to use one or more runtime env vars to connect to a custom roller.

For example:

```sh
REACT_APP_ROLLER_HOST=my-personal-roller.net npm run pilot-mainnet
```

The following are configurable, and will otherwise fallback to the defaults in `constants`:
- `REACT_APP_ROLLER_HOST` - host
- `REACT_APP_ROLLER_PORT` - port
- `REACT_APP_ROLLER_TRANSPORT_TYPE` - transport type (e.g., `http` or `https`)

Resolves #974