### PR TITLE
auth: use keccak256 to derive token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14239,15 +14239,14 @@
       }
     },
     "ethereumjs-util": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
-      "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
+      "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
       "requires": {
         "@types/bn.js": "^5.1.0",
         "bn.js": "^5.1.2",
         "create-hash": "^1.1.2",
         "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "0.1.6",
         "rlp": "^2.2.4"
       },
       "dependencies": {
@@ -14309,15 +14308,6 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         }
-      }
-    },
-    "ethjs-util": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-      "requires": {
-        "is-hex-prefixed": "1.0.0",
-        "strip-hex-prefix": "1.0.0"
       }
     },
     "event-iterator": {
@@ -28808,11 +28798,18 @@
       }
     },
     "rlp": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
-      "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
+      "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
       "requires": {
-        "bn.js": "^4.11.1"
+        "bn.js": "^5.2.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        }
       }
     },
     "rn-host-detect": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "copy-to-clipboard": "^3.2.0",
     "date-fns": "^2.25.0",
     "ethereum-blockies-base64": "^1.0.2",
-    "ethereumjs-util": "^7.0.10",
+    "ethereumjs-util": "^7.1.4",
     "file-saver": "^2.0.0",
     "final-form": "^4.18.4",
     "final-form-arrays": "^3.0.1",

--- a/src/components/L2/Modal.scss
+++ b/src/components/L2/Modal.scss
@@ -39,3 +39,15 @@
     }
   }
 }
+
+.info-modal-content {
+  position: relative;
+  background-color: white;
+  width: 280px;
+  border-radius: $large-border-radius;
+  font-family: $default-font;
+  padding: 24px;
+  font-size: 14px;
+  line-height: 24px;
+  max-width: 100%;
+}

--- a/src/components/L2/Window/HeaderPane.scss
+++ b/src/components/L2/Window/HeaderPane.scss
@@ -33,6 +33,11 @@
       padding: 8px 16px;
       font-family: $default-font;
 
+      &.keyfile-unavailable {
+        height: unset;
+        background-color: rgba(0, 0, 0, 0.6);
+      }
+
       &:hover {
         opacity: 0.8;
       }

--- a/src/lib/authToken.ts
+++ b/src/lib/authToken.ts
@@ -1,4 +1,3 @@
-import { crypto } from 'bitcoinjs-lib';
 import { ecdsaSign } from 'secp256k1';
 import Web3 from 'web3';
 import { hexToBytes } from 'web3-utils';
@@ -9,13 +8,13 @@ import { ledgerSignMessage } from './ledger';
 import { trezorSignMessage } from './trezor';
 import BridgeWallet from './types/BridgeWallet';
 import { Hash } from '@urbit/roller-api';
