### PR TITLE
invites: use absolute URL for invite links

### DIFF
--- a/src/lib/utils/invite.ts
+++ b/src/lib/utils/invite.ts
@@ -2,7 +2,7 @@ import * as ob from 'urbit-ob';
 
 export const generateUrl = (ticket: string, planet: number) => {
   if (ticket && planet) {
-    return `${window.location.host}/#${ticket.slice(1)}-${ob
+    return `${window.location.origin}/#${ticket.slice(1)}-${ob
       .patp(planet)
       .slice(1)}`;
   } else if (planet) {
@@ -14,7 +14,7 @@ export const generateUrl = (ticket: string, planet: number) => {
 
 export const generateUrlAbbreviation = (ticket: string, planet: number) => {
   if (ticket && planet) {
-    return `${window.location.host}/#${ticket.slice(1, 7)}...${ob
+    return `${window.location.origin}/#${ticket.slice(1, 7)}...${ob
       .patp(planet)
       .slice(1)}`;
   } else if (planet) {


### PR DESCRIPTION
Previously, `location.host` was used to generate the invite URL. This resulted in a relative path that was missing the URL protocol (e.g., https). This change renders the full URL with protocol for improved pasteability.

This closes #1003.

# Preview

## Invites View

![image](https://user-images.githubusercontent.com/16504501/160006614-4f040f71-ee08-4c72-92e0-550aea8d7c37.png)

## CSV Export

![image](https://user-images.githubusercontent.com/16504501/160006740-7a585b00-b7d4-44b5-82db-e70ba455594c.png)

# Testing

This was tested on Ropsten, using ~net / ~wacnet.