### PR TITLE
login: throw when no approved MM accounts

### DIFF
--- a/src/views/Login/LoginSelector.tsx
+++ b/src/views/Login/LoginSelector.tsx
@@ -86,11 +86,15 @@ export default function LoginSelector({
       }
       setMetamask(true);
       setMetamaskSelected(true);
+
       const accounts = await window.ethereum.request({
         method: 'eth_requestAccounts',
       });
-      const wallet = new MetamaskWallet(accounts[0]);
+      if (accounts.length === 0) {
+        throw new Error('No accounts approved');
+      }
 
+      const wallet = new MetamaskWallet(accounts[0]);
       const web3 = new Web3(window.ethereum);
       const authToken = await getAuthToken({
         address: wallet.address,


### PR DESCRIPTION
This micro-PR handles the case when a use does not approve any Metamask / Brave wallet accounts to be connected to Bridge.