### PR TITLE
Fix wrong sponsor being displayed for ships who are on L1 but escaped via L2

### DIFF
--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -167,17 +167,18 @@ export default function useRoller() {
         const _contracts = need.contracts(contracts);
         const l1Details = await azimuth.azimuth.getPoint(_contracts, point);
 
-        l1Details.owner = details.owner;
+        l1Details.sponsor = details.sponsor;
+        l1Details.escapeRequested = details.escapeRequested;
+        l1Details.escapeRequestedTo = details.escapeRequestedTo;
 
         return new Point({
           value: pointNum,
           details: l1Details,
           address: _wallet.address,
         });
-
       } catch (e) {
         console.warn(e);
-          // Just return a placeholder Point
+        // Just return a placeholder Point
         const details: L1Point = toL1Details();
         return new Point({
           value: pointNum,
@@ -185,7 +186,6 @@ export default function useRoller() {
           address: _wallet.address,
           isPlaceholder: true,
         });
-
       }
     },
     [api, wallet, contracts]

--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -167,7 +167,7 @@ export default function useRoller() {
         const _contracts = need.contracts(contracts);
         const l1Details = await azimuth.azimuth.getPoint(_contracts, point);
 
-        L1Details.owner = details.owner;
+        l1Details.owner = details.owner;
 
         return new Point({
           value: pointNum,

--- a/src/lib/useRoller.ts
+++ b/src/lib/useRoller.ts
@@ -148,12 +148,12 @@ export default function useRoller() {
       const rawDetails = await api.getPoint(pointNum);
       const isL2 = isL2Spawn(rawDetails?.dominion);
 
+      const details = toL1Details(rawDetails);
+
       try {
         if (isL2) {
           const l2Quota = isL2 ? await api.getRemainingQuota(pointNum) : 0;
           const l2Allowance = isL2 ? await api.getAllowance(pointNum) : 0;
-
-          const details = toL1Details(rawDetails);
 
           return new Point({
             value: pointNum,
@@ -165,23 +165,26 @@ export default function useRoller() {
         }
 
         const _contracts = need.contracts(contracts);
-        const details = await azimuth.azimuth.getPoint(_contracts, point);
+        const l1Details = await azimuth.azimuth.getPoint(_contracts, point);
+
+        L1Details.owner = details.owner;
+
         return new Point({
           value: pointNum,
-          details,
+          details: l1Details,
           address: _wallet.address,
         });
 
       } catch (e) {
         console.warn(e);
           // Just return a placeholder Point
-          const details: L1Point = toL1Details();
-          return new Point({
-            value: pointNum,
-            details,
-            address: _wallet.address,
-            isPlaceholder: true,
-          });
+        const details: L1Point = toL1Details();
+        return new Point({
+          value: pointNum,
+          details,
+          address: _wallet.address,
+          isPlaceholder: true,
+        });
 
       }
     },


### PR DESCRIPTION
Sponsorship actions may be performed on L2 even for L1 ships:

https://developers.urbit.org/reference/azimuth/l2/l2-actions#spawn-1-galaxies-1

Bridge has to always read the sponsor from L2, even when handling a L1 point.