### PR TITLE
ux: option to skip token signing on login

### DIFF
--- a/src/lib/useWalletConnect.ts
+++ b/src/lib/useWalletConnect.ts
@@ -30,7 +30,13 @@ type ConnectEvent = {
 };
 
 export const useWalletConnect = () => {
-  const { setWallet, setAuthToken, resetWallet }: any = useWallet();
+  const {
+    setWallet,
+    setAuthToken,
+    setFakeToken,
+    skipLoginSigning,
+    resetWallet,
+  }: any = useWallet();
   const [connector, setConnector] = useState<WalletConnect | null>(null);
   const [address, setAddress] = useState<string | null>(null);
   const [peerMeta, setPeerMeta] = useState<PeerMeta | null>(null);
@@ -81,6 +87,15 @@ export const useWalletConnect = () => {
       return;
     }
 
+    const wallet: WalletConnectWallet = {
+      address,
+    };
+    setWallet(Just(wallet));
+    if (skipLoginSigning) {
+      setFakeToken();
+      return;
+    }
+
     let authToken = Nothing();
     try {
       const token = await getAuthToken({
@@ -89,6 +104,7 @@ export const useWalletConnect = () => {
         walletType: WALLET_TYPES.WALLET_CONNECT,
       });
       authToken = Just(token);
+      setAuthToken(authToken);
     } catch (e) {
       if (e.message === 'METHOD_NOT_SUPPORTED') {
         console.warn(
@@ -99,13 +115,6 @@ export const useWalletConnect = () => {
         //TODO  should errors with this *really* prevent login?
       }
     }
-
-    const wallet: WalletConnectWallet = {
-      address,
-    };
-
-    setAuthToken(authToken);
-    setWallet(Just(wallet));
   };
 
   const isConnected = () => {

--- a/src/store/wallet.js
+++ b/src/store/wallet.js
@@ -52,6 +52,8 @@ function _useWallet(initialWallet = Nothing(), initialMnemonic = Nothing()) {
   const [networkRevision, setNetworkRevision] = useState(Nothing());
 
   const [authToken, setAuthToken] = useState(Nothing());
+  // Allow users to skip signing the auth token on login
+  const [skipLoginSigning, setSkipLoginSigning] = useState(false);
 
   // See: https://github.com/urbit/bridge/issues/549#issuecomment-1048359617
   // This is used for legacy compatibility; this flow should eventually be
@@ -176,6 +178,8 @@ function _useWallet(initialWallet = Nothing(), initialMnemonic = Nothing()) {
     setAuthToken,
     useLegacyTokenSigning,
     setUseLegacyTokenSigning,
+    skipLoginSigning,
+    setSkipLoginSigning
   };
 }
 

--- a/src/store/wallet.js
+++ b/src/store/wallet.js
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import { Just, Nothing } from 'folktale/maybe';
 import { includes } from 'lodash';
+import { randomHex } from 'web3-utils';
 
 import { walletFromMnemonic } from 'lib/wallet';
 import {
@@ -55,6 +56,10 @@ function _useWallet(initialWallet = Nothing(), initialMnemonic = Nothing()) {
   // Allow users to skip signing the auth token on login
   const [skipLoginSigning, setSkipLoginSigning] = useState(false);
 
+  const setFakeToken = () => {
+    setAuthToken(Just(randomHex(32)));
+  };
+
   // See: https://github.com/urbit/bridge/issues/549#issuecomment-1048359617
   // This is used for legacy compatibility; this flow should eventually be
   // be removed after ~1 year.
@@ -74,6 +79,11 @@ function _useWallet(initialWallet = Nothing(), initialMnemonic = Nothing()) {
 
       const _wallet = wallet.value;
       const _web3 = web3.value;
+      if (skipLoginSigning) {
+        setFakeToken();
+        return;
+      }
+
       const token = await getAuthToken({
         wallet: _wallet,
         walletType,
@@ -84,7 +94,15 @@ function _useWallet(initialWallet = Nothing(), initialMnemonic = Nothing()) {
 
       setAuthToken(Just(token));
     })();
-  }, [wallet, walletType, walletHdPath, web3, useLegacyTokenSigning]);
+  }, [
+    wallet,
+    walletType,
+    walletHdPath,
+    web3,
+    useLegacyTokenSigning,
+    setAuthToken,
+    skipLoginSigning,
+  ]);
 
   const setWalletType = useCallback(
     walletType => {
@@ -179,7 +197,8 @@ function _useWallet(initialWallet = Nothing(), initialMnemonic = Nothing()) {
     useLegacyTokenSigning,
     setUseLegacyTokenSigning,
     skipLoginSigning,
-    setSkipLoginSigning
+    setSkipLoginSigning,
+    setFakeToken,
   };
 }
 

--- a/src/views/Login/Ledger.tsx
+++ b/src/views/Login/Ledger.tsx
@@ -52,7 +52,13 @@ interface LedgerProps {
 export default function Ledger({ className, goHome }: LedgerProps) {
   useLoginView(WALLET_TYPES.LEDGER);
 
-  const { setWallet, setWalletHdPath, setAuthToken }: any = useWallet();
+  const {
+    setWallet,
+    setWalletHdPath,
+    setAuthToken,
+    setFakeToken,
+    skipLoginSigning,
+  }: any = useWallet();
 
   const validate = useMemo(
     () =>
@@ -77,20 +83,24 @@ export default function Ledger({ className, goHome }: LedgerProps) {
         const chainCode = Buffer.from(info.chainCode!.toString(), 'hex');
         const pub = Buffer.from(publicKeyConvert(publicKey, true));
         const hd = bip32.fromPublicKey(pub, chainCode);
+        setWallet(Just(hd));
+        setWalletHdPath(addHdPrefix(values.hdpath));
+        if (skipLoginSigning) {
+          setFakeToken();
+          return;
+        }
+
         const authToken = await getAuthToken({
           walletType: WALLET_TYPES.LEDGER,
           walletHdPath: addHdPrefix(values.hdpath),
         });
-
         setAuthToken(Just(authToken));
-        setWallet(Just(hd));
-        setWalletHdPath(addHdPrefix(values.hdpath));
       } catch (error) {
         console.error(error);
         return { [FORM_ERROR]: error.message };
       }
     },
-    [setAuthToken, setWallet, setWalletHdPath]
+    [setAuthToken, setFakeToken, setWallet, setWalletHdPath, skipLoginSigning]
   );
 
   const onValues = useCallback(({ valid, values, form }) => {

--- a/src/views/Login/LoginSelector.scss
+++ b/src/views/Login/LoginSelector.scss
@@ -93,4 +93,28 @@
       background-color: $washed-gray;
     }
   }
+
+  .advanced-options {
+    margin-top: 16px;
+    cursor: pointer;
+    text-align: center;
+  }
+
+  .skip-signing {
+    margin-top: 16px;
+    display: flex;
+    flex-flow: row nowrap;
+    cursor: pointer;
+    width: 100%;
+    justify-content: center;
+    align-items: center;
+    font-family: $default-font;
+
+    span {
+      margin-left: 10px;
+      width: 160px;
+      font-size: 14px;
+      line-height: 18px;
+    }
+  }
 }

--- a/src/views/Login/LoginSelector.tsx
+++ b/src/views/Login/LoginSelector.tsx
@@ -62,6 +62,7 @@ export default function LoginSelector({
     setWallet,
     setWalletType,
     setAuthToken,
+    setFakeToken,
     skipLoginSigning,
     setSkipLoginSigning,
   }: any = useWallet();
@@ -105,6 +106,15 @@ export default function LoginSelector({
 
       const wallet = new MetamaskWallet(accounts[0]);
       const web3 = new Web3(window.ethereum);
+      setWallet(Just(wallet));
+      setWalletType(WALLET_TYPES.METAMASK);
+
+      if (skipLoginSigning) {
+        setFakeToken();
+        goHome();
+        return;
+      }
+
       const authToken = await getAuthToken({
         address: wallet.address,
         walletType: WALLET_TYPES.METAMASK,
@@ -112,8 +122,6 @@ export default function LoginSelector({
       });
 
       setAuthToken(Just(authToken));
-      setWallet(Just(wallet));
-      setWalletType(WALLET_TYPES.METAMASK);
 
       goHome();
     } catch (e) {
@@ -121,7 +129,15 @@ export default function LoginSelector({
       setMetamask(false);
       setMetamaskSelected(false);
     }
-  }, [setAuthToken, setWallet, setWalletType, setMetamask, goHome]);
+  }, [
+    setMetamask,
+    setWallet,
+    setWalletType,
+    skipLoginSigning,
+    setAuthToken,
+    goHome,
+    setFakeToken,
+  ]);
 
   const onSubmitWalletConnect = useCallback(async () => {
     try {

--- a/src/views/Login/LoginSelector.tsx
+++ b/src/views/Login/LoginSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import cn from 'classnames';
-import { Grid } from 'indigo-react';
+import { Flex, Grid } from 'indigo-react';
 import {
   Box,
   Button,
@@ -9,6 +9,7 @@ import {
   Row,
   Text,
   Image,
+  Checkbox,
 } from '@tlon/indigo-react';
 import Web3 from 'web3';
 import { Just } from 'folktale/maybe';
@@ -57,11 +58,19 @@ export default function LoginSelector({
   useLoginView(WALLET_TYPES.WALLET_CONNECT);
 
   const { push, names }: any = useHistory();
-  const { setWallet, setWalletType, setAuthToken }: any = useWallet();
+  const {
+    setWallet,
+    setWalletType,
+    setAuthToken,
+    skipLoginSigning,
+    setSkipLoginSigning,
+  }: any = useWallet();
   const { setMetamask }: any = useNetwork();
   const [showModal, setShowModal] = useState(false);
   // TODO: do we still need this? currently not being set
   const [metamaskSelected, setMetamaskSelected] = useState(false);
+
+  const [showAdvanced, setShowAdvanced] = useState(false);
 
   const {
     address,
@@ -199,6 +208,33 @@ export default function LoginSelector({
           onClick={() => setShowModal(true)}>
           <Icon icon="Info" />I have a wallet type not supported here
         </Grid.Item>
+        <Grid.Item
+          className="advanced-options"
+          full
+          as={Text}
+          onClick={() => setShowAdvanced(!showAdvanced)}>
+          Advanced{' '}
+          <Icon
+            display="inline-block"
+            icon={showAdvanced ? 'ChevronNorth' : 'ChevronSouth'}
+            size="14px"
+            color={'black'}
+          />
+        </Grid.Item>
+        {showAdvanced ? (
+          <Grid.Item
+            full
+            as={Box}
+            onClick={() => setSkipLoginSigning(!skipLoginSigning)}>
+            <Box className="skip-signing">
+              <Checkbox
+                selected={skipLoginSigning}
+                onClick={() => setSkipLoginSigning(!skipLoginSigning)}
+              />
+              <Text>Skip Signing on Login</Text>
+            </Box>
+          </Grid.Item>
+        ) : null}
         <Modal show={showModal} hide={() => setShowModal(false)}>
           <Box className="info-modal-content">
             <div className="fw-bold mb5">Other Wallet Types</div>

--- a/src/views/Login/Metamask.js
+++ b/src/views/Login/Metamask.js
@@ -22,7 +22,13 @@ import Web3 from 'web3';
 
 export default function Metamask({ className, goHome }) {
   useLoginView(WALLET_TYPES.METAMASK);
-  const { setWallet, setWalletType, setAuthToken } = useWallet();
+  const {
+    setWallet,
+    setWalletType,
+    setAuthToken,
+    setFakeToken,
+    skipLoginSigning,
+  } = useWallet();
 
   const { setMetamask } = useNetwork();
 
@@ -37,8 +43,15 @@ export default function Metamask({ className, goHome }) {
         method: 'eth_requestAccounts',
       });
       const wallet = new MetamaskWallet(accounts.result[0]);
-
       const web3 = new Web3(window.ethereum);
+      setWallet(Just(wallet));
+      setWalletType(WALLET_TYPES.METAMASK);
+
+      if (skipLoginSigning) {
+        setFakeToken();
+        return;
+      }
+
       const authToken = await getAuthToken({
         address: wallet.address,
         walletType: WALLET_TYPES.METAMASK,
@@ -46,13 +59,18 @@ export default function Metamask({ className, goHome }) {
       });
 
       setAuthToken(Just(authToken));
-      setWallet(Just(wallet));
-      setWalletType(WALLET_TYPES.METAMASK);
     } catch (e) {
       console.error(e);
       return { [FORM_ERROR]: e.message };
     }
-  }, [setAuthToken, setWallet, setWalletType, setMetamask]);
+  }, [
+    setMetamask,
+    setWallet,
+    setWalletType,
+    skipLoginSigning,
+    setAuthToken,
+    setFakeToken,
+  ]);
 
   return (
     <Grid className={className}>

--- a/src/views/Login/Trezor.tsx
+++ b/src/views/Login/Trezor.tsx
@@ -41,7 +41,13 @@ interface TrezorProps {
 export default function Trezor({ className, goHome }: TrezorProps) {
   useLoginView(WALLET_TYPES.TREZOR);
 
-  const { setWallet, setWalletHdPath, setAuthToken }: any = useWallet();
+  const {
+    setWallet,
+    setWalletHdPath,
+    setAuthToken,
+    setFakeToken,
+    skipLoginSigning,
+  }: any = useWallet();
 
   const validate = useMemo(
     () =>
@@ -81,6 +87,13 @@ export default function Trezor({ className, goHome }: TrezorProps) {
 
       const pub = Buffer.from(publicKeyConvert(publicKey, true));
       const hd = bip32.fromPublicKey(pub, chainCode);
+      setWallet(Just(hd));
+      setWalletHdPath(values.hdPath);
+
+      if (skipLoginSigning) {
+        setFakeToken();
+        return;
+      }
 
       const authToken = await getAuthToken({
         walletType: WALLET_TYPES.TREZOR,
@@ -88,10 +101,8 @@ export default function Trezor({ className, goHome }: TrezorProps) {
       });
 
       setAuthToken(Just(authToken));
-      setWallet(Just(hd));
-      setWalletHdPath(values.hdPath);
     },
-    [setAuthToken, setWallet, setWalletHdPath]
+    [setAuthToken, setFakeToken, setWallet, setWalletHdPath, skipLoginSigning]
   );
 
   const onValues = useCallback(({ valid, values, form }) => {


### PR DESCRIPTION
# Context

This change introduces the option to skip eagerly generating an auth token on login using the following checkbox on the Login view:

![image](https://user-images.githubusercontent.com/16504501/194616250-2a3e345e-8ba3-4cc1-91d3-4d952114077c.png)

Instead, a fake token is generated using random entropy. For reference, the auth token is used to derive and configure network keys, and to spawn / generate planet invites. 

Here is an excerpt from the conversation that inspired this change:

> ~wicdev-wisryt
> is there any way at all we can override the need for a signature on login from bridge?
> it's not terrible if you're working in metamask but it's terrible for anyone using a multisig or custodied address
> it means to log into bridge you use walletconnect, then go get all the other signers on the account to approve the signature, then you can do what you needed to do
> which is practically unworkable
> [...]
> at the very least we should just have a button that shows up at the same time as the signature request that fills in the signature with randomness
> a "skip signature" button

# Future Work

- Lazily generate the token on demand for the affected flows (network keys and spawning planets)