### PR TITLE
NetworkKeys: fix stale keyfile download

### DIFF
--- a/src/views/UrbitOS/NetworkKeys.tsx
+++ b/src/views/UrbitOS/NetworkKeys.tsx
@@ -53,6 +53,7 @@ function useSetKeys(
   setManualNetworkSeed: (seed: string) => void
 ) {
   const { urbitWallet, wallet, authMnemonic, authToken }: any = useWallet();
+  const { getAndUpdatePoint } = useRoller();
   const { point } = useRollerStore();
   const { syncDetails, syncRekeyDate }: any = usePointCache();
   const { contracts }: any = useNetwork();
@@ -126,7 +127,9 @@ function useSetKeys(
       [_contracts, point, buildNetworkSeed]
     ),
     useCallback(
-      () => Promise.all([syncDetails(point.value), syncRekeyDate(point.value)]),
+      () => Promise.all([getAndUpdatePoint(point.value),
+                         syncDetails(point.value),
+                         syncRekeyDate(point.value)]),
       [point, syncDetails, syncRekeyDate]
     ),
     GAS_LIMITS.CONFIGURE_KEYS


### PR DESCRIPTION
The roller store wasn't fetching updates to the point after rekeying on L1. [Tested in production](https://network.urbit.org/~batnup-davdys). Fixes #1068.