### PR TITLE
NetworkKeys: actually fix stale keyfile download

### DIFF
--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -213,7 +213,8 @@ export default function useRoller() {
     }: UpdateParams) => {
 
 
-      const p = (typeof point === 'number' ? await initPoint(point) : point) as Point
+      const pVal = (typeof point === 'number' ? point : point.value);
+      const p = await initPoint(pVal);
 
       if (l1Txn) storePendingL1Txn(l1Txn);
 

--- a/src/views/UrbitOS/NetworkKeys.tsx
+++ b/src/views/UrbitOS/NetworkKeys.tsx
@@ -47,13 +47,13 @@ import BodyPane from 'components/L2/Window/BodyPane';
 
 import './NetworkKeys.scss';
 import { L1TxnType } from 'lib/types/PendingL1Transaction';
+import { PointField } from 'lib/types/Point';
 
 function useSetKeys(
   manualNetworkSeed: string,
   setManualNetworkSeed: (seed: string) => void
 ) {
   const { urbitWallet, wallet, authMnemonic, authToken }: any = useWallet();
-  const { getAndUpdatePoint } = useRoller();
   const { point } = useRollerStore();
   const { syncDetails, syncRekeyDate }: any = usePointCache();
   const { contracts }: any = useNetwork();
@@ -127,9 +127,7 @@ function useSetKeys(
       [_contracts, point, buildNetworkSeed]
     ),
     useCallback(
-      () => Promise.all([getAndUpdatePoint(point.value),
-                         syncDetails(point.value),
-                         syncRekeyDate(point.value)]),
+      () => Promise.all([syncDetails(point.value), syncRekeyDate(point.value)]),
       [point, syncDetails, syncRekeyDate]
     ),
     GAS_LIMITS.CONFIGURE_KEYS
@@ -180,6 +178,7 @@ export default function UrbitOSNetworkKeys({
     if (completed) {
       checkForUpdates({
         point: point,
+        field: PointField.keyRevisionNumber,
         message: `${point.patp}'s Network Keys have been set!`,
         l1Txn: {
           id: `${point.keyRevisionNumber}-network-keys-${point.value}`,


### PR DESCRIPTION
My previous PR #1069 fixed the stale keyfile download issue #1068, but introduced a race condition where sometimes the point state would update prematurely, leading to the rekey never completing in the UI.

On deeper investigation I found out that the stale keyfile bug was introduced by me in #1052 when I misunderstood and changed the `checkForUpdates` function. This PR reverts the relevant changes in #1069 and #1052, fixing #1068 once and for all.