### PR TITLE
gas: replace deprecated TX wait estimate API

### DIFF
--- a/src/components/L2/Dropdowns/FeeDropdown.tsx
+++ b/src/components/L2/Dropdowns/FeeDropdown.tsx
@@ -17,8 +17,6 @@ export interface GasPriceData {
   suggestedBaseFeePerGas: number;
 }
 
-// Convert seconds to minutes prettily
-export const formatWait = (wait: number) => Math.round((wait * 100) / 60) / 100;
 export const formatDisplay = ({ price, wait }: GasPriceData) =>
   `${price} gwei (${wait} min)`;
 

--- a/src/components/L2/Dropdowns/FeeDropdown.tsx
+++ b/src/components/L2/Dropdowns/FeeDropdown.tsx
@@ -17,7 +17,8 @@ export interface GasPriceData {
   suggestedBaseFeePerGas: number;
 }
 
-export const formatWait = (wait: number) => Math.round(wait * 100) / 100;
+// Convert seconds to minutes prettily
+export const formatWait = (wait: number) => Math.round((wait * 100) / 60) / 100;
 export const formatDisplay = ({ price, wait }: GasPriceData) =>
   `${price} gwei (${wait} min)`;
 

--- a/src/lib/getSuggestedGasPrice.js
+++ b/src/lib/getSuggestedGasPrice.js
@@ -1,6 +1,5 @@
 import { NETWORK_TYPES } from './network';
 import { DEFAULT_GAS_PRICE_GWEI, MAX_GAS_PRICE_GWEI } from './constants';
-import { formatWait } from 'components/L2/Dropdowns/FeeDropdown';
 import Web3 from 'web3';
 
 // ethgasstation returns values in floating point, one order of magitude
@@ -13,6 +12,9 @@ const feeToInt = (f) => f < 1 ? 1 : Math.round(f);
 const feeToWei = (fee) => Web3.utils.toHex(Web3.utils.toWei(String(fee), 'gwei' ))
 
 const calculateMaxFee = (baseFee, maxPriorityFee) => feeToWei(Math.round((2 * baseFee) + maxPriorityFee))
+
+// Convert seconds to minutes prettily
+const formatWait = (wait) => Math.round((wait * 100) / 60) / 100;
 
 export const defaultGasValues = value => ({
   fast: {

--- a/src/lib/getSuggestedGasPrice.js
+++ b/src/lib/getSuggestedGasPrice.js
@@ -40,7 +40,7 @@ export const defaultGasValues = value => ({
 
 const getGasForNetwork = async (providerUrl) => {
   try {
-    const [etherscanGas, ethgasstationGas] = await Promise.all([
+    const [feeResponse, waitResponse] = await Promise.all([
       fetch(
         `${providerUrl}/api` +
           '?module=gastracker' +
@@ -52,7 +52,7 @@ const getGasForNetwork = async (providerUrl) => {
         }
       ),
       fetch(
-        'https://ethgasstation.info/json/ethgasAPI.json',
+        'https://ethereum-api.xyz/gas-prices',
         {
           method: 'GET',
           cache: 'no-cache',
@@ -60,35 +60,35 @@ const getGasForNetwork = async (providerUrl) => {
       )
     ]);
 
-    const [etherscanGasJson, ethgasstationGasJson] = await Promise.all([
-      etherscanGas.json(),
-      ethgasstationGas.json()
+    const [feeJson, waitJson] = await Promise.all([
+      feeResponse.json(),
+      waitResponse.json()
     ])
 
-    const suggestedBaseFeePerGas = Number(etherscanGasJson.result.suggestBaseFee);
+    const suggestedBaseFeePerGas = Number(feeJson.result.suggestBaseFee);
 
     // Calculations derived from:
     // https://www.blocknative.com/blog/eip-1559-fees
     return {
       fast: {
-        price: minGas(etherscanGasJson.result.FastGasPrice),
-        wait: formatWait(ethgasstationGasJson.fastWait),
-        maxFeePerGas: calculateMaxFee(suggestedBaseFeePerGas, etherscanGasJson.result.FastGasPrice - suggestedBaseFeePerGas),
-        maxPriorityFeePerGas: feeToInt((etherscanGasJson.result.FastGasPrice - suggestedBaseFeePerGas)),
+        price: minGas(feeJson.result.FastGasPrice),
+        wait: formatWait(waitJson.result.fast.time),
+        maxFeePerGas: calculateMaxFee(suggestedBaseFeePerGas, feeJson.result.FastGasPrice - suggestedBaseFeePerGas),
+        maxPriorityFeePerGas: feeToInt((feeJson.result.FastGasPrice - suggestedBaseFeePerGas)),
         suggestedBaseFeePerGas
       },
       average: {
-        price: minGas(etherscanGasJson.result.ProposeGasPrice),
-        wait: formatWait(ethgasstationGasJson.avgWait),
-        maxFeePerGas: calculateMaxFee(suggestedBaseFeePerGas, etherscanGasJson.result.ProposeGasPrice - suggestedBaseFeePerGas),
-        maxPriorityFeePerGas: feeToInt((etherscanGasJson.result.ProposeGasPrice - suggestedBaseFeePerGas)),
+        price: minGas(feeJson.result.ProposeGasPrice),
+        wait: formatWait(waitJson.result.average.time),
+        maxFeePerGas: calculateMaxFee(suggestedBaseFeePerGas, feeJson.result.ProposeGasPrice - suggestedBaseFeePerGas),
+        maxPriorityFeePerGas: feeToInt((feeJson.result.ProposeGasPrice - suggestedBaseFeePerGas)),
         suggestedBaseFeePerGas
       },
       low: {
-        price: minGas(etherscanGasJson.result.SafeGasPrice),
-        wait: formatWait(ethgasstationGasJson.safeLowWait),
-        maxFeePerGas: calculateMaxFee(suggestedBaseFeePerGas, etherscanGasJson.result.SafeGasPrice - suggestedBaseFeePerGas),
-        maxPriorityFeePerGas: feeToInt((etherscanGasJson.result.SafeGasPrice - suggestedBaseFeePerGas)),
+        price: minGas(feeJson.result.SafeGasPrice),
+        wait: formatWait(waitJson.result.slow.time),
+        maxFeePerGas: calculateMaxFee(suggestedBaseFeePerGas, feeJson.result.SafeGasPrice - suggestedBaseFeePerGas),
+        maxPriorityFeePerGas: feeToInt((feeJson.result.SafeGasPrice - suggestedBaseFeePerGas)),
         suggestedBaseFeePerGas
       },
     };


### PR DESCRIPTION
# Context

This resolves #1077.

As of 12/12/2022, ETHGasStation is sunsetting:

![image](https://user-images.githubusercontent.com/16504501/207172457-0ac5af33-166f-4f67-bec5-48f0d3fa16ac.png)

https://twitter.com/ETHGasStation/status/1597341610777317376

This change replaces the API call with another provider.

# Preview

![Screenshot from 2022-12-12 14-48-29](https://user-images.githubusercontent.com/16504501/207172375-c64d2ff1-0bf9-44df-8fd7-67e2fade32a0.png)
