### PR TITLE
Fix incorrect sponsor displayed for L1 ships after escape

### DIFF
--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -139,9 +139,8 @@ export default function useRoller() {
   const initPoint = useCallback(
     async (point: string | number): Promise<Point> => {
       const _wallet = wallet.getOrElse(null);
-      const _contracts = contracts.getOrElse(null);
 
-      if (!_wallet || !_contracts) {
+      if (!_wallet) {
         return EMPTY_POINT;
       }
 
@@ -152,9 +151,7 @@ export default function useRoller() {
         const l2Quota = isL2 ? await api.getRemainingQuota(pointNum) : 0;
         const l2Allowance = isL2 ? await api.getAllowance(pointNum) : 0;
 
-        const details = isL2Spawn(rawDetails?.dominion)
-          ? toL1Details(rawDetails)
-          : await azimuth.azimuth.getPoint(_contracts, point);
+        const details = toL1Details(rawDetails);
 
         return new Point({
           value: pointNum,
@@ -309,14 +306,14 @@ export default function useRoller() {
         proxy === 'own'
           ? await api.getOwnedPoints(address)
           : proxy === 'manage'
-            ? await api.getManagerFor(address)
-            : proxy === 'vote'
-              ? await api.getVotingFor(address)
-              : proxy === 'transfer'
-                ? await api.getTransferringFor(address)
-                : proxy === 'spawn'
-                  ? await api.getSpawningFor(address)
-                  : [];
+          ? await api.getManagerFor(address)
+          : proxy === 'vote'
+          ? await api.getVotingFor(address)
+          : proxy === 'transfer'
+          ? await api.getTransferringFor(address)
+          : proxy === 'spawn'
+          ? await api.getSpawningFor(address)
+          : [];
 
       return points;
     },
@@ -365,14 +362,14 @@ export default function useRoller() {
       const networkSeed = customNetworkSeed
         ? customNetworkSeed
         : await attemptNetworkSeedDerivation({
-          urbitWallet,
-          wallet,
-          authMnemonic,
-          details: point,
-          authToken,
-          point: point.value,
-          revision: nextRevision,
-        });
+            urbitWallet,
+            wallet,
+            authMnemonic,
+            details: point,
+            authToken,
+            point: point.value,
+            revision: nextRevision,
+          });
       const txHash = await submitL2Transaction({
         api,
         wallet: _wallet,
@@ -422,7 +419,7 @@ export default function useRoller() {
     let nonce = await api.getNonce({ ship: point, proxy });
     const progress = onUpdate
       ? (state: number) => onUpdate({ type: 'progress', state })
-      : () => { };
+      : () => {};
 
     let requests = [];
 

--- a/src/store/lib/useDetailsStore.ts
+++ b/src/store/lib/useDetailsStore.ts
@@ -33,18 +33,10 @@ export default function useDetailsStore() {
 
   const syncDetails = useCallback(
     async point => {
-      const _contracts = contracts.getOrElse(null);
-      if (!_contracts) {
-        return;
-      }
-
       // fetch point details
       try {
-        const l2Point = await api.getPoint(point);
-        const details =
-          l2Point && (l2Point.dominion === 'l2' || l2Point.dominion === 'spawn')
-            ? toL1Details(l2Point)
-            : await azimuth.azimuth.getPoint(_contracts, point);
+        const _point = await api.getPoint(point);
+        const details = toL1Details(_point);
         addToDetails({
           [point]: details,
         });
@@ -53,7 +45,13 @@ export default function useDetailsStore() {
           console.warn(error);
         }
 
+        // Try getting the details from L1
         try {
+          const _contracts = contracts.getOrElse(null);
+          if (!_contracts) {
+            return;
+          }
+
           const details = await azimuth.azimuth.getPoint(_contracts, point);
           addToDetails({
             [point]: details,


### PR DESCRIPTION
There’s a bug in the OS section where an incorrect sponsor will be displayed for an L1 ship that has escaped to a new point (if the adoption transaction has been done using Bridge/L2).

For context, Bridge currently seems to only use L2 to execute the adopt transaction even if the sponsee is on L1 and the escape request is through L1. This is valid behaviour as per the [docs](https://developers.urbit.org/reference/azimuth/l2/l2-actions#spawn-1-galaxies-1) - 

> "...sponsorship actions may be performed on layer 2 using the ownership or management proxies regardless of the dominion status...".

Because of this, when using `getPoint()` in azimuth-js, the returned values for ‘sponsor’,  ‘escapeRequested’, and ‘escapeRequestedTo’ fields may not be accurate.

This fix removes the condition that checks whether the point is L1 or L2, and instead only uses the roller to fetch additional details about the point.

Note that there’s still a try-catch fallback which uses azimuth-js if the initial call to the roller fails. I’ve left this in place for now but it arguably should also be removed.
