### PR TITLE
dev: update L2 local instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -174,6 +174,7 @@ Start a local fake ship from the master branch in the [urbit repo](https://githu
 > |mount /=base=
 > :azimuth %resub
 > :azimuth|watch 'http://0.0.0.0:8545' %local
+> :azimuth &azimuth-poke [%kick ~]
 > |rein %base [& %roller] [& %roller-rpc] [& %azimuth-rpc]
 > :roller|local
 > :roller|setkey '58d62eb79797502bc0f66cd3e7a49d00287bff53a2734b799ef09cb746340ed0'


### PR DESCRIPTION
Fakeships don't use the normal codepath triggered by a timer to start receiving azimuth updates and need to manually start the azimuth log retrieval.

There seems to be other issues with the deployment of the contracts/migration scripts (https://github.com/urbit/azimuth/issues/62) but this is necessary for both %azimuth and %roller apps to get data from chain