### PR TITLE
metamask: resolve connected accounts

### DIFF
--- a/src/lib/metamask.ts
+++ b/src/lib/metamask.ts
@@ -18,13 +18,22 @@ export const metamaskSignTransaction = async (txn: EIP1559Transaction) => {
 };
 
 const metamaskSendTransaction = async (txn: FakeSignableTx, web3: Web3) => {
-  const accounts = await web3.eth.getAccounts();
-  if(accounts.length === 0) {
-    throw new Error('No accounts connected');
+  let from = null;
+  if(window.ethereum) {
+    from = window.ethereum.selectedAddress;
+    if (!from) {
+      const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' });
+      from = accounts[0] ?? null;
+    }
+  } else if (window.web3) {
+    from = window.web3?.eth?.defaultAccount ?? null;
+  } else {
+    const accounts = await web3.eth.getAccounts();
+    from = accounts[0] ?? null;
   }
-  const from = accounts[0];
+
   const { data, to, value, maxPriorityFeePerGas, maxFeePerGas } = txn.toJSON();
-  if (!(data && to && value && maxPriorityFeePerGas && maxFeePerGas && from)) { // TODO
+  if (!(data && to && value && maxPriorityFeePerGas && maxFeePerGas && from)) {
     throw new Error('Unable to send Metamask TX, something is missing');
   }
 

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -3,4 +3,5 @@ declare module 'folktale/maybe';
 
 interface Window {
   ethereum: any;
+  web3?: any;
 }


### PR DESCRIPTION
This change adds the recommended approach to get a user's connected account address, as well as fallbacks for older versions of Metamask. This resolves #1073

See:

https://docs.metamask.io/guide/sending-transactions.html#example

https://metamask.zendesk.com/hc/en-us/articles/360053147012-MetaMask-Legacy-Web3