### PR TITLE
Clear state on logout

### DIFF
--- a/src/components/L2/Dropdowns/AccountsDropdown.tsx
+++ b/src/components/L2/Dropdowns/AccountsDropdown.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { Icon, Row, Box } from '@tlon/indigo-react';
 import { Just } from 'folktale/maybe';
-
 import LayerIndicator from 'components/L2/LayerIndicator';
 import CopiableAddressWrap from 'components/copiable/CopiableAddressWrap';
 import { TooltipPosition } from 'components/WithTooltip';
@@ -26,7 +25,7 @@ const AccountsDropdown = ({ showMigrate = false }: AccountsDropdownProps) => {
   const walletInfo: any = useWallet();
   const { push, popTo, names, reset }: any = useHistory();
   const { setPointCursor }: any = usePointCursor();
-  const { point, pointList } = useRollerStore();
+  const { point, pointList, resetStore } = useRollerStore();
 
   const canBitcoin = Just.hasInstance(walletInfo.urbitWallet);
 
@@ -65,7 +64,8 @@ const AccountsDropdown = ({ showMigrate = false }: AccountsDropdownProps) => {
 
   const onLogout = () => {
     clearInvitesStorage();
-    reset();
+    reset(); // router
+    resetStore();
   };
 
   const hasL1Points = Boolean(pointList.find(({ layer }) => layer === 1));

--- a/src/store/rollerStore.ts
+++ b/src/store/rollerStore.ts
@@ -20,7 +20,7 @@ export const EMPTY_POINT = new Point({
   address: '',
 });
 
-export interface RollerStore {
+export interface RollerState {
   loading: boolean;
   nextQuotaTime: number;
   pendingTransactions: PendingTransaction[];
@@ -31,6 +31,9 @@ export interface RollerStore {
   modalText?: string;
   recentlyCompleted: number;
   ethBalance: BN;
+}
+
+export interface RollerActions {
   setLoading: (loading: boolean) => void;
   setModalText: (modalText: string) => void;
   setNextQuotaTime: (nextQuotaTime: number) => void;
@@ -41,9 +44,10 @@ export interface RollerStore {
   storePendingL1Txn: (txn: PendingL1Txn) => void;
   deletePendingL1Txn: (txn: PendingL1Txn) => void;
   setEthBalance: (ethBalance: BN) => void;
+  resetStore: () => void;
 }
 
-export const useRollerStore = create<RollerStore>(set => ({
+const initialRollerState: RollerState = {
   loading: false,
   nextQuotaTime: new Date().getTime() + 24 * HOUR,
   pendingTransactions: [],
@@ -53,6 +57,10 @@ export const useRollerStore = create<RollerStore>(set => ({
   pendingL1ByPoint: {},
   recentlyCompleted: 0,
   ethBalance: toBN(0),
+};
+
+export const useRollerStore = create<RollerState & RollerActions>(set => ({
+  ...initialRollerState,
   setLoading: (loading: boolean) => set(() => ({ loading })),
   setNextQuotaTime: (nextQuotaTime: number) => set(() => ({ nextQuotaTime })),
   setPendingTransactions: (pendingTransactions: PendingTransaction[]) =>
@@ -92,4 +100,7 @@ export const useRollerStore = create<RollerStore>(set => ({
       return { pendingL1ByPoint: newPending };
     }),
   setEthBalance: (ethBalance: BN) => set(() => ({ ethBalance })),
+  resetStore: () => {
+    set(initialRollerState);
+  },
 }));


### PR DESCRIPTION
Note that this addresses issue #1123 (and possibly #1092 ?)

State was not cleared on logout, so logging in again with another master ticket always failed as stale data remained in store.

- added resetStore function which is triggered on logout. In-line with Zustand docs (https://docs.pmnd.rs/zustand/guides/how-to-reset-state)