+import { keccak256 } from 'ethereumjs-util';
 
 const MESSAGE = 'Bridge Authentication Token';
 
 function signMessage(privateKey: Buffer) {
   const msg = '\x19Ethereum Signed Message:\n' + MESSAGE.length + MESSAGE;
-  // #ecdsaSign requires a 32-byte buffer, hence sha256
-  const hashed = crypto.sha256(Buffer.from(msg));
+  const hashed = keccak256(Buffer.from(msg));
   const { signature } = ecdsaSign(Buffer.from(hashed), privateKey);
 
   // add key recovery parameter

--- a/src/store/wallet.js
+++ b/src/store/wallet.js
@@ -53,6 +53,11 @@ function _useWallet(initialWallet = Nothing(), initialMnemonic = Nothing()) {
 
   const [authToken, setAuthToken] = useState(Nothing());
 
+  // See: https://github.com/urbit/bridge/issues/549#issuecomment-1048359617
+  // This is used for legacy compatibility; this flow should eventually be
+  // be removed after ~1 year.
+  const [useLegacyTokenSigning, setUseLegacyTokenSigning] = useState(false);
+
   const { web3 } = useNetwork();
 
   useEffect(() => {
@@ -72,11 +77,12 @@ function _useWallet(initialWallet = Nothing(), initialMnemonic = Nothing()) {
         walletType,
         walletHdPath,
         web3: _web3,
+        useLegacyTokenSigning,
       });
 
       setAuthToken(Just(token));
     })();
-  }, [wallet, walletType, walletHdPath, web3]);
+  }, [wallet, walletType, walletHdPath, web3, useLegacyTokenSigning]);
 
   const setWalletType = useCallback(
     walletType => {
@@ -132,6 +138,7 @@ function _useWallet(initialWallet = Nothing(), initialMnemonic = Nothing()) {
     setAuthMnemonic(Nothing());
     setNetworkSeed(Nothing());
     setNetworkRevision(Nothing());
+    setUseLegacyTokenSigning(false);
   }, [
     _setWalletType,
     setWalletHdPath,
@@ -167,6 +174,8 @@ function _useWallet(initialWallet = Nothing(), initialMnemonic = Nothing()) {
     //
     authToken,
     setAuthToken,
+    useLegacyTokenSigning,
+    setUseLegacyTokenSigning,
   };
 }
 

--- a/src/views/Login/LoginSelector.scss
+++ b/src/views/Login/LoginSelector.scss
@@ -60,18 +60,6 @@
     }
   }
 
