### PR TITLE
Update links to new docs site

### DIFF
--- a/src/components/Greeting.jsx
+++ b/src/components/Greeting.jsx
@@ -38,7 +38,7 @@ export default function ActivateDisclaimer({ point }) {
         <Text className={cn(TEXT_STYLE, 'block mb2')}>Right now you can:</Text>
       </Grid.Item>
 
-      <Grid.Item full as={LinkButton} href="https://docs.urbit.org/manual/getting-started">
+      <Grid.Item full as={LinkButton} href="https://docs.urbit.org/get-on-urbit#get-the-urbit-runtime">
         <Text className={cn(TEXT_STYLE, 'block mb2')}>
           Boot Arvo, the Urbit OS
         </Text>

--- a/src/views/Activate/MasterKeyTransfer.tsx
+++ b/src/views/Activate/MasterKeyTransfer.tsx
@@ -97,7 +97,7 @@ const MasterKeyTransfer = () => {
         {error && <DangerBox>{error.toString()}</DangerBox>}
         <ActivateButton
           onClick={() =>
-            window.open('https://docs.urbit.org/manual/getting-started/self-hosted/cloud-hosting')
+            window.open('https://docs.urbit.org/user-manual/running/cloud-hosting')
           }
           className="pointer-hover"
           disabled={error}
@@ -105,7 +105,7 @@ const MasterKeyTransfer = () => {
           To use it, set up a cloud instance for your urbit
         </ActivateButton>
         <Anchor
-          href="https://docs.urbit.org/manual/getting-started/self-hosted/cli"
+          href="https://docs.urbit.org/get-on-urbit#get-the-urbit-runtime"
           marginTop={'20px'}
           marginBottom={'10px'}
           underline={false}

--- a/src/views/Point/MigrateL2.tsx
+++ b/src/views/Point/MigrateL2.tsx
@@ -282,7 +282,7 @@ export default function MigrateL2() {
             className="bold"
             target="_blank"
             rel="noreferrer"
-            href="https://docs.urbit.org/manual/id/layer-2-for-planets">
+            href="https://docs.urbit.org/user-manual/id/layer-2-for-planets">
             Learn More
           </a>
         </Box>


### PR DESCRIPTION
All links to the docs site in Bridge's onboarding flow are broken. This PR updates the links to the corresponding pages in the new docs site.