### PR TITLE
WalletConnect & Ledger bug fix

### DIFF
--- a/src/lib/useWalletConnect.ts
+++ b/src/lib/useWalletConnect.ts
@@ -220,6 +220,12 @@ export const useWalletConnect = () => {
         return;
       }
 
+      // Ledger Live needs to use fakeSign instead since it sends the txn upon signing
+      if (peerMeta?.name === 'Ledger Wallet') {
+        reject(new Error('METHOD_NOT_SUPPORTED'));
+        return;
+      }
+
       return connector
         .request<string>({
           topic: session?.topic!,


### PR DESCRIPTION
Fixes issue with WalletConnect where Ledger Live is expected to just sign the transaction, but instead also tries to send it.

- Bridge was throwing the error "invalid serialized tx input" when trying to sign a transaction using Ledger Live via WalletConnect, as it was actually evaluating the transaction hash that was returned after Ledger Live had already sent it.

- It seems the 'fakeSign' logic is in place for such circumstances, so I'm just making it use that approach instead. The user is now alerted that their transaction will be signed when sending.



![WC_Ledger_issue](https://github.com/urbit/bridge/assets/3984057/6fbe0af7-2387-4f39-b55b-23e5676467f5)