-  .info-modal-content {
-    position: relative;
-    background-color: white;
-    width: 280px;
-    border-radius: $large-border-radius;
-    font-family: $default-font;
-    padding: 24px;
-    font-size: 14px;
-    line-height: 24px;
-    max-width: 100%;
-  }
-
   .master-ticket {
     .body-pane {
       .input-form {

--- a/src/views/Login/Mnemonic.tsx
+++ b/src/views/Login/Mnemonic.tsx
@@ -100,7 +100,7 @@ export default function Mnemonic({ className, goHome }: MnemonicProps) {
     {
       selected: useLegacyTokenSigning,
       key: 'useLegacyTokenSigning',
-      label: 'Use Legacy Compatibility',
+      label: 'Use Legacy Keyfile',
       onClick: () => setUseLegacyTokenSigning(!useLegacyTokenSigning),
     },
   ];

--- a/src/views/Login/Mnemonic.tsx
+++ b/src/views/Login/Mnemonic.tsx
@@ -34,7 +34,13 @@ interface MnemonicProps {
 export default function Mnemonic({ className, goHome }: MnemonicProps) {
   useLoginView(WALLET_TYPES.MNEMONIC);
 
-  const { setWallet, setAuthMnemonic, setWalletHdPath }: any = useWallet();
+  const {
+    setWallet,
+    setAuthMnemonic,
+    setWalletHdPath,
+    setUseLegacyTokenSigning,
+    useLegacyTokenSigning,
+  }: any = useWallet();
 
   const [skipValidation, setSkipValidation] = useState(false);
   const [phraseHdPath, setPhraseHdPath] = useState(false);
@@ -90,6 +96,12 @@ export default function Mnemonic({ className, goHome }: MnemonicProps) {
       key: 'phraseHdPath',
       label: 'Passphrase & HD Path',
       onClick: () => setPhraseHdPath(!phraseHdPath),
+    },
+    {
+      selected: useLegacyTokenSigning,
+      key: 'useLegacyTokenSigning',
+      label: 'Use Legacy Compatibility',
+      onClick: () => setUseLegacyTokenSigning(!useLegacyTokenSigning),
     },
   ];
 

--- a/src/views/Login/Ticket.tsx
+++ b/src/views/Login/Ticket.tsx
@@ -180,7 +180,7 @@ export default function Ticket({ className, goHome }: TicketProps) {
     {
       selected: useLegacyTokenSigning,
       key: 'useLegacyTokenSigning',
-      label: 'Use Legacy Compatibility',
+      label: 'Use Legacy Keyfile',
       onClick: () => setUseLegacyTokenSigning(!useLegacyTokenSigning),
     },
   ];

--- a/src/views/Login/Ticket.tsx
+++ b/src/views/Login/Ticket.tsx
@@ -17,7 +17,6 @@ import { timeout } from 'lib/timeout';
 import useRoller from 'lib/useRoller';
 
 import BridgeForm from 'form/BridgeForm';
-import Condition from 'form/Condition';
 import { TicketInput, PassphraseInput, PointInput } from 'form/Inputs';
 import {
   composeValidator,
@@ -44,7 +43,11 @@ interface TicketProps {
 export default function Ticket({ className, goHome }: TicketProps) {
   useLoginView(WALLET_TYPES.TICKET);
 
-  const { setUrbitWallet }: any = useWallet();
+  const {
+    setUrbitWallet,
+    setUseLegacyTokenSigning,
+    useLegacyTokenSigning,
+  }: any = useWallet();
   const { setPointCursor }: any = usePointCursor();
   const impliedPoint = useImpliedPoint();
   const didWarn = useRef(false);
@@ -173,6 +176,12 @@ export default function Ticket({ className, goHome }: TicketProps) {
       key: 'useShards',
       label: 'Shards',
       onClick: () => setUseShards(!useShards),
+    },
+    {
+      selected: useLegacyTokenSigning,
+      key: 'useLegacyTokenSigning',
+      label: 'Use Legacy Compatibility',
+      onClick: () => setUseLegacyTokenSigning(!useLegacyTokenSigning),
     },
   ];
 

--- a/src/views/UrbitOS/Home.tsx
+++ b/src/views/UrbitOS/Home.tsx
@@ -7,6 +7,7 @@ import Window from 'components/L2/Window/Window';
 import HeaderPane from 'components/L2/Window/HeaderPane';
 import BodyPane from 'components/L2/Window/BodyPane';
 import { ReactComponent as KeyfileIcon } from 'assets/keyfile.svg';
+import { ReactComponent as InfoIcon } from 'assets/info.svg';
 
 import { useLocalRouter } from 'lib/LocalRouter';
 import { useSingleKeyfileGenerator } from 'lib/useKeyfileGenerator';
@@ -16,7 +17,6 @@ import CopiableWithTooltip from 'components/copiable/CopiableWithTooltip';
 import './UrbitOS.scss';
 import Modal from 'components/L2/Modal';
 import { useRollerStore } from 'store/rollerStore';
-import WithTooltip from 'components/WithTooltip';
 
 export default function UrbitOSHome() {
   const { point } = useRollerStore();
@@ -47,6 +47,9 @@ export default function UrbitOSHome() {
     {}
   );
   const keyfileAvailable = available && !generating;
+  const [showKeysUnavailableModal, setShowKeysUnavailableModal] = useState(
+    false
+  );
 
   const headerButton = () => {
     if (!hasSetNetworkKeys) {
@@ -63,11 +66,25 @@ export default function UrbitOSHome() {
         Download Keyfile
       </Button>
     ) : (
-      <WithTooltip content="Either the key was derived non-deterministically, or try Login > Use Legacy Compatibility">
-        <Box className="header-button keyfile-unavailable">
-          Keyfile Unavailable
-        </Box>
-      </WithTooltip>
+      <>
+        <Button
+          className="header-button keyfile-unavailable"
+          onClick={() => setShowKeysUnavailableModal(true)}>
+          <InfoIcon />
+          &nbsp;Keyfile Unavailable
+        </Button>
+        <Modal
+          show={showKeysUnavailableModal}
+          hide={() => setShowKeysUnavailableModal(false)}>
+          <Box className="info-modal-content">
+            <div className="fw-bold mb5">Keyfile Unavailable</div>
+            <div className="mb5">
+              Keys generated between 2021-05 and 2022-02 used a different
+              algorithm. Please login again with 'Use Legacy Keyfile' selected.
+            </div>
+          </Box>
+        </Modal>
+      </>
     );
   };
 

--- a/src/views/UrbitOS/Home.tsx
+++ b/src/views/UrbitOS/Home.tsx
@@ -16,6 +16,7 @@ import CopiableWithTooltip from 'components/copiable/CopiableWithTooltip';
 import './UrbitOS.scss';
 import Modal from 'components/L2/Modal';
 import { useRollerStore } from 'store/rollerStore';
+import WithTooltip from 'components/WithTooltip';
 
 export default function UrbitOSHome() {
   const { point } = useRollerStore();
@@ -42,22 +43,40 @@ export default function UrbitOSHome() {
     names,
   ]);
 
-  const { code, download } = useSingleKeyfileGenerator({});
+  const { available, code, download, generating } = useSingleKeyfileGenerator(
+    {}
+  );
+  const keyfileAvailable = available && !generating;
+
+  const headerButton = () => {
+    if (!hasSetNetworkKeys) {
+      return null;
+    }
+
+    if (generating) {
+      return <Box className="header-button keyfile">Generating...</Box>;
+    }
+
+    return keyfileAvailable ? (
+      <Button className="header-button keyfile" onClick={download}>
+        <KeyfileIcon />
+        Download Keyfile
+      </Button>
+    ) : (
+      <WithTooltip content="Either the key was derived non-deterministically, or try Login > Use Legacy Compatibility">
+        <Box className="header-button keyfile-unavailable">
+          Keyfile Unavailable
+        </Box>
+      </WithTooltip>
+    );
+  };
 
   return (
     <Window className="os-home">
       <HeaderPane>
         <Row className="header-row">
           <h5>OS</h5>
-          {hasSetNetworkKeys && (
-            <Button
-              className="header-button keyfile"
-              disabled={!hasSetNetworkKeys}
-              onClick={download}>
-              <KeyfileIcon />
-              Download Keyfile
-            </Button>
-          )}
+          {headerButton()}
         </Row>
       </HeaderPane>
       <BodyPane>


### PR DESCRIPTION
# Context

See the recent comments in #549 for details, but in short:

[This commit](https://github.com/urbit/bridge/commit/003c08396edb548527e8ffd56218fca90d7f2d8b#diff-ea521a1b242dfb1472db45d56b3f869a255d301f033f3c2d0aeb504c316c24bcL17) introduced a discrepancy between how auth tokens are generated between custodial and non-custodial wallets. Specifically, [per the docs](https://wallet-docs.brave.com/ethereum/use-cases/signing-data/#personal_sign) for `personal_sign`, `keccak256` is used by Ethereum Providers to sign a message.

When I first joined the Bridge project and had little insight into how things worked, I instead used the subtly different `sha256` for the default auth token case (i.e, for master tickets and mnemonics). As such, for roughly the past 6 months, any actions performed in Bridge (generating invites, setting keys, etc) using these login methods were with a logically incorrect auth token.

# Changes

This resolves #549 by:

- using `keccak256` for default auth token derivation 
- adding a "Legacy Compatibility" login flow for custodial wallets; when this is enabled, the auth token is derived using `sha256` instead of `keccak256` to allow users to re-derive deterministic keys

# Preview

## Legacy Toggle
![image](https://user-images.githubusercontent.com/16504501/155578787-fc2d2d6b-7ef2-4bb1-85e2-1d5f154af52a.png)

## When Keyfile is Unavailable
![image](https://user-images.githubusercontent.com/16504501/155577404-f5d72d5c-2f23-4477-9597-d165e7fa6758.png)

## Info Modal
![image](https://user-images.githubusercontent.com/16504501/155579179-8b9ab346-52f3-4e43-9e05-3fbb35764df3.png)

# Testing

Confirmed using the dev mnemonic on Ropsten. 

1. Log in with Recovery Phrase
2. Select ~winnet
3. Navigate to Home > OS, verify that Keyfile is unavailable
4. Logout
5. Log in with Recovery Phrase again, this time with Use Legacy Compatibility enabled
6. Select ~winnet
7. Navigate to Home > OS, verify that Keyfile can be downloaded