### PR TITLE
invite-converter: always show button, add empty state

### DIFF
--- a/src/components/L2/InviteConverter.tsx
+++ b/src/components/L2/InviteConverter.tsx
@@ -177,10 +177,6 @@ export const InviteConverter = ({ points }: InviteConverterProps) => {
       return (sum += star.children.length);
     }, 0) > 0;
 
-  if (!hasPlanets) {
-    return null;
-  }
-
   if (generatingStatus !== 'initial') {
     return (
       <CreatingInvitesModal
@@ -235,7 +231,9 @@ export const InviteConverter = ({ points }: InviteConverterProps) => {
               mt={3}
               p={3}
               borderRadius={2}
-              overflowY="auto">
+              overflowY="auto"
+              alignItems={hasPlanets ? '' : 'center'}
+              justifyContent={hasPlanets ? '' : 'center'}>
               {Object.entries(starMap).map(([patp, { children }]) => (
                 <Col mb={4}>
                   <Row>
@@ -268,7 +266,7 @@ export const InviteConverter = ({ points }: InviteConverterProps) => {
                   ))}
                 </Col>
               ))}
-              {}
+              {!hasPlanets && <Text>No planets to update</Text>}
             </Col>
             <Row mt={3} justifyContent="end">
               <IndigoButton


### PR DESCRIPTION
Based on some confusion about the invite button showing or not, I think it's clearer to always have it and just show an empty state if no planets are available to update.