### PR TITLE
accept-transfer: fix infinite render leading to roller request spam

### DIFF
--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -210,22 +210,25 @@ export default function useRoller() {
       field,
       l1Txn,
       intervalTime = TEN_SECONDS,
+      pointValue,
     }: UpdateParams) => {
+
+      point = point === undefined ? await initPoint(pointValue) : point;
+
       if (l1Txn) storePendingL1Txn(l1Txn);
 
       let interval: any;
       const check = async () => {
-        const updatedPoint = await initPoint(point);
         const changedField = !points[point]
           ? 'newPoint'
-          : updatedPoint.getChangedField(points[point], field);
+          : point.getChangedField(points[point], field);
 
         if (isDevelopment) {
-          console.log(`CHECKING FOR ${changedField} UPDATES:`, updatedPoint);
+          console.log(`CHECKING FOR ${changedField} UPDATES:`, point.patp);
         }
 
-        if (!updatedPoint.isPlaceholder && changedField) {
-          updatePoint(updatedPoint);
+        if (!point.isPlaceholder && changedField) {
+          updatePoint(point);
           if (interval) {
             clearInterval(interval);
           }
@@ -233,7 +236,7 @@ export default function useRoller() {
           if (l1Txn) deletePendingL1Txn(l1Txn);
           if (notify) {
             showNotification(
-              `${message || getUpdatedPointMessage(updatedPoint, changedField)}`
+              `${message || getUpdatedPointMessage(point, changedField)}`
             );
           }
         }

--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -44,7 +44,7 @@ import { useRollerOptions } from './useRollerOptions';
 import { useTimerStore } from 'store/timerStore';
 
 interface UpdateParams {
-  point: number;
+  point?: Point | number;
   message?: string;
   notify?: boolean;
   field?: PointField;
@@ -140,7 +140,7 @@ export default function useRoller() {
   }, [nextQuotaTime, point, setModalText]);
 
   const initPoint = useCallback(
-    async (point: string | number) => {
+    async (point: string | number): Promise<Point> => {
       const _wallet = wallet.getOrElse(null);
       const _contracts = contracts.getOrElse(null);
 
@@ -210,25 +210,25 @@ export default function useRoller() {
       field,
       l1Txn,
       intervalTime = TEN_SECONDS,
-      pointValue,
     }: UpdateParams) => {
 
-      point = point === undefined ? await initPoint(pointValue) : point;
+
+      const p = (typeof point === 'number' ? await initPoint(point) : point) as Point
 
       if (l1Txn) storePendingL1Txn(l1Txn);
 
       let interval: any;
       const check = async () => {
-        const changedField = !points[point]
+        const changedField = !points[p.value]
           ? 'newPoint'
-          : point.getChangedField(points[point], field);
+          : p.getChangedField(points[p.value], field);
 
         if (isDevelopment) {
-          console.log(`CHECKING FOR ${changedField} UPDATES:`, point.patp);
+          console.log(`CHECKING FOR ${changedField} UPDATES:`, p.patp);
         }
 
-        if (!point.isPlaceholder && changedField) {
-          updatePoint(point);
+        if (!p.isPlaceholder && changedField) {
+          updatePoint(p);
           if (interval) {
             clearInterval(interval);
           }
@@ -236,7 +236,7 @@ export default function useRoller() {
           if (l1Txn) deletePendingL1Txn(l1Txn);
           if (notify) {
             showNotification(
-              `${message || getUpdatedPointMessage(point, changedField)}`
+              `${message || getUpdatedPointMessage(p, changedField)}`
             );
           }
         }

--- a/src/store/pointCache.js
+++ b/src/store/pointCache.js
@@ -1,5 +1,6 @@
 import React, { createContext, forwardRef, useContext } from 'react';
 
+import useDeepEqualReference from 'lib/useDeepEqualReference';
 import usePointStore from './lib/usePointStore';
 
 export const PointCacheContext = createContext(null);
@@ -8,7 +9,7 @@ export function PointCacheProvider({ children }) {
   const cache = usePointStore();
 
   return (
-    <PointCacheContext.Provider value={cache}>
+    <PointCacheContext.Provider value={useDeepEqualReference(cache)}>
       {children}
     </PointCacheContext.Provider>
   );

--- a/src/views/AcceptTransfer.tsx
+++ b/src/views/AcceptTransfer.tsx
@@ -53,7 +53,7 @@ function useAcceptTransfer() {
     ),
     useCallback(
       () => Promise.all([syncExtras(_point), syncControlledPoints()]),
-      [_point, syncControlledPoints, syncExtras]
+      [_point]
     ),
     GAS_LIMITS.TRANSFER
   );
@@ -89,7 +89,7 @@ export default function AcceptTransfer() {
     // Update this one
     if (completed) {
       checkForUpdates({
-        point: point.value,
+        point: point,
         message: `${point.patp} has been transferred to you!`,
         l1Txn: {
           id: `accept-transfer-${point.value}`,
@@ -129,7 +129,7 @@ export default function AcceptTransfer() {
     transferring.current = true;
     await transferPoint(_address, reset);
     await checkForUpdates({
-      point: point.value,
+      point: point,
       message: `${point.patp} has been transferred to you!`,
     });
 

--- a/src/views/CancelTransfer.tsx
+++ b/src/views/CancelTransfer.tsx
@@ -68,7 +68,7 @@ function AdminCancelTransfer() {
   useEffect(() => {
     if (completed) {
       checkForUpdates({
-        point: point.value,
+        point: point,
         message: `${point.patp} transfer cancelled`,
         l1Txn: {
           id: `cancel-${point.value}`,
@@ -89,7 +89,7 @@ function AdminCancelTransfer() {
   const cancelTransfer = useCallback(async () => {
     await setProxyAddress('transfer', ETH_ZERO_ADDR);
     await checkForUpdates({
-      point: point.value,
+      point: point,
       message: `${point.patp} transfer cancelled`,
     });
     goBack();

--- a/src/views/Point/IssueChild.tsx
+++ b/src/views/Point/IssueChild.tsx
@@ -119,7 +119,7 @@ export default function IssueChild() {
     if (pointToSpawn && destinationAddress) {
       setLoading(true);
       await spawnPoint(pointToSpawn, destinationAddress);
-      checkForUpdates({ point: pointToSpawn });
+      checkForUpdates({ pointValue: pointToSpawn });
       setPointToSpawn(null);
       setDestinationAddress(null);
       setL2SpawnSent(true);
@@ -140,7 +140,7 @@ export default function IssueChild() {
   useEffect(() => {
     if (completed && pointToSpawn) {
       checkForUpdates({
-        point: pointToSpawn,
+        pointValue: pointToSpawn,
         l1Txn: {
           id: `${pointToSpawn}`,
           point: point.value,

--- a/src/views/Point/IssueChild.tsx
+++ b/src/views/Point/IssueChild.tsx
@@ -119,7 +119,7 @@ export default function IssueChild() {
     if (pointToSpawn && destinationAddress) {
       setLoading(true);
       await spawnPoint(pointToSpawn, destinationAddress);
-      checkForUpdates({ pointValue: pointToSpawn });
+      checkForUpdates({ point: pointToSpawn });
       setPointToSpawn(null);
       setDestinationAddress(null);
       setL2SpawnSent(true);
@@ -140,7 +140,7 @@ export default function IssueChild() {
   useEffect(() => {
     if (completed && pointToSpawn) {
       checkForUpdates({
-        pointValue: pointToSpawn,
+        point: pointToSpawn,
         l1Txn: {
           id: `${pointToSpawn}`,
           point: point.value,

--- a/src/views/Point/MigrateL2.tsx
+++ b/src/views/Point/MigrateL2.tsx
@@ -135,7 +135,7 @@ export default function MigrateL2() {
         : `${selectedPoint.patp}'s spawn proxy has been set to Layer 2!`;
 
       checkForUpdates({
-        point: selectedPoint.value,
+        point: selectedPoint,
         message,
         notify: true,
         field: PointField.layer,

--- a/src/views/UrbitID/SetProxy.js
+++ b/src/views/UrbitID/SetProxy.js
@@ -165,7 +165,7 @@ export default function SetProxy() {
       await setProxyAddress(getL2ProxyName(data.proxyType), newAddress);
 
       checkForUpdates({
-        point: point.value,
+        point: point,
         message: `${point.patp}'s ${humanProxyType} proxy has been set!`,
       });
 
@@ -191,7 +191,7 @@ export default function SetProxy() {
   useEffect(() => {
     if (completed) {
       checkForUpdates({
-        point: point.value,
+        point: point,
         message: `${point.patp}'s ${humanProxyType} proxy has been set!`,
         l1Txn: {
           id: `${newAddress}-${point.value}`,

--- a/src/views/UrbitID/Transfer.tsx
+++ b/src/views/UrbitID/Transfer.tsx
@@ -80,7 +80,7 @@ export default function AdminTransfer() {
     // Update this one
     if (completed) {
       checkForUpdates({
-        point: point.value,
+        point: point,
         message: `${point.patp}'s transfer proxy has been set!`,
         l1Txn: {
           id: `set-transfer-proxy-${point.value}`,
@@ -105,7 +105,7 @@ export default function AdminTransfer() {
       await setProxyAddress('transfer', owner);
       getPendingTransactions();
       checkForUpdates({
-        point: point.value,
+        point: point,
         message: `${point.patp}'s transfer proxy has been set!`,
       });
       pop();

--- a/src/views/UrbitOS/ChangeSponsor.tsx
+++ b/src/views/UrbitOS/ChangeSponsor.tsx
@@ -63,7 +63,7 @@ function ChangeSponsor({ onDone }: { onDone: Function }) {
       setLoading(true);
       await changeSponsor(newSponsor!);
       checkForUpdates({
-        point: point.value,
+        point: point,
         message: `${point.patp} has requested ${ob.patp(
           newSponsor
         )} as a sponsor`,
@@ -210,7 +210,7 @@ function CurrentEscape({ onDone }: { onDone: Function }) {
     setLoading(true);
     await cancelEscape();
     checkForUpdates({
-      point: point.value,
+      point: point,
       message: `${point.patp}'s sponsor change cancelled`,
     });
     setLoading(false);

--- a/src/views/UrbitOS/NetworkKeys.tsx
+++ b/src/views/UrbitOS/NetworkKeys.tsx
@@ -176,7 +176,7 @@ export default function UrbitOSNetworkKeys({
   useEffect(() => {
     if (completed) {
       checkForUpdates({
-        point: point.value,
+        point: point,
         message: `${point.patp}'s Network Keys have been set!`,
         l1Txn: {
           id: `${point.keyRevisionNumber}-network-keys-${point.value}`,
@@ -252,7 +252,7 @@ export default function UrbitOSNetworkKeys({
       // we could inspect if there's a changeKeys in the local list of pending txs,...
       //
       checkForUpdates({
-        point: point.value,
+        point: point,
         message: `${point.patp}'s Network Keys have been set!`,
         intervalTime: ONE_SECOND,
       });


### PR DESCRIPTION
I recently decided to accept some stars. It was not a great experience, hence this PR.

The root of the problem is that Bridge is polling the roller every second, which together with some bugs relating to reference equality results in a DDOS-esque number of requests to the roller after a the transaction to accept the point completes.

Fixes #709, #965