### PR TITLE
ux: show countdown to next roll

### DIFF
--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -41,6 +41,7 @@ import { useWalletConnect } from './useWalletConnect';
 import { PendingL1Txn } from './types/PendingL1Transaction';
 import { TRANSACTION_PROGRESS } from './reticket';
 import { useRollerOptions } from './useRollerOptions';
+import { useTimerStore } from 'store/timerStore';
 
 interface UpdateParams {
   point: number;
@@ -69,7 +70,6 @@ export default function useRoller() {
     point,
     points,
     nextQuotaTime,
-    setNextBatchTime,
     setNextQuotaTime,
     setPendingTransactions,
     setModalText,
@@ -78,6 +78,7 @@ export default function useRoller() {
     storePendingL1Txn,
     deletePendingL1Txn,
   } = useRollerStore();
+  const { setNextBatchTime } = useTimerStore();
   const [config, setConfig] = useState<Config | null>(null);
 
   const { options } = useRollerOptions();

--- a/src/store/rollerStore.ts
+++ b/src/store/rollerStore.ts
@@ -22,7 +22,6 @@ export const EMPTY_POINT = new Point({
 
 export interface RollerStore {
   loading: boolean;
-  nextBatchTime: number;
   nextQuotaTime: number;
   pendingTransactions: PendingTransaction[];
   point: Point;
@@ -34,7 +33,6 @@ export interface RollerStore {
   ethBalance: BN;
   setLoading: (loading: boolean) => void;
   setModalText: (modalText: string) => void;
-  setNextBatchTime: (nextBatchTime: number) => void;
   setNextQuotaTime: (nextQuotaTime: number) => void;
   setPendingTransactions: (pendingTransactions: PendingTransaction[]) => void;
   setPoint: (point: number) => void;
@@ -47,7 +45,6 @@ export interface RollerStore {
 
 export const useRollerStore = create<RollerStore>(set => ({
   loading: false,
-  nextBatchTime: new Date().getTime() + HOUR,
   nextQuotaTime: new Date().getTime() + 24 * HOUR,
   pendingTransactions: [],
   point: EMPTY_POINT,
@@ -57,7 +54,6 @@ export const useRollerStore = create<RollerStore>(set => ({
   recentlyCompleted: 0,
   ethBalance: toBN(0),
   setLoading: (loading: boolean) => set(() => ({ loading })),
-  setNextBatchTime: (nextBatchTime: number) => set(() => ({ nextBatchTime })),
   setNextQuotaTime: (nextQuotaTime: number) => set(() => ({ nextQuotaTime })),
   setPendingTransactions: (pendingTransactions: PendingTransaction[]) =>
     set(state => {


### PR DESCRIPTION
On load, Bridge queries the roller for the Roller Config. One of the properties in the response is time to next batch. This value drives the countdown timer in the UI.

Before this change, it was being set in the legacy state context. This change removes the deprecated state context from rollerStore in favor of timerStore.

# Preview

![image](https://user-images.githubusercontent.com/16504501/159198178-521aaa04-e930-4916-b0b7-e9789ed104db.png)


Resolves #1004