### PR TITLE
keys: use sha256 token if unable to re-derive with keccak256 token

### DIFF
--- a/src/lib/authToken.ts
+++ b/src/lib/authToken.ts
@@ -109,6 +109,23 @@ const getDefaultAuthToken = ({ wallet }: DefaultAuthTokenArgs) => {
   return token;
 };
 
+/**
+ * Heads up, this is probably not the authToken derivation function you're
+ * looking for.
+ *
+ * Due to a logical error with auth token derivation, keys set between May
+ * 2021 and March 2022 used `sha256` instead of the logically correct
+ * `keccak256`. To mitigate this for users who log back into Bridge to
+ * download their keyfile or copy their access code, the keyfile generator
+ * will first try re-deriving with `keccak256`, then will fallback to `sha256`
+ * via this function.
+ *
+ * See this issue for additional context:
+ * https://github.com/urbit/bridge/issues/549
+ *
+ * @param wallet BIP32 wallet
+ * @returns string
+ */
 export const getSha256AuthToken = ({ wallet }: DefaultAuthTokenArgs) => {
   const signature = signMessage(wallet.privateKey!, crypto.sha256);
 

--- a/src/lib/authToken.ts
+++ b/src/lib/authToken.ts
@@ -9,13 +9,13 @@ import { ledgerSignMessage } from './ledger';
 import { trezorSignMessage } from './trezor';
 import BridgeWallet from './types/BridgeWallet';
 import { Hash } from '@urbit/roller-api';
+import { keccak256 } from 'ethereumjs-util';
 
 const MESSAGE = 'Bridge Authentication Token';
 
-function signMessage(privateKey: Buffer) {
+function signMessage(privateKey: Buffer, hashFunction = keccak256) {
   const msg = '\x19Ethereum Signed Message:\n' + MESSAGE.length + MESSAGE;
-  // #ecdsaSign requires a 32-byte buffer, hence sha256
-  const hashed = crypto.sha256(Buffer.from(msg));
+  const hashed = hashFunction(Buffer.from(msg));
   const { signature } = ecdsaSign(Buffer.from(hashed), privateKey);
 
   // add key recovery parameter
@@ -103,6 +103,14 @@ const getWalletConnectAuthToken = ({
 
 const getDefaultAuthToken = ({ wallet }: DefaultAuthTokenArgs) => {
   const signature = signMessage(wallet.privateKey!);
+
+  const token = `0x${Buffer.from(signature).toString('hex')}`;
+
+  return token;
+};
+
+export const getSha256AuthToken = ({ wallet }: DefaultAuthTokenArgs) => {
+  const signature = signMessage(wallet.privateKey!, crypto.sha256);
 
   const token = `0x${Buffer.from(signature).toString('hex')}`;
 

--- a/src/lib/useKeyfileGenerator.ts
+++ b/src/lib/useKeyfileGenerator.ts
@@ -16,7 +16,7 @@ import { stripSigPrefix } from 'form/formatters';
 import useRoller from './useRoller';
 import Point from './types/Point';
 import { toL1Details } from './utils/point';
-import { ETH_ZERO_ADDR } from './constants';
+import { ETH_ZERO_ADDR, NONCUSTODIAL_WALLETS } from './constants';
 import { getSha256AuthToken } from './authToken';
 
 interface useKeyfileGeneratorArgs {
@@ -225,7 +225,13 @@ export const useSingleKeyfileGenerator = ({
 }: SingleKeyfileGeneratorArgs) => {
   const { point } = useRollerStore();
 
-  const { authMnemonic, authToken, urbitWallet, wallet }: any = useWallet();
+  const {
+    authMnemonic,
+    authToken,
+    urbitWallet,
+    wallet,
+    walletType,
+  }: any = useWallet();
   const [defaultSeeds, setDefaultSeeds] = useState<string[]>([]);
   const [fallbackSeeds, setFallbackSeeds] = useState<string[]>([]);
 
@@ -264,6 +270,11 @@ export const useSingleKeyfileGenerator = ({
      * https://github.com/urbit/bridge/issues/549
      */
 
+    if (NONCUSTODIAL_WALLETS.has(walletType)) {
+      console.log('cannot derive fallback token for non-custodial wallets');
+      return;
+    }
+
     const fallbackAuthToken = getSha256AuthToken({ wallet: wallet.value });
     const fallbackDerivedSeed = deriveNetworkSeedFromAuthToken(
       point.value,
@@ -274,7 +285,7 @@ export const useSingleKeyfileGenerator = ({
     if (Just.hasInstance(fallbackDerivedSeed)) {
       setFallbackSeeds([fallbackDerivedSeed.value]);
     }
-  }, [authMnemonic, authToken, point, seed, urbitWallet, wallet]);
+  }, [authMnemonic, authToken, point, seed, urbitWallet, wallet, walletType]);
 
   useEffect(() => {
     deriveSeeds();


### PR DESCRIPTION
# Context

When re-deriving a keyfile and access code within the Bridge dashboard, derive using both the default auth token (derived with keccak256) and an optional fallback token (derived with sha256, if necessary).

This resolves #549.

# Testing

1. `git checkout t/549-auth-token-fallback`
2. `npm run pilot-ropsten`
3. log in with mnemonic from DEVELOPMENT.md
4. select ~winnet, navigate to Home > OS, and download Keyfile