### PR TITLE
login: adds L1 activation banner for BTC conference

### DIFF
--- a/src/views/Login/LoginSelector.scss
+++ b/src/views/Login/LoginSelector.scss
@@ -93,4 +93,16 @@
       background-color: $washed-gray;
     }
   }
+
+  .l1-activation {
+    border: $light-gray-border;
+    padding: 12px 8px;
+    border-radius: $medium-border-radius;
+    font-size: 14px;
+    line-height: 18px;
+    margin-top: 16px;
+    font-family: $default-font;
+    text-align: center;
+  }
+
 }

--- a/src/views/Login/LoginSelector.tsx
+++ b/src/views/Login/LoginSelector.tsx
@@ -192,6 +192,13 @@ export default function LoginSelector({
         <Grid.Item full className="activate" as={Button} onClick={goToActivate}>
           Activate a Planet
         </Grid.Item>
+        <Grid.Item full className="l1-activation" as={Text}>
+          BitBlockBoom attendee?{' '}
+          <a className="underline" href="https://bridge-sunset.urbit.org">
+            Activate
+          </a>{' '}
+          your L1 planet from invite card{' '}
+        </Grid.Item>
         <Grid.Item
           full
           className="unsupported-info"


### PR DESCRIPTION
Adds a small banner for BitBlockBoom attendees to redeem a L1 planet via `bridge-sunset`.

@bioy-casares will be distributing 500 L1 invite cards, so this fixes urbit/bridge#1024 in the least-intensive way we can at the moment.