### PR TITLE
invite: clear stored invite from cache on reticket

### DIFF
--- a/src/store/storage/roller.ts
+++ b/src/store/storage/roller.ts
@@ -34,6 +34,20 @@ export const setStoredInvite = (ls: SecureLS, newInvite: Invite) => {
   ls.set(INVITES_KEY, invites);
 };
 
+export const removeStoredInvite = (ls: SecureLS, key: number) => {
+  let invites: InviteTickets = {};
+  try {
+    invites = ls.get(INVITES_KEY) || {};
+  } catch (e) {}
+
+  if (key in invites) {
+    let { [key]: _, ...filtered } = invites;
+    invites = filtered;
+  }
+
+  ls.set(INVITES_KEY, invites);
+};
+
 export const clearInvitesStorage = () => localStorage.removeItem(INVITES_KEY);
 
 export const getHideMigrationMessage = () =>


### PR DESCRIPTION
# Context

Previously, when a reticket is performed with a stale invite in the cache, the old ticket value will be used instead of the newly generated value when creating the invite wallet.

This change:
- only stores the generated invite if it's unclaimed
- removes it from the cache upon reticketing or determining if it's been claimed
# Testing

Two potential flows that lead to reticket

## L2 Invite --> Restored to Owner --> Reticketed

- [x] Tested on Ropsten with ~bornet / ~bisbel-batryd

1. using a monkeypatched local Bridge, select an L2 star and generate an invite. confirm visibility in invites view, which also caches it in localstorage
2. restore the invite to original owner
3. using the bugfix branch local Bridge, select Update Invites ... select the planet to reticket
4. confirm visibility in invites view

## Spawned --> Reticketed

- [x] Tested on Ropsten with ~bornet / ~randuc-minnum

1. select an L2 star, spawn a new planet under Star Ops
2. from the family view, select Update Invites and select the newly spawned planet
3. confirm visibility in the Invites View